### PR TITLE
Small fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 .DS_Store
+vendor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.14.5
+* Added `conn.Creator` interface to `conn.Pool`
+* Never close discovery connection from `conn.Pool`
+
 ## 3.14.4
 * Implemented auto-removing `conn.Conn` from `conn.Pool` with counting usages of `conn.Conn`
 * Refactored naming of source files which declares service client interfaces

--- a/internal/balancer/multi/multi.go
+++ b/internal/balancer/multi/multi.go
@@ -44,11 +44,8 @@ func WithBalancer(b balancer.Balancer, filter func(cc conn.Conn) bool) Option {
 type Option func(*multi)
 
 func (m *multi) Contains(x balancer.Element) bool {
-	for i, x := range x.(multiHandle).elements {
-		if x == nil {
-			continue
-		}
-		if m.balancer[i].Contains(x) {
+	for i, h := range x.(multiHandle).elements {
+		if h != nil && m.balancer[i].Contains(x) {
 			return true
 		}
 	}
@@ -75,8 +72,7 @@ func (m *multi) Insert(conn conn.Conn) balancer.Element {
 
 	for i, f := range m.filter {
 		if f(conn) {
-			x := m.balancer[i].Insert(conn)
-			h.elements[i] = x
+			h.elements[i] = m.balancer[i].Insert(conn)
 			inserted = true
 		}
 	}
@@ -87,17 +83,17 @@ func (m *multi) Insert(conn conn.Conn) balancer.Element {
 }
 
 func (m *multi) Update(x balancer.Element, info info.Info) {
-	for i, x := range x.(multiHandle).elements {
-		if x != nil {
-			m.balancer[i].Update(x, info)
+	for i, h := range x.(multiHandle).elements {
+		if h != nil {
+			m.balancer[i].Update(h, info)
 		}
 	}
 }
 
 func (m *multi) Remove(x balancer.Element) (removed bool) {
-	for i, x := range x.(multiHandle).elements {
-		if x != nil {
-			if m.balancer[i].Remove(x) {
+	for i, h := range x.(multiHandle).elements {
+		if h != nil {
+			if m.balancer[i].Remove(h) {
 				removed = true
 			}
 		}

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -437,15 +437,7 @@ func DiffEndpoints(curr, next []endpoint.Endpoint, eq, add, del func(i, j int)) 
 		func(i, j int) int {
 			return compareEndpoints(curr[i], next[j])
 		},
-		func(i, j int) {
-			eq(i, j)
-		},
-		func(i, j int) {
-			add(i, j)
-		},
-		func(i, j int) {
-			del(i, j)
-		},
+		eq, add, del,
 	)
 }
 

--- a/internal/conn/conn.go
+++ b/internal/conn/conn.go
@@ -210,13 +210,13 @@ func (c *conn) changeUsages(delta int32) int32 {
 func (c *conn) incUsages() {
 	c.Lock()
 	defer c.Unlock()
+	c.lastUsage = time.Now()
 	c.changeUsages(1)
 }
 
 func (c *conn) decUsages() int32 {
 	c.Lock()
 	defer c.Unlock()
-	c.lastUsage = time.Now()
 	return c.changeUsages(-1)
 }
 

--- a/internal/db/database.go
+++ b/internal/db/database.go
@@ -74,7 +74,7 @@ func New(
 	}
 	defer cancel()
 
-	cc := pool.Get(ctx, endpoint.New(c.Endpoint(), endpoint.WithLocalDC(true)))
+	cc := pool.Create(ctx, endpoint.New(c.Endpoint(), endpoint.WithLocalDC(true)))
 
 	db.discovery, err = builder.New(
 		ctx,

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -75,8 +75,7 @@ func New(
 
 				cluster.DiffEndpoints(curr, next,
 					func(i, j int) {
-						// Endpoints are equal, but we still need to update meta
-						// data such that load factor and others.
+						// Endpoints are equal, but we still need to update metadata (e.g., load factor).
 						crudExplorer.Update(
 							ctx,
 							next[j],

--- a/internal/meta/version.go
+++ b/internal/meta/version.go
@@ -1,5 +1,5 @@
 package meta
 
 const (
-	Version = "ydb-go-sdk/3.14.4"
+	Version = "ydb-go-sdk/3.14.5"
 )

--- a/internal/ratelimiter/ratelimiter.go
+++ b/internal/ratelimiter/ratelimiter.go
@@ -120,6 +120,7 @@ func (c *client) ListResource(
 	response, err = c.service.ListResources(ctx, &Ydb_RateLimiter.ListResourcesRequest{
 		CoordinationNodePath: coordinationNodePath,
 		ResourcePath:         resourcePath,
+		Recursive:            recursive,
 		OperationParams: operation.Params(
 			c.config.OperationTimeout(),
 			c.config.OperationCancelAfter(),


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

* don't close discovery connection from pool
* fix last usage
* small refactoring

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

When `Connection.With` is called for the same endpoint (no override) and discovery error appears on initial discovery setup, it'll close the base conn used by the underlying Connection for discovery.

## What is the new behavior?

Create new conn for discovery and don't put it into pool (let discovery goroutine fill in cluster).
