### PR TITLE
Fixed repeater force initial timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed repeater initial force timeout from 500 to 0.5 second
+
 ## v3.25.1
 * Fixed bug with unexpected failing of call `Invoke` and `NewStream` on closed cluster
 * Fixed bug with releasing `internal/conn/conn.Pool` in cluster

--- a/internal/repeater/repeater.go
+++ b/internal/repeater/repeater.go
@@ -140,7 +140,7 @@ func (r *repeater) worker(ctx context.Context, interval time.Duration) {
 
 	// force returns backoff with delays [500ms...32s]
 	force := backoff.New(
-		backoff.WithSlotDuration(500*time.Second),
+		backoff.WithSlotDuration(500*time.Millisecond),
 		backoff.WithCeiling(6),
 		backoff.WithJitterLimit(1),
 	)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Initial force timeout 500 seconds (in fact - deny second force discovery)

## What is the new behavior?
Initial force timeout 500 milliseconds (0.5 second)
