### PR TITLE
define tls.Config explicitly instead redefine default TLS config options 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* Added `WithTLSConfig` option for redefine TLS config
+* Added `sugar.LoadCertificatesFromFile` and `sugar.LoadCertificatesFromPem` helpers
+
 ## v3.22.0
 * Supported `json.Unmarshaler` type for scanning row to values 
 * Reimplement `sugar.DSN` with `net/url`

--- a/internal/dsn/dsn.go
+++ b/internal/dsn/dsn.go
@@ -16,13 +16,8 @@ var (
 			}, nil
 		},
 	}
-	schemasSecure = map[string]bool{
-		"":      true,
-		"grpcs": true,
-		"grpc":  false,
-	}
-	errSchemeNotValid = xerrors.Wrap(fmt.Errorf("schema not valid"))
-	errParserExists   = xerrors.Wrap(fmt.Errorf("already exists parser. newest parser replaced old. param"))
+	insecureSchema  = "grpc"
+	errParserExists = xerrors.Wrap(fmt.Errorf("already exists parser. newest parser replaced old. param"))
 )
 
 type Parser func(value string) ([]config.Option, error)
@@ -41,15 +36,10 @@ func Parse(dsn string) (options []config.Option, err error) {
 	if err != nil {
 		return nil, xerrors.WithStackTrace(err)
 	}
-	if _, has := schemasSecure[uri.Scheme]; !has {
-		return nil, xerrors.WithStackTrace(
-			fmt.Errorf("%w: %v", errSchemeNotValid, uri.Scheme),
-		)
-	}
 	options = append(
 		options,
 		config.WithEndpoint(uri.Host),
-		config.WithSecure(schemasSecure[uri.Scheme]),
+		config.WithSecure(uri.Scheme != insecureSchema),
 	)
 	for param, values := range uri.Query() {
 		if p, has := parsers[param]; has {

--- a/internal/dsn/dsn_test.go
+++ b/internal/dsn/dsn_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/config"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/credentials"
-	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
 	"github.com/ydb-platform/ydb-go-sdk/v3/testutil"
 )
 
@@ -27,7 +26,6 @@ func TestParseConnectionString(t *testing.T) {
 		endpoint         string
 		database         string
 		token            string
-		error            error
 	}{
 		{
 			"grpc://ydb-ru.yandex.net:2135/?" +
@@ -36,7 +34,6 @@ func TestParseConnectionString(t *testing.T) {
 			"ydb-ru.yandex.net:2135",
 			"/ru/home/gvit/mydb",
 			"123",
-			nil,
 		},
 		{
 			"grpcs://ydb.serverless.yandexcloud.net:2135/?" +
@@ -45,7 +42,6 @@ func TestParseConnectionString(t *testing.T) {
 			"ydb.serverless.yandexcloud.net:2135",
 			"/ru-central1/b1g8skpblkos03malf3s/etn02qso4v3isjb00te1",
 			"123",
-			nil,
 		},
 		{
 			"grpcs://lb.etn03r9df42nb631unbv.ydb.mdb.yandexcloud.net:2135/?" +
@@ -54,20 +50,18 @@ func TestParseConnectionString(t *testing.T) {
 			"lb.etn03r9df42nb631unbv.ydb.mdb.yandexcloud.net:2135",
 			"/ru-central1/b1g8skpblkos03malf3s/etn03r9df42nb631unbv",
 			"123",
-			nil,
 		},
 		{
 			"abcd://ydb-ru.yandex.net:2135/?database=/ru/home/gvit/mydb",
 			true,
+			"ydb-ru.yandex.net:2135",
+			"/ru/home/gvit/mydb",
 			"",
-			"",
-			"",
-			errSchemeNotValid,
 		},
 	} {
 		t.Run(test.connectionString, func(t *testing.T) {
 			options, err := Parse(test.connectionString)
-			if !xerrors.Is(err, test.error) {
+			if err != nil {
 				t.Fatalf("Received unexpected error:\n%+v", err)
 			}
 			config := config.New(options...)

--- a/sugar/certificates.go
+++ b/sugar/certificates.go
@@ -1,0 +1,44 @@
+package sugar
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
+)
+
+// LoadCertificatesFromFile read and parse caFile and returns certificates
+func LoadCertificatesFromFile(caFile string) ([]*x509.Certificate, error) {
+	bytes, err := ioutil.ReadFile(filepath.Clean(caFile))
+	if err != nil {
+		return nil, xerrors.WithStackTrace(err)
+	}
+	return LoadCertificatesFromPem(bytes), nil
+}
+
+// LoadCertificatesFromPem parse bytes and returns certificates
+func LoadCertificatesFromPem(bytes []byte) (certs []*x509.Certificate) {
+	var (
+		cert *x509.Certificate
+		err  error
+	)
+	for len(bytes) > 0 {
+		var block *pem.Block
+		block, bytes = pem.Decode(bytes)
+		if block == nil {
+			break
+		}
+		if block.Type != "CERTIFICATE" || len(block.Headers) != 0 {
+			continue
+		}
+		certBytes := block.Bytes
+		cert, err = x509.ParseCertificate(certBytes)
+		if err != nil {
+			continue
+		}
+		certs = append(certs, cert)
+	}
+	return
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

The SDK's default tls.Config contains root CA. User may appends custom certificates to defaults TLS config, redefine min TLS version and change InsecureSkipVerify flag. 
Also internal config field secure is an ambigious with TLS config. Always true secure flag indirectly redefines tls config with default TLS, false secure flag skips TLS config to nil.
PR's contains changes for using user-defined tls.Config explicitly and deprecates other options about TLS config.

CHANGELOG:
* Added `WithTLSConfig` option for redefine TLS config
* Marked as deprecated options `WithSecure`, `WithInSecure`, `WithMinTLSVersion`, `WithTLSSInsecureSkipVerify`, `WithCertificate`, `WithCertificatesFromFile, `WithCertificatesFromPem`
* Added `sugar.LoadCertificatesFromFile` and `sugar.LoadCertificatesFromPem` helpers


## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #217 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
