### PR TITLE
fix min grpc keepalive interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.2
+* fix minimum grpc keepalive interval
+
 ## 3.0.1
 * refactored integration tests
 

--- a/internal/dial/dialer.go
+++ b/internal/dial/dialer.go
@@ -21,7 +21,7 @@ import (
 // Dial dials given addr and initializes driver instance on success.
 func Dial(ctx context.Context, c config.Config) (_ public.Cluster, err error) {
 	grpcKeepalive := c.GrpcConnectionPolicy().Timeout
-	if grpcKeepalive <= 0 {
+	if grpcKeepalive <= config.MinKeepaliveInterval {
 		grpcKeepalive = config.MinKeepaliveInterval
 	}
 	var e endpoint.Endpoint

--- a/internal/meta/version.go
+++ b/internal/meta/version.go
@@ -1,5 +1,5 @@
 package meta
 
 const (
-	Version = "ydb-go-sdk/3.0.1"
+	Version = "ydb-go-sdk/3.0.2"
 )


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

set grpc keepalive as grpc keep alive policy if it more then 0, but less then MinKeepaliveInterval const.

Issue Number: N/A

## What is the new behavior?

set grpc keepalive as MinKeepaliveInterval if grpc keep alive policy less then MinKeepaliveInterval const.

<!-- Please describe the behavior or changes that are being added by this PR. -->

