### PR TITLE
feat(scanner): add support json.RawMessage in setDefaultValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Supported json.Unmarshaler type for scanning row to values 
 * Reimplement sugar.DSN with net/url
 
 ## v3.21.0

--- a/internal/table/scanner/scanner.go
+++ b/internal/table/scanner/scanner.go
@@ -717,6 +717,7 @@ func (s *scanner) trySetByteArray(v interface{}, optional bool, def bool) bool {
 	return true
 }
 
+// nolint: gocyclo
 func (s *scanner) scanRequired(value interface{}) {
 	switch v := value.(type) {
 	case *bool:
@@ -770,6 +771,19 @@ func (s *scanner) scanRequired(value interface{}) {
 		err := v.Scan(s.any())
 		if err != nil {
 			_ = s.errorf(0, "sql.Scanner error: %w", err)
+		}
+	case json.Unmarshaler:
+		var err error
+		switch s.getType() {
+		case types.TypeJSON:
+			err = v.UnmarshalJSON(s.converter.JSON())
+		case types.TypeJSONDocument:
+			err = v.UnmarshalJSON(s.converter.JSONDocument())
+		default:
+			_ = s.errorf(0, "ydb required type %T not unsupported for applying to json.Unmarshaler", s.getType())
+		}
+		if err != nil {
+			_ = s.errorf(0, "json.Unmarshaler error: %w", err)
 		}
 	default:
 		ok := s.trySetByteArray(v, false, false)
@@ -949,6 +963,20 @@ func (s *scanner) scanOptional(value interface{}, defaultValueForOptional bool) 
 		if err != nil {
 			_ = s.errorf(0, "sql.Scanner error: %w", err)
 		}
+	case json.Unmarshaler:
+		s.unwrap()
+		var err error
+		switch s.getType() {
+		case types.TypeJSON:
+			err = v.UnmarshalJSON(s.converter.JSON())
+		case types.TypeJSONDocument:
+			err = v.UnmarshalJSON(s.converter.JSONDocument())
+		default:
+			_ = s.errorf(0, "ydb optional type %T not unsupported for applying to json.Unmarshaler", s.getType())
+		}
+		if err != nil {
+			_ = s.errorf(0, "json.Unmarshaler error: %w", err)
+		}
 	default:
 		s.unwrap()
 		ok := s.trySetByteArray(v, true, false)
@@ -1012,6 +1040,11 @@ func (s *scanner) setDefaultValue(dst interface{}) {
 		err := v.UnmarshalYDB(s.converter)
 		if err != nil {
 			_ = s.errorf(0, "ydb.Scanner error: %w", err)
+		}
+	case json.Unmarshaler:
+		err := v.UnmarshalJSON(nil)
+		if err != nil {
+			_ = s.errorf(0, "json.Unmarshaler error: %w", err)
 		}
 	default:
 		ok := s.trySetByteArray(v, false, true)

--- a/table/result/indexed/indexed.go
+++ b/table/result/indexed/indexed.go
@@ -5,7 +5,7 @@ package indexed
 //
 // This is a proxy type for preparing go1.18 type set constrains such as
 //   type Required interface {
-//     *int8 | *int64 | *string | types.Scanner
+//     *int8 | *int64 | *string | types.Scanner | json.Unmarshaler
 //   }
 type Required interface{}
 
@@ -14,7 +14,7 @@ type Required interface{}
 //
 // This is a proxy type for preparing go1.18 type set constrains such as
 //   type Optional interface {
-//     **int8 | **int64 | **string | types.Scanner
+//     **int8 | **int64 | **string | types.Scanner | json.Unmarshaler
 //   }
 // or alias such as
 //   type Optional *Required

--- a/table/result/result.go
+++ b/table/result/result.go
@@ -92,7 +92,7 @@ type result interface {
 	//   time.Time
 	//   time.Duration
 	//   ydb.Value
-	// For custom types implement sql.Scanner interface.
+	// For custom types implement sql.Scanner or json.Unmarshaler interface.
 	// For optional types use double pointer construction.
 	// For unknown types use interface types.
 	// Supported scanning byte arrays of various length.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

```
scan row failed: type *json.RawMessage is unknown at `github.com/ydb-platform/ydb-go-sdk/v3/internal/table/scanner.(*scanner).setDefaultValue(scanner.go:1019)`
```

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Error

Issue Number: N/A

## What is the new behavior?

-  Set nil as default value for json.RawMessage when scanning rows

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
