### PR TITLE
v3.14.2: Refactored internal error wrapping (with file and line identification…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.14.2
+* Refactored internal error wrapping (with file and line identification) - replaced `fmt.Printf("%w", err)` error wrapping to internal `stackError`
+
 ## 3.14.1
 * Added `balacers.CreateFromConfig` balancer creator
 * Added `Create` method to interface `balancer.Balancer`

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -1,0 +1,34 @@
+package errors
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestError(t *testing.T) {
+	for _, test := range []struct {
+		error error
+		text  string
+	}{
+		{
+			error: Error(fmt.Errorf("TestError")),
+			text:  "TestError at `errors.TestError(github.com/ydb-platform/ydb-go-sdk/v3/internal/errors/errors_test.go:14)`",
+		},
+		{
+			error: Errorf("TestError%s", "Printf"),
+			// nolint:lll
+			text: "TestErrorPrintf at `errors.TestError(github.com/ydb-platform/ydb-go-sdk/v3/internal/errors/errors_test.go:18)`",
+		},
+		{
+			error: ErrorfSkip(0, "TestError%s", "Printf"),
+			// nolint:lll
+			text: "TestErrorPrintf at `errors.TestError(github.com/ydb-platform/ydb-go-sdk/v3/internal/errors/errors_test.go:23)`",
+		},
+	} {
+		t.Run(test.text, func(t *testing.T) {
+			if test.error.Error() != test.text {
+				t.Fatalf("unexpected text of error: \"%s\", exp: \"%s\"", test.error.Error(), test.text)
+			}
+		})
+	}
+}

--- a/internal/meta/version.go
+++ b/internal/meta/version.go
@@ -1,5 +1,5 @@
 package meta
 
 const (
-	Version = "ydb-go-sdk/3.14.1"
+	Version = "ydb-go-sdk/3.14.2"
 )


### PR DESCRIPTION
…) - replaced `fmt.Printf("%w", err)` error wrapping to internal `stackError`

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
