### PR TITLE
Add minimum force rediscovery interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Prevent overload server by infinite force rediscovery
+
 ## v3.24.0
 * Fixed re-opening case after close lazy-initialized clients
 * Removed dependency of call context for initializing lazy table client


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Discovery errors call rediscovery process without pause and can overload discovery endpoint.

## What is the new behavior?

SDK has minimum interval between force rediscovery - 1 second.
