### PR TITLE
Fix bug with reopening lazy table client on call after Close()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* Fixed re-opening case after close lazy-initialized clients
+* Removed dependency of call context for initializing lazy table client
+
 ## v3.23.0
 * Added `WithTLSConfig` option for redefine TLS config
 * Added `sugar.LoadCertificatesFromFile` and `sugar.LoadCertificatesFromPem` helpers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 * Fixed re-opening case after close lazy-initialized clients
 * Removed dependency of call context for initializing lazy table client
+* Added `config.AutoRetry()` flag with `true` value by default. `config.AutoRetry()` affects how to errors handle in sub-clients calls.
+* Added `config.WithNoAutoRetry` for disabling auto-retry on errors in sub-clients calls 
+* Refactored `internal/lazy` package (supported check `config.AutoRetry()`, removed all error wrappings with stacktrace)
 
 ## v3.23.0
 * Added `WithTLSConfig` option for redefine TLS config

--- a/config/config.go
+++ b/config/config.go
@@ -208,6 +208,13 @@ func WithOperationCancelAfter(operationCancelAfter time.Duration) Option {
 	}
 }
 
+// WithNoAutoRetry disable auto-retry calls from YDB sub-clients
+func WithNoAutoRetry() Option {
+	return func(c *Config) {
+		config.SetAutoRetry(&c.Common, false)
+	}
+}
+
 // WithPanicCallback applies panic callback to config
 func WithPanicCallback(panicCallback func(e interface{})) Option {
 	return func(c *Config) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -7,8 +7,14 @@ import (
 type Common struct {
 	operationTimeout     time.Duration
 	operationCancelAfter time.Duration
+	disableAutoRetry     bool
 
 	panicCallback func(e interface{})
+}
+
+// AutoRetry defines auto-retry flag
+func (c *Common) AutoRetry() bool {
+	return !c.disableAutoRetry
 }
 
 // PanicCallback returns user-defined panic callback
@@ -58,4 +64,9 @@ func SetOperationCancelAfter(c *Common, operationCancelAfter time.Duration) {
 // SetPanicCallback applies panic callback to config
 func SetPanicCallback(c *Common, panicCallback func(e interface{})) {
 	c.panicCallback = panicCallback
+}
+
+// SetAutoRetry affects on AutoRetry() flag
+func SetAutoRetry(c *Common, autoRetry bool) {
+	c.disableAutoRetry = !autoRetry
 }

--- a/internal/coordination/client.go
+++ b/internal/coordination/client.go
@@ -21,9 +21,9 @@ type client struct {
 	service Ydb_Coordination_V1.CoordinationServiceClient
 }
 
-func New(cc grpc.ClientConnInterface, options []config.Option) coordination.Client {
+func New(cc grpc.ClientConnInterface, config config.Config) coordination.Client {
 	return &client{
-		config:  config.New(options...),
+		config:  config,
 		service: Ydb_Coordination_V1.NewCoordinationServiceClient(cc),
 	}
 }

--- a/internal/lazy/coordiantion.go
+++ b/internal/lazy/coordiantion.go
@@ -66,9 +66,6 @@ func (c *lazyCoordination) Close(ctx context.Context) (err error) {
 	if c.c == nil {
 		return nil
 	}
-	defer func() {
-		c.c = nil
-	}()
 	err = c.c.Close(ctx)
 	if err != nil {
 		return xerrors.WithStackTrace(err)

--- a/internal/lazy/coordiantion.go
+++ b/internal/lazy/coordiantion.go
@@ -8,38 +8,46 @@ import (
 	builder "github.com/ydb-platform/ydb-go-sdk/v3/internal/coordination"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/coordination/config"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/database"
-	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
 	"github.com/ydb-platform/ydb-go-sdk/v3/retry"
 	"github.com/ydb-platform/ydb-go-sdk/v3/scheme"
 )
 
 type lazyCoordination struct {
-	db      database.Connection
-	options []config.Option
-	c       coordination.Client
-	m       sync.Mutex
+	db     database.Connection
+	config config.Config
+	c      coordination.Client
+	m      sync.Mutex
 }
 
 func Coordination(db database.Connection, options []config.Option) coordination.Client {
 	return &lazyCoordination{
-		db:      db,
-		options: options,
+		db:     db,
+		config: config.New(options...),
 	}
 }
 
 func (c *lazyCoordination) CreateNode(ctx context.Context, path string, config coordination.NodeConfig) (err error) {
+	if !c.config.AutoRetry() {
+		return c.client().CreateNode(ctx, path, config)
+	}
 	return retry.Retry(ctx, func(ctx context.Context) (err error) {
 		return c.client().CreateNode(ctx, path, config)
 	})
 }
 
 func (c *lazyCoordination) AlterNode(ctx context.Context, path string, config coordination.NodeConfig) (err error) {
+	if !c.config.AutoRetry() {
+		return c.client().AlterNode(ctx, path, config)
+	}
 	return retry.Retry(ctx, func(ctx context.Context) (err error) {
 		return c.client().AlterNode(ctx, path, config)
 	})
 }
 
 func (c *lazyCoordination) DropNode(ctx context.Context, path string) (err error) {
+	if !c.config.AutoRetry() {
+		return c.client().DropNode(ctx, path)
+	}
 	return retry.Retry(ctx, func(ctx context.Context) (err error) {
 		return c.client().DropNode(ctx, path)
 	})
@@ -53,11 +61,14 @@ func (c *lazyCoordination) DescribeNode(
 	config *coordination.NodeConfig,
 	err error,
 ) {
+	if !c.config.AutoRetry() {
+		return c.client().DescribeNode(ctx, path)
+	}
 	err = retry.Retry(ctx, func(ctx context.Context) (err error) {
 		entry, config, err = c.client().DescribeNode(ctx, path)
-		return xerrors.WithStackTrace(err)
+		return err
 	})
-	return entry, config, xerrors.WithStackTrace(err)
+	return entry, config, err
 }
 
 func (c *lazyCoordination) Close(ctx context.Context) (err error) {
@@ -66,18 +77,14 @@ func (c *lazyCoordination) Close(ctx context.Context) (err error) {
 	if c.c == nil {
 		return nil
 	}
-	err = c.c.Close(ctx)
-	if err != nil {
-		return xerrors.WithStackTrace(err)
-	}
-	return nil
+	return c.c.Close(ctx)
 }
 
 func (c *lazyCoordination) client() coordination.Client {
 	c.m.Lock()
 	defer c.m.Unlock()
 	if c.c == nil {
-		c.c = builder.New(c.db, c.options)
+		c.c = builder.New(c.db, c.config)
 	}
 	return c.c
 }

--- a/internal/lazy/ratelimiter.go
+++ b/internal/lazy/ratelimiter.go
@@ -33,9 +33,6 @@ func (r *lazyRatelimiter) Close(ctx context.Context) (err error) {
 	if r.c == nil {
 		return nil
 	}
-	defer func() {
-		r.c = nil
-	}()
 	err = r.c.Close(ctx)
 	if err != nil {
 		return xerrors.WithStackTrace(err)

--- a/internal/lazy/scheme.go
+++ b/internal/lazy/scheme.go
@@ -42,9 +42,6 @@ func (s *lazyScheme) Close(ctx context.Context) (err error) {
 	if s.c == nil {
 		return nil
 	}
-	defer func() {
-		s.c = nil
-	}()
 	err = s.c.Close(ctx)
 	if err != nil {
 		return xerrors.WithStackTrace(err)

--- a/internal/lazy/scheme.go
+++ b/internal/lazy/scheme.go
@@ -7,22 +7,21 @@ import (
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/database"
 	builder "github.com/ydb-platform/ydb-go-sdk/v3/internal/scheme"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/scheme/config"
-	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
 	"github.com/ydb-platform/ydb-go-sdk/v3/retry"
 	"github.com/ydb-platform/ydb-go-sdk/v3/scheme"
 )
 
 type lazyScheme struct {
-	db      database.Connection
-	options []config.Option
-	c       scheme.Client
-	m       sync.Mutex
+	db     database.Connection
+	config config.Config
+	c      scheme.Client
+	m      sync.Mutex
 }
 
 func Scheme(db database.Connection, options []config.Option) scheme.Client {
 	return &lazyScheme{
-		db:      db,
-		options: options,
+		db:     db,
+		config: config.New(options...),
 	}
 }
 
@@ -42,19 +41,15 @@ func (s *lazyScheme) Close(ctx context.Context) (err error) {
 	if s.c == nil {
 		return nil
 	}
-	err = s.c.Close(ctx)
-	if err != nil {
-		return xerrors.WithStackTrace(err)
-	}
-	return nil
+	return s.c.Close(ctx)
 }
 
 func (s *lazyScheme) DescribePath(ctx context.Context, path string) (e scheme.Entry, err error) {
 	err = retry.Retry(ctx, func(ctx context.Context) (err error) {
 		e, err = s.client().DescribePath(ctx, path)
-		return xerrors.WithStackTrace(err)
+		return err
 	}, retry.WithIdempotent(true))
-	return e, xerrors.WithStackTrace(err)
+	return e, err
 }
 
 func (s *lazyScheme) MakeDirectory(ctx context.Context, path string) (err error) {
@@ -66,9 +61,9 @@ func (s *lazyScheme) MakeDirectory(ctx context.Context, path string) (err error)
 func (s *lazyScheme) ListDirectory(ctx context.Context, path string) (d scheme.Directory, err error) {
 	err = retry.Retry(ctx, func(ctx context.Context) (err error) {
 		d, err = s.client().ListDirectory(ctx, path)
-		return xerrors.WithStackTrace(err)
+		return err
 	}, retry.WithIdempotent(true))
-	return d, xerrors.WithStackTrace(err)
+	return d, err
 }
 
 func (s *lazyScheme) RemoveDirectory(ctx context.Context, path string) (err error) {
@@ -81,7 +76,7 @@ func (s *lazyScheme) client() scheme.Client {
 	s.m.Lock()
 	defer s.m.Unlock()
 	if s.c == nil {
-		s.c = builder.New(s.db, s.options)
+		s.c = builder.New(s.db, s.config)
 	}
 	return s.c
 }

--- a/internal/lazy/scripting.go
+++ b/internal/lazy/scripting.go
@@ -63,9 +63,6 @@ func (s *lazyScripting) Close(ctx context.Context) (err error) {
 	if s.c == nil {
 		return nil
 	}
-	defer func() {
-		s.c = nil
-	}()
 	err = s.c.Close(ctx)
 	if err != nil {
 		return xerrors.WithStackTrace(err)

--- a/internal/lazy/scripting.go
+++ b/internal/lazy/scripting.go
@@ -7,7 +7,6 @@ import (
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/database"
 	builder "github.com/ydb-platform/ydb-go-sdk/v3/internal/scripting"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/scripting/config"
-	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
 	"github.com/ydb-platform/ydb-go-sdk/v3/retry"
 	"github.com/ydb-platform/ydb-go-sdk/v3/scripting"
 	"github.com/ydb-platform/ydb-go-sdk/v3/table"
@@ -15,10 +14,10 @@ import (
 )
 
 type lazyScripting struct {
-	db      database.Connection
-	options []config.Option
-	c       scripting.Client
-	m       sync.Mutex
+	db     database.Connection
+	config config.Config
+	c      scripting.Client
+	m      sync.Mutex
 }
 
 func (s *lazyScripting) Execute(
@@ -28,9 +27,9 @@ func (s *lazyScripting) Execute(
 ) (res result.Result, err error) {
 	err = retry.Retry(ctx, func(ctx context.Context) (err error) {
 		res, err = s.client().Execute(ctx, query, params)
-		return xerrors.WithStackTrace(err)
+		return err
 	})
-	return res, xerrors.WithStackTrace(err)
+	return res, err
 }
 
 func (s *lazyScripting) Explain(
@@ -40,9 +39,9 @@ func (s *lazyScripting) Explain(
 ) (e table.ScriptingYQLExplanation, err error) {
 	err = retry.Retry(ctx, func(ctx context.Context) (err error) {
 		e, err = s.client().Explain(ctx, query, mode)
-		return xerrors.WithStackTrace(err)
+		return err
 	})
-	return e, xerrors.WithStackTrace(err)
+	return e, err
 }
 
 func (s *lazyScripting) StreamExecute(
@@ -52,9 +51,9 @@ func (s *lazyScripting) StreamExecute(
 ) (res result.StreamResult, err error) {
 	err = retry.Retry(ctx, func(ctx context.Context) (err error) {
 		res, err = s.client().StreamExecute(ctx, query, params)
-		return xerrors.WithStackTrace(err)
+		return err
 	})
-	return res, xerrors.WithStackTrace(err)
+	return res, err
 }
 
 func (s *lazyScripting) Close(ctx context.Context) (err error) {
@@ -63,17 +62,13 @@ func (s *lazyScripting) Close(ctx context.Context) (err error) {
 	if s.c == nil {
 		return nil
 	}
-	err = s.c.Close(ctx)
-	if err != nil {
-		return xerrors.WithStackTrace(err)
-	}
-	return nil
+	return s.c.Close(ctx)
 }
 
 func Scripting(db database.Connection, options []config.Option) scripting.Client {
 	return &lazyScripting{
-		db:      db,
-		options: options,
+		db:     db,
+		config: config.New(options...),
 	}
 }
 
@@ -81,7 +76,7 @@ func (s *lazyScripting) client() scripting.Client {
 	s.m.Lock()
 	defer s.m.Unlock()
 	if s.c == nil {
-		s.c = builder.New(s.db, s.options)
+		s.c = builder.New(s.db, s.config)
 	}
 	return s.c
 }

--- a/internal/lazy/table.go
+++ b/internal/lazy/table.go
@@ -26,15 +26,15 @@ func Table(db database.Connection, options []config.Option) table.Client {
 }
 
 func (t *lazyTable) CreateSession(ctx context.Context, opts ...table.Option) (s table.ClosableSession, err error) {
-	return t.client(ctx).CreateSession(ctx, opts...)
+	return t.client().CreateSession(ctx, opts...)
 }
 
 func (t *lazyTable) Do(ctx context.Context, op table.Operation, opts ...table.Option) (err error) {
-	return t.client(ctx).Do(ctx, op, opts...)
+	return t.client().Do(ctx, op, opts...)
 }
 
 func (t *lazyTable) DoTx(ctx context.Context, op table.TxOperation, opts ...table.Option) (err error) {
-	return t.client(ctx).DoTx(ctx, op, opts...)
+	return t.client().DoTx(ctx, op, opts...)
 }
 
 func (t *lazyTable) Close(ctx context.Context) (err error) {
@@ -43,9 +43,6 @@ func (t *lazyTable) Close(ctx context.Context) (err error) {
 	if t.c == nil {
 		return nil
 	}
-	defer func() {
-		t.c = nil
-	}()
 	err = t.c.Close(ctx)
 	if err != nil {
 		return xerrors.WithStackTrace(err)
@@ -53,11 +50,11 @@ func (t *lazyTable) Close(ctx context.Context) (err error) {
 	return nil
 }
 
-func (t *lazyTable) client(ctx context.Context) table.Client {
+func (t *lazyTable) client() table.Client {
 	t.m.Lock()
 	defer t.m.Unlock()
 	if t.c == nil {
-		t.c = builder.New(ctx, t.db, t.options...)
+		t.c = builder.New(t.db, t.options)
 	}
 	return t.c
 }

--- a/internal/ratelimiter/ratelimiter.go
+++ b/internal/ratelimiter/ratelimiter.go
@@ -34,9 +34,9 @@ func (c *client) Close(ctx context.Context) error {
 	return nil
 }
 
-func New(cc grpc.ClientConnInterface, options []config.Option) *client {
+func New(cc grpc.ClientConnInterface, config config.Config) *client {
 	return &client{
-		config:  config.New(options...),
+		config:  config,
 		service: Ydb_RateLimiter_V1.NewRateLimiterServiceClient(cc),
 	}
 }

--- a/internal/scheme/scheme.go
+++ b/internal/scheme/scheme.go
@@ -24,9 +24,9 @@ func (c *client) Close(_ context.Context) error {
 	return nil
 }
 
-func New(cc grpc.ClientConnInterface, options []config.Option) scheme.Client {
+func New(cc grpc.ClientConnInterface, config config.Config) scheme.Client {
 	return &client{
-		config:  config.New(options...),
+		config:  config,
 		service: Ydb_Scheme_V1.NewSchemeServiceClient(cc),
 	}
 }

--- a/internal/scripting/scripting.go
+++ b/internal/scripting/scripting.go
@@ -188,9 +188,9 @@ func (c *client) Close(ctx context.Context) (err error) {
 	return nil
 }
 
-func New(cc grpc.ClientConnInterface, options []config.Option) scripting.Client {
+func New(cc grpc.ClientConnInterface, config config.Config) scripting.Client {
 	return &client{
-		config:  config.New(options...),
+		config:  config,
 		service: Ydb_Scripting_V1.NewScriptingServiceClient(cc),
 	}
 }

--- a/internal/table/client.go
+++ b/internal/table/client.go
@@ -52,8 +52,7 @@ type Client interface {
 	CloseSession(ctx context.Context, s Session) (err error)
 }
 
-func New(cc grpc.ClientConnInterface, opts []config.Option) Client {
-	config := config.New(opts...)
+func New(cc grpc.ClientConnInterface, config config.Config) Client {
 	return newClient(cc, nil, config)
 }
 

--- a/internal/table/client_test.go
+++ b/internal/table/client_test.go
@@ -230,10 +230,10 @@ func TestSessionPoolCloseWhenWaiting(t *testing.T) {
 			const timeout = time.Second
 			select {
 			case err := <-got:
-				if !xerrors.Is(err, errSessionPoolClosed) {
+				if !xerrors.Is(err, errAlreadyClosed) {
 					t.Fatalf(
 						"unexpected error: %v; want %v",
-						err, errSessionPoolClosed,
+						err, errAlreadyClosed,
 					)
 				}
 			case <-time.After(timeout):
@@ -310,10 +310,10 @@ func TestSessionPoolClose(t *testing.T) {
 		t.Fatalf("unexpected session close")
 	}
 
-	if err := p.Put(context.Background(), s3); !xerrors.Is(err, errSessionPoolClosed) {
+	if err := p.Put(context.Background(), s3); !xerrors.Is(err, errAlreadyClosed) {
 		t.Errorf(
 			"unexpected Put() error: %v; want %v",
-			err, errSessionPoolClosed,
+			err, errAlreadyClosed,
 		)
 	}
 	wg.Wait()
@@ -366,7 +366,7 @@ func TestRaceWgClosed(t *testing.T) {
 								return nil
 							},
 						)
-						if xerrors.Is(err, errSessionPoolClosed) {
+						if xerrors.Is(err, errAlreadyClosed) {
 							return
 						}
 					}
@@ -474,7 +474,6 @@ func TestSessionPoolRacyGet(t *testing.T) {
 	}
 	create := make(chan createReq)
 	p := newClient(
-		context.Background(),
 		nil,
 		(&StubBuilder{
 			Limit: 1,
@@ -1357,7 +1356,6 @@ func newClientWithStubBuilder(
 	options ...config.Option,
 ) *client {
 	return newClient(
-		context.Background(),
 		cc,
 		(&StubBuilder{
 			T:     t,

--- a/internal/table/session_test.go
+++ b/internal/table/session_test.go
@@ -331,7 +331,6 @@ func TestSessionOperationModeOnExecuteDataQuery(t *testing.T) {
 				for _, srcDst := range fromTo {
 					t.Run(srcDst.srcMode.String()+"->"+srcDst.dstMode.String(), func(t *testing.T) {
 						client := newClient(
-							context.Background(),
 							testutil.NewDB(
 								testutil.WithInvokeHandlers(
 									testutil.InvokeHandlers{


### PR DESCRIPTION
* Fixed re-opening case after close lazy-initialized clients
* Removed dependency of call context for initializing lazy table client

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
