### PR TITLE
Prefer YDB scanner interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.4.4
+* Prefer types.Scanner (ydb) scanner implementation over sql.Scanner, when both available.
+
 ## 3.4.3
 * Forced `round_bobin` grpc load balancing instead default `pick_first`
 * Added checker `IsTransportErrorCancelled`

--- a/internal/meta/version.go
+++ b/internal/meta/version.go
@@ -1,5 +1,5 @@
 package meta
 
 const (
-	Version = "ydb-go-sdk/3.4.3"
+	Version = "ydb-go-sdk/3.4.4"
 )

--- a/internal/table/scanner/scanner.go
+++ b/internal/table/scanner/scanner.go
@@ -663,20 +663,20 @@ func (s *scanner) scanRequired(value interface{}) {
 		*v = s.uint128()
 	case *interface{}:
 		*v = s.any()
-	case sql.Scanner:
-		err := v.Scan(s.any())
-		if err != nil {
-			s.errorf("sql.Scanner error: %w", err)
-		}
+	case *types.Value:
+		*v = s.value()
+	case *types.Decimal:
+		*v = s.unwrapDecimal()
 	case types.Scanner:
 		err := v.UnmarshalYDB(s.converter)
 		if err != nil {
 			s.errorf("ydb.Scanner error: %w", err)
 		}
-	case *types.Value:
-		*v = s.value()
-	case *types.Decimal:
-		*v = s.unwrapDecimal()
+	case sql.Scanner:
+		err := v.Scan(s.any())
+		if err != nil {
+			s.errorf("sql.Scanner error: %w", err)
+		}
 	default:
 		ok := s.trySetByteArray(v, false, false)
 		if !ok {
@@ -835,16 +835,6 @@ func (s *scanner) scanOptional(value interface{}) {
 			src := s.any()
 			*v = &src
 		}
-	case sql.Scanner:
-		err := v.Scan(s.any())
-		if err != nil {
-			s.errorf("sql.Scanner error: %w", err)
-		}
-	case types.Scanner:
-		err := v.UnmarshalYDB(s.converter)
-		if err != nil {
-			s.errorf("ydb.Scanner error: %w", err)
-		}
 	case *types.Value:
 		*v = s.value()
 	case **types.Decimal:
@@ -853,6 +843,16 @@ func (s *scanner) scanOptional(value interface{}) {
 		} else {
 			src := s.unwrapDecimal()
 			*v = &src
+		}
+	case types.Scanner:
+		err := v.UnmarshalYDB(s.converter)
+		if err != nil {
+			s.errorf("ydb.Scanner error: %w", err)
+		}
+	case sql.Scanner:
+		err := v.Scan(s.any())
+		if err != nil {
+			s.errorf("sql.Scanner error: %w", err)
 		}
 	default:
 		s.unwrap()

--- a/internal/table/scanner/scanner.go
+++ b/internal/table/scanner/scanner.go
@@ -904,20 +904,20 @@ func (s *scanner) setDefaultValue(dst interface{}) {
 		*v = [16]byte{}
 	case *interface{}:
 		*v = nil
-	case sql.Scanner:
-		err := v.Scan(nil)
-		if err != nil {
-			s.errorf("sql.Scanner error: %w", err)
-		}
+	case *types.Value:
+		*v = s.value()
+	case *types.Decimal:
+		*v = types.Decimal{}
 	case types.Scanner:
 		err := v.UnmarshalYDB(s.converter)
 		if err != nil {
 			s.errorf("ydb.Scanner error: %w", err)
 		}
-	case *types.Value:
-		*v = s.value()
-	case *types.Decimal:
-		*v = types.Decimal{}
+	case sql.Scanner:
+		err := v.Scan(nil)
+		if err != nil {
+			s.errorf("sql.Scanner error: %w", err)
+		}
 	default:
 		ok := s.trySetByteArray(v, false, true)
 		if !ok {


### PR DESCRIPTION
I have type:
```golang
type UUID struct {
	uuid.UUID
}

func (d *UUID) UnmarshalYDB(v types.RawValue) error {
...
}
```

It has explicit implementation for types.Scanner and implicit sql.Scanner (from uuid.UUID type).
When I do res.ScanWithDefaults for my UUID - it try use sql.Scanner for scan nil value and throw error: "uuid: cannot convert <nil> to UUID".

In this PR I set priority of special YDB scanner implementation higher then more generic sql scanner.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

If type implement both sql.Scanner and types.Scanner (ydb) interfaces - scanner prefer sql.Scanner implementation.

## What is the new behavior?

If type implement both sql.Scanner and types.Scanner (ydb) interfaces - scanner prefer  types.Scanner (ydb) implementation.
