### PR TITLE
allow parallel read and commit with topic api reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Allow read and commit messages in parallel
+
 ## v3.31.0
 * Extended the ydb.Connection interface with experimental db.Topic() client (control plane and reader API)
 * Removed `ydb.RegisterParser()` function (was needed for `database/sql` driver outside `ydb-go-sdk` repository, necessity of `ydb.RegisterParser()` disappeared with implementation `database/sql` driver in same repository)

--- a/topic/topicreader/errors.go
+++ b/topic/topicreader/errors.go
@@ -20,4 +20,4 @@ var ErrUnexpectedCodec = topicreaderinternal.PublicErrUnexpectedCodec
 // Experimental
 //
 // Notice: This API is EXPERIMENTAL and may be changed or removed in a later release.
-var ErrConcurrencyCall = xerrors.Wrap(errors.New("concurrency call"))
+var ErrConcurrencyCall = xerrors.Wrap(errors.New("ydb: concurrency call denied"))


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Read and commit must be serialized on client side

## What is the new behavior?
Read and commit cal call in parallel
