### PR TITLE
Removed internal counters of conn.Conn + disable auto-reconnection of broken conns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Removed `internal/conn/conn.streamUsages` and `internal/conn/conn.usages` (`internal/conn.conn` always touching last usage timestamp on API calls)
+* Removed auto-reconnecting for broken conns
 * Refactored applying actual endpoints list after re-discovery (replaced diff-merge logic to swap cluster struct, cluster and balancers are immutable now)
 * Added `trace.Driver.OnUnpessimizeNode` trace event
 

--- a/internal/balancer/mock/conn.go
+++ b/internal/balancer/mock/conn.go
@@ -75,10 +75,6 @@ func (c *Conn) Unban() conn.State {
 	return conn.Online
 }
 
-func (c *Conn) Release(ctx context.Context) error {
-	panic("not implemented in mock")
-}
-
 type Endpoint struct {
 	AddrField     string
 	LocationField string

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -119,18 +119,6 @@ func (c *Cluster) Close(ctx context.Context) (err error) {
 	c.m.Lock()
 	defer c.m.Unlock()
 
-	var issues []error
-
-	for _, cc := range c.conns {
-		if err := cc.Release(ctx); err != nil {
-			issues = append(issues, err)
-		}
-	}
-
-	if len(issues) > 0 {
-		return xerrors.WithStackTrace(xerrors.NewWithIssues("cluster closed with issues", issues...))
-	}
-
 	return nil
 }
 

--- a/internal/conn/conn.go
+++ b/internal/conn/conn.go
@@ -3,9 +3,7 @@ package conn
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb"
@@ -41,8 +39,6 @@ type Conn interface {
 	GetState() State
 	SetState(State) State
 	Unban() State
-
-	Release(ctx context.Context) error
 }
 
 func (c *conn) Address() string {
@@ -50,17 +46,15 @@ func (c *conn) Address() string {
 }
 
 type conn struct {
-	mtx          sync.RWMutex
-	config       Config // ro access
-	cc           *grpc.ClientConn
-	done         chan struct{}
-	endpoint     endpoint.Endpoint // ro access
-	closed       bool
-	state        State
-	usages       int32
-	streamUsages int32
-	lastUsage    time.Time
-	onClose      []func(*conn)
+	mtx       sync.RWMutex
+	config    Config // ro access
+	cc        *grpc.ClientConn
+	done      chan struct{}
+	endpoint  endpoint.Endpoint // ro access
+	closed    bool
+	state     State
+	lastUsage time.Time
+	onClose   []func(*conn)
 }
 
 func (c *conn) Ping(ctx context.Context) error {
@@ -74,39 +68,7 @@ func (c *conn) Ping(ctx context.Context) error {
 	return nil
 }
 
-func (c *conn) Release(ctx context.Context) (err error) {
-	var (
-		onDone = trace.DriverOnConnRelease(
-			c.config.Trace(),
-			&ctx,
-			c.endpoint.Copy(),
-		)
-		issues []error
-	)
-	defer func() {
-		onDone(err)
-	}()
-
-	if c.changeUsages(-1) == 0 {
-		if usages := atomic.LoadInt32(&c.streamUsages); usages > 0 {
-			issues = append(issues, fmt.Errorf("conn in stream use: usages=%d", usages))
-		}
-		if closeErr := c.Close(ctx); closeErr != nil {
-			issues = append(issues, closeErr)
-		}
-	}
-
-	if len(issues) > 0 {
-		return xerrors.WithStackTrace(xerrors.NewWithIssues("conn released with issues", issues...))
-	}
-
-	return nil
-}
-
 func (c *conn) LastUsage() time.Time {
-	if usages := atomic.LoadInt32(&c.streamUsages); usages > 0 {
-		return time.Now()
-	}
 	c.mtx.RLock()
 	defer c.mtx.RUnlock()
 	return c.lastUsage
@@ -224,11 +186,9 @@ func (c *conn) take(ctx context.Context) (cc *grpc.ClientConn, err error) {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 
-	if !isBroken(c.cc) {
+	if c.cc != nil {
 		return c.cc, nil
 	}
-
-	_ = c.close()
 
 	if dialTimeout := c.config.DialTimeout(); dialTimeout > 0 {
 		var cancel context.CancelFunc
@@ -255,48 +215,6 @@ func (c *conn) touchLastUsage() {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 	c.lastUsage = time.Now()
-}
-
-func (c *conn) changeUsages(delta int32) int32 {
-	defer c.touchLastUsage()
-
-	usages := atomic.AddInt32(&c.usages, delta)
-
-	if usages < 0 {
-		panic("negative usages: " + strconv.Itoa(int(usages)))
-	}
-
-	trace.DriverOnConnUsagesChange(
-		c.config.Trace(),
-		c.endpoint.Copy(),
-		int(usages),
-	)
-
-	return usages
-}
-
-func (c *conn) changeStreamUsages(delta int32) {
-	defer c.touchLastUsage()
-
-	usages := atomic.AddInt32(&c.streamUsages, delta)
-
-	if usages < 0 {
-		panic("negative stream usages: " + strconv.Itoa(int(usages)))
-	}
-
-	trace.DriverOnConnStreamUsagesChange(
-		c.config.Trace(),
-		c.endpoint.Copy(),
-		int(usages),
-	)
-}
-
-func isBroken(raw *grpc.ClientConn) bool {
-	if raw == nil {
-		return true
-	}
-	s := raw.GetState()
-	return s == connectivity.Shutdown || s == connectivity.TransientFailure
 }
 
 func isAvailable(raw *grpc.ClientConn) bool {
@@ -379,8 +297,8 @@ func (c *conn) Invoke(
 		return xerrors.WithStackTrace(err)
 	}
 
-	c.changeUsages(1)
-	defer c.changeUsages(-1)
+	c.touchLastUsage()
+	defer c.touchLastUsage()
 
 	err = cc.Invoke(ctx, method, req, res, opts...)
 
@@ -459,8 +377,8 @@ func (c *conn) NewStream(
 		return nil, xerrors.WithStackTrace(err)
 	}
 
-	c.changeStreamUsages(1)
-	defer c.changeStreamUsages(-1)
+	c.touchLastUsage()
+	defer c.touchLastUsage()
 
 	s, err = cc.NewStream(ctx, desc, method, opts...)
 
@@ -499,7 +417,6 @@ func withOnClose(onClose func(*conn)) option {
 
 func newConn(e endpoint.Endpoint, config Config, opts ...option) *conn {
 	c := &conn{
-		usages:   1,
 		state:    Created,
 		endpoint: e,
 		config:   config,

--- a/internal/conn/pool.go
+++ b/internal/conn/pool.go
@@ -63,7 +63,6 @@ func (p *pool) Get(endpoint endpoint.Endpoint) Conn {
 	)
 
 	if cc, has = p.conns[address]; has {
-		cc.changeUsages(1)
 		return cc
 	}
 

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -132,5 +132,5 @@ func (c *Client) WhoAmI(ctx context.Context) (whoAmI *discovery.WhoAmI, err erro
 }
 
 func (c *Client) Close(ctx context.Context) error {
-	return c.cc.Release(ctx)
+	return nil
 }

--- a/internal/xerrors/transport.go
+++ b/internal/xerrors/transport.go
@@ -175,7 +175,6 @@ func FromGRPCError(err error, opts ...teOpt) error {
 	if errors.As(err, &t) {
 		return err
 	}
-
 	if s, ok := grpcStatus.FromError(err); ok {
 		te := &transportError{
 			code:    s.Code(),


### PR DESCRIPTION
* Removed `internal/conn/conn.streamUsages` and `internal/conn/conn.usages` (`internal/conn.conn` always touching last usage timestamp on API calls)
* Added `config.AutoReconnect()` flag for auto-reconnecting broken conns
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #232 #231 #219 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
