### PR TITLE
Fixed result type of `RawValue.String` to ydb string compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.2
+* Fixed result type of `RawValue.String` (ydb string compatible)
+* Fixed scans ydb types into string and slice byte receivers
+
 ## 3.2.1
 * Upgraded dependencies
 * Added `WithEndpoint` and `WithDatabase` Option constructors

--- a/internal/meta/version.go
+++ b/internal/meta/version.go
@@ -1,5 +1,5 @@
 package meta
 
 const (
-	Version = "ydb-go-sdk/3.2.1"
+	Version = "ydb-go-sdk/3.2.2"
 )

--- a/internal/table/scanner/scan_raw.go
+++ b/internal/table/scanner/scan_raw.go
@@ -20,6 +20,11 @@ type rawConverter struct {
 	*scanner
 }
 
+func (s *rawConverter) String() (v []byte) {
+	s.unwrap()
+	return s.bytes()
+}
+
 func (s *rawConverter) HasItems() bool {
 	return s.hasItems()
 }
@@ -203,11 +208,6 @@ func (s *rawConverter) TzTimestamp() (v time.Time) {
 		s.errorf("scan raw failed: %w", err)
 	}
 	return src
-}
-
-func (s *rawConverter) String() (v string) {
-	s.unwrap()
-	return string(s.bytes())
 }
 
 func (s *rawConverter) UTF8() (v string) {

--- a/internal/table/scanner/scanner.go
+++ b/internal/table/scanner/scanner.go
@@ -277,7 +277,7 @@ func (s *scanner) any() interface{} {
 	case value.TypeDouble:
 		return s.double()
 	case value.TypeString:
-		return string(s.bytes())
+		return s.bytes()
 	case value.TypeUUID:
 		return s.uint128()
 	case value.TypeUint32:
@@ -554,12 +554,13 @@ func (s *scanner) setTime(dst *time.Time) {
 
 func (s *scanner) setString(dst *string) {
 	switch t := s.stack.current().t.GetTypeId(); t {
+	case Ydb.Type_UUID:
+		src := s.uint128()
+		*dst = string(src[:])
+	case Ydb.Type_UTF8, Ydb.Type_DYNUMBER, Ydb.Type_YSON, Ydb.Type_JSON, Ydb.Type_JSON_DOCUMENT:
+		*dst = s.text()
 	case Ydb.Type_STRING:
 		*dst = string(s.bytes())
-	case Ydb.Type_UTF8:
-		*dst = s.text()
-	case Ydb.Type_DYNUMBER:
-		*dst = s.text()
 	default:
 		s.errorf("scan row failed: incorrect source types %s", t)
 	}
@@ -570,7 +571,7 @@ func (s *scanner) setByte(dst *[]byte) {
 	case Ydb.Type_UUID:
 		src := s.uint128()
 		*dst = src[:]
-	case Ydb.Type_YSON, Ydb.Type_JSON, Ydb.Type_JSON_DOCUMENT:
+	case Ydb.Type_UTF8, Ydb.Type_DYNUMBER, Ydb.Type_YSON, Ydb.Type_JSON, Ydb.Type_JSON_DOCUMENT:
 		*dst = []byte(s.text())
 	case Ydb.Type_STRING:
 		*dst = s.bytes()

--- a/table/types/type.go
+++ b/table/types/type.go
@@ -148,7 +148,7 @@ type RawValue interface {
 	TzDate() (v time.Time)
 	TzDatetime() (v time.Time)
 	TzTimestamp() (v time.Time)
-	String() (v string)
+	String() (v []byte)
 	UTF8() (v string)
 	YSON() (v []byte)
 	JSON() (v []byte)


### PR DESCRIPTION
 + fixed scans ydb types into string and slice byte receivers

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
