### PR TITLE
wait ydb container ready before table tests

### DIFF
--- a/.github/scripts/wait-ydb-container.sh
+++ b/.github/scripts/wait-ydb-container.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+while ! docker run --network host cr.yandex/yc/yandex-docker-local-ydb:latest /ydb -e grpc://localhost:2136 -d /local scheme ls; do
+  echo wait db...
+  sleep 3
+done
+echo DB available

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,7 @@ jobs:
         image: cr.yandex/yc/yandex-docker-local-ydb:latest
         ports:
           - 2135:2135
+          - 2136:2136
           - 8765:8765
         volumes:
           - /tmp/ydb_certs:/ydb_certs
@@ -63,6 +64,8 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Wait database available
+        run: bash ./.github/scripts/wait-ydb-container.sh
       - name: Test
         run: go test -race -coverpkg=./... -coverprofile table.txt -covermode atomic ./test/table_test.go
       - name: Upload coverage to Codecov
@@ -81,6 +84,7 @@ jobs:
         image: cr.yandex/yc/yandex-docker-local-ydb:latest
         ports:
           - 2135:2135
+          - 2136:2136
           - 8765:8765
         volumes:
           - /tmp/ydb_certs:/ydb_certs
@@ -102,6 +106,8 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Wait database available
+        run: bash ./.github/scripts/wait-ydb-container.sh
       - name: Test
         run: go test -race -coverpkg=./... -coverprofile ratelimiter.txt -covermode atomic ./test/ratelimiter_test.go
         shell: bash
@@ -121,6 +127,7 @@ jobs:
         image: cr.yandex/yc/yandex-docker-local-ydb:latest
         ports:
           - 2135:2135
+          - 2136:2136
           - 8765:8765
         volumes:
           - /tmp/ydb_certs:/ydb_certs
@@ -142,6 +149,8 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Wait database available
+        run: bash ./.github/scripts/wait-ydb-container.sh
       - name: Test
         run: go test -race -coverpkg=./... -coverprofile scripting.txt -covermode atomic ./test/scripting_test.go
       - name: Upload coverage to Codecov
@@ -160,6 +169,7 @@ jobs:
         image: cr.yandex/yc/yandex-docker-local-ydb:latest
         ports:
           - 2135:2135
+          - 2136:2136
           - 8765:8765
         volumes:
           - /tmp/ydb_certs:/ydb_certs
@@ -181,6 +191,8 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Wait database available
+        run: bash ./.github/scripts/wait-ydb-container.sh
       - name: Test
         run: go test -race -coverpkg=./... -coverprofile discovery.txt -covermode atomic ./test/discovery_test.go
       - name: Upload coverage to Codecov
@@ -199,6 +211,7 @@ jobs:
         image: cr.yandex/yc/yandex-docker-local-ydb:latest
         ports:
           - 2135:2135
+          - 2136:2136
           - 8765:8765
         volumes:
           - /tmp/ydb_certs:/ydb_certs
@@ -220,6 +233,8 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Wait database available
+        run: bash ./.github/scripts/wait-ydb-container.sh
       - name: Test
         run: go test -race -coverpkg=./... -coverprofile connection.txt -covermode atomic ./test/connection_test.go
       - name: Upload coverage to Codecov


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Start table tests right repository checkout

## What is the new behavior?

Wait while ydb container complete start and ydb service available. It prevent race condition between start test and background starting of ydb container.
