### PR TITLE
context cancel with reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Added context cancel with specific error
+
 ## v3.26.10
 * Fixed syntax mistake in `trace.TablePooStateChangeInfo` to `trace.TablePoolStateChangeInfo` 
 

--- a/internal/conn/grpc_client_stream.go
+++ b/internal/conn/grpc_client_stream.go
@@ -2,10 +2,13 @@ package conn
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb"
 	"google.golang.org/grpc"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xcontext"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/wrap"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
@@ -40,7 +43,7 @@ func (s *grpcClientStream) CloseSend() (err error) {
 
 func (s *grpcClientStream) SendMsg(m interface{}) (err error) {
 	cancel := createPinger(s.c)
-	defer cancel()
+	defer cancel(xerrors.WithStackTrace(errors.New("send msg finished")))
 
 	err = s.ClientStream.SendMsg(m)
 
@@ -61,7 +64,7 @@ func (s *grpcClientStream) SendMsg(m interface{}) (err error) {
 
 func (s *grpcClientStream) RecvMsg(m interface{}) (err error) {
 	cancel := createPinger(s.c)
-	defer cancel()
+	defer cancel(xerrors.WithStackTrace(errors.New("receive msg finished")))
 
 	defer func() {
 		onDone := s.recv(xerrors.HideEOF(err))
@@ -102,9 +105,9 @@ func (s *grpcClientStream) RecvMsg(m interface{}) (err error) {
 	return nil
 }
 
-func createPinger(c *conn) context.CancelFunc {
+func createPinger(c *conn) xcontext.CancelErrFunc {
 	c.touchLastUsage()
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := xcontext.WithErrCancel(context.Background())
 	go func() {
 		ticker := time.NewTicker(time.Second)
 		ctxDone := ctx.Done()

--- a/internal/xcontext/cancel_with_error.go
+++ b/internal/xcontext/cancel_with_error.go
@@ -3,14 +3,13 @@ package xcontext
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 	"time"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
 )
 
-var errCancelWithNilError = fmt.Errorf("nil error: %w", context.Canceled)
+var errCancelWithNilError = cancelError{err: errors.New("cancel context with nil error")}
 
 // CancelErrFunc use for cancel with wrap with specific error
 // if err == nil CancelErrFunc will panic for prevent

--- a/internal/xcontext/cancel_with_error.go
+++ b/internal/xcontext/cancel_with_error.go
@@ -1,0 +1,74 @@
+package xcontext
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
+)
+
+var errCancelWithNilError = fmt.Errorf("nil error: %w", context.Canceled)
+
+// CancelErrFunc use for cancel with wrap with specific error
+// if err == nil CancelErrFunc will panic for prevent
+// call cancel, then ctx.Err() == nil
+type CancelErrFunc func(err error)
+
+func WithErrCancel(ctx context.Context) (resCtx context.Context, cancel CancelErrFunc) {
+	res := &ctxError{}
+	res.ctx, res.ctxCancel = context.WithCancel(ctx)
+	return res, res.cancel
+}
+
+type ctxError struct {
+	ctx       context.Context
+	ctxCancel context.CancelFunc
+
+	m   sync.Mutex
+	err error
+}
+
+func (c *ctxError) Deadline() (deadline time.Time, ok bool) {
+	return c.ctx.Deadline()
+}
+
+func (c *ctxError) Done() <-chan struct{} {
+	return c.ctx.Done()
+}
+
+func (c *ctxError) Err() error {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	return c.errUnderLock()
+}
+
+func (c *ctxError) errUnderLock() error {
+	if c.err == nil {
+		c.err = c.ctx.Err()
+	}
+
+	return c.err
+
+}
+
+func (c *ctxError) Value(key interface{}) interface{} {
+	return c.ctx.Value(key)
+}
+
+func (c *ctxError) cancel(err error) {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	if err == nil {
+		err = xerrors.WithStackTrace(errCancelWithNilError)
+	}
+
+	if c.errUnderLock() == nil {
+		c.err = err
+	}
+
+	c.ctxCancel()
+}

--- a/internal/xcontext/cancel_with_error_test.go
+++ b/internal/xcontext/cancel_with_error_test.go
@@ -13,7 +13,7 @@ func TestCancelWithError(t *testing.T) {
 	t.Run("SimpleCancel", func(t *testing.T) {
 		ctx, cancel := WithErrCancel(context.Background())
 		cancel(testError)
-		require.Equal(t, testError, ctx.Err())
+		require.ErrorIs(t, ctx.Err(), testError)
 	})
 
 	t.Run("CancelBeforeParent", func(t *testing.T) {
@@ -23,7 +23,8 @@ func TestCancelWithError(t *testing.T) {
 		cancel(testError)
 		parentCancel()
 
-		require.Equal(t, testError, ctx.Err())
+		require.ErrorIs(t, ctx.Err(), testError)
+		require.ErrorIs(t, ctx.Err(), context.Canceled)
 	})
 
 	t.Run("CancelAfterParent", func(t *testing.T) {
@@ -36,4 +37,10 @@ func TestCancelWithError(t *testing.T) {
 		require.Equal(t, context.Canceled, ctx.Err())
 	})
 
+	t.Run("CancelWithNil", func(t *testing.T) {
+		ctx, cancel := WithErrCancel(context.Background())
+		cancel(nil)
+		require.ErrorIs(t, ctx.Err(), errCancelWithNilError)
+		require.ErrorIs(t, ctx.Err(), context.Canceled)
+	})
 }

--- a/internal/xcontext/cancel_with_error_test.go
+++ b/internal/xcontext/cancel_with_error_test.go
@@ -1,0 +1,39 @@
+package xcontext
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCancelWithError(t *testing.T) {
+	testError := errors.New("test error")
+	t.Run("SimpleCancel", func(t *testing.T) {
+		ctx, cancel := WithErrCancel(context.Background())
+		cancel(testError)
+		require.Equal(t, testError, ctx.Err())
+	})
+
+	t.Run("CancelBeforeParent", func(t *testing.T) {
+		parent, parentCancel := context.WithCancel(context.Background())
+		ctx, cancel := WithErrCancel(parent)
+
+		cancel(testError)
+		parentCancel()
+
+		require.Equal(t, testError, ctx.Err())
+	})
+
+	t.Run("CancelAfterParent", func(t *testing.T) {
+		parent, parentCancel := context.WithCancel(context.Background())
+		ctx, cancel := WithErrCancel(parent)
+
+		parentCancel()
+		cancel(testError)
+
+		require.Equal(t, context.Canceled, ctx.Err())
+	})
+
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Context always cancel with context.Canceled error and not show source/reason of cancelation.

## What is the new behavior?

Add xcontext.WithErrCancel function - for cancel context with reason.
