### PR TITLE
Install gorelease util with latest go

### DIFF
--- a/.github/workflows/breaking.yml
+++ b/.github/workflows/breaking.yml
@@ -24,7 +24,7 @@ jobs:
             ~/go/bin/gorelease
           key: ${{ runner.os }}-gorelease
       - name: Install gorelease
-        run: test -e ~/go/bin/gorelease || go install golang.org/x/exp/cmd/gorelease@latest
+        run: test -e ~/go/bin/gorelease || go install golang.org/x/exp/cmd/gorelease@v0.0.0-20220602145555-4a0574d9293f
       - name: Install egrep
         run: which egrep || apt install egrep
       - name: Check API changes

--- a/.github/workflows/breaking.yml
+++ b/.github/workflows/breaking.yml
@@ -6,15 +6,10 @@ env:
   GO111MODULE: "on"
 jobs:
   gorelease:
-    strategy:
-      matrix:
-        go-version: [ 1.18.x ]
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
         uses: actions/setup-go@v2
-        with:
-          go-version: ${{ matrix.go-version }}
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Gorelease cache

--- a/.github/workflows/breaking.yml
+++ b/.github/workflows/breaking.yml
@@ -8,7 +8,7 @@ jobs:
   gorelease:
     strategy:
       matrix:
-        go-version: [ 1.17.x ]
+        go-version: [ 1.18.x ]
     runs-on: ubuntu-latest
     steps:
       - name: Install Go
@@ -24,7 +24,7 @@ jobs:
             ~/go/bin/gorelease
           key: ${{ runner.os }}-gorelease
       - name: Install gorelease
-        run: test -e ~/go/bin/gorelease || go install golang.org/x/exp/cmd/gorelease@v0.0.0-20220602145555-4a0574d9293f
+        run: test -e ~/go/bin/gorelease || go install golang.org/x/exp/cmd/gorelease@latest
       - name: Install egrep
         run: which egrep || apt install egrep
       - name: Check API changes


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

gorelease installed with go 1.17, but need go 1.18 for compile.

## What is the new behavior?

We not need special go version for the util, use latest.

