### PR TITLE
shared pool management with config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+* Added `config.SharedPool()` setting and `config.WithSharedPool()` option
+* Added management of shared pool flag on change dial timeout and credentials 
+* Removed explicit checks of conditions for use (or not) shared pool in `ydb.With()`
+* Renamed `internal/db` interfaces
+* Changed signature of `conn.Conn.Release` (added error as result)
+
 ## v3.16.4
 * Removed `WithMeta()` discovery config option
 * Moved `meta.Meta` call to conn exclusively

--- a/connection.go
+++ b/connection.go
@@ -34,7 +34,7 @@ import (
 // Interface and list of clients may be changed in the future
 type Connection interface {
 	closer.Closer
-	db.ConnectionInfo
+	db.Info
 	grpc.ClientConnInterface
 
 	// Table returns table client
@@ -265,7 +265,7 @@ func New(ctx context.Context, opts ...Option) (_ Connection, err error) {
 		)
 	}
 
-	if c.pool == nil {
+	if c.pool == nil || !c.config.SharedPool() {
 		c.pool = conn.NewPool(
 			ctx,
 			c.config,

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -417,7 +417,9 @@ func (c *cluster) Remove(ctx context.Context, e endpoint.Endpoint, opts ...crudO
 		panic("ydb: can't remove not-existing endpoint")
 	}
 
-	defer entry.Conn.Release(ctx)
+	defer func() {
+		_ = entry.Conn.Release(ctx)
+	}()
 
 	removed = entry.RemoveFrom(c.balancer, &c.balancerMtx)
 

--- a/internal/db/connection.go
+++ b/internal/db/connection.go
@@ -16,11 +16,11 @@ type Cluster interface {
 	closer.Closer
 }
 
-type ConnectionDiscovery interface {
+type Discoverer interface {
 	Discovery() discovery.Client
 }
 
-type ConnectionInfo interface {
+type Info interface {
 	// Endpoint returns initial endpoint
 	Endpoint() string
 
@@ -33,6 +33,6 @@ type ConnectionInfo interface {
 
 type Connection interface {
 	Cluster
-	ConnectionInfo
-	ConnectionDiscovery
+	Info
+	Discoverer
 }

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -197,6 +197,5 @@ func (c *client) WhoAmI(ctx context.Context) (whoAmI *discovery.WhoAmI, err erro
 }
 
 func (c *client) Close(ctx context.Context) error {
-	c.cc.Release(ctx)
-	return nil
+	return c.cc.Release(ctx)
 }

--- a/test/connection_test.go
+++ b/test/connection_test.go
@@ -83,6 +83,7 @@ func TestConnection(t *testing.T) {
 		ydb.WithUserAgent(userAgent),
 		ydb.WithRequestsType(requestType),
 		ydb.With(
+			config.WithInternalDNSResolver(),
 			config.WithGrpcOptions(
 				grpc.WithUnaryInterceptor(func(
 					ctx context.Context,
@@ -236,7 +237,7 @@ func TestConnection(t *testing.T) {
 		var childDB ydb.Connection
 		childDB, err = db.With(
 			ctx,
-			ydb.WithAccessTokenCredentials(""),
+			ydb.WithDialTimeout(time.Second*5),
 		)
 		if err != nil {
 			t.Fatalf("failed to open sub-connection: %v", err)


### PR DESCRIPTION
* Added `config.SharedPool()` setting and `config.WithSharedPool()` option
* Added management of shared pool flag on change dial timeout and credentials
* Removed explicit checks of conditions for use (or not) shared pool in `ydb.With()`
* Renamed `internal/db` interfaces
* Changed signature of `conn.Conn.Release` (added error as result)

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
