### PR TITLE
Implement send stop partition message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-* Fix deadlock in topicreader batcher, while add and read raw server messages
+* Fixed deadlock in topicreader batcher, while add and read raw server messages
 * Fixed bug in `db.Topic()` with send response to stop partition message
 
 ## v3.32.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Fix deadlock in topicreader batcher, while add and read raw server messages
 * Fixed bug in `db.Topic()` with send response to stop partition message
 
 ## v3.32.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed bug in `db.Topic()` with send response to stop partition message
+
 ## v3.32.1
 * Fixed flaky TestTable
 * Renamed topic events in `trace.Details` enum

--- a/internal/grpcwrapper/rawtopic/rawtopicreader/messages.go
+++ b/internal/grpcwrapper/rawtopic/rawtopicreader/messages.go
@@ -490,3 +490,9 @@ type StopPartitionSessionResponse struct {
 
 	PartitionSessionID PartitionSessionID
 }
+
+func (r *StopPartitionSessionResponse) toProto() *Ydb_Topic.StreamReadMessage_StopPartitionSessionResponse {
+	return &Ydb_Topic.StreamReadMessage_StopPartitionSessionResponse{
+		PartitionSessionId: r.PartitionSessionID.ToInt64(),
+	}
+}

--- a/internal/grpcwrapper/rawtopic/rawtopicreader/messages.go
+++ b/internal/grpcwrapper/rawtopic/rawtopicreader/messages.go
@@ -485,7 +485,6 @@ func (r *StopPartitionSessionRequest) fromProto(proto *Ydb_Topic.StreamReadMessa
 }
 
 type StopPartitionSessionResponse struct {
-	//nolint:unused
 	clientMessageImpl
 
 	PartitionSessionID PartitionSessionID

--- a/internal/grpcwrapper/rawtopic/rawtopicreader/rawtopicreader.go
+++ b/internal/grpcwrapper/rawtopic/rawtopicreader/rawtopicreader.go
@@ -115,6 +115,13 @@ func (s StreamReader) Send(msg ClientMessage) error {
 			},
 		}
 		return s.Stream.Send(grpcMess)
+	case *StopPartitionSessionResponse:
+		grpcMess := &Ydb_Topic.StreamReadMessage_FromClient{
+			ClientMessage: &Ydb_Topic.StreamReadMessage_FromClient_StopPartitionSessionResponse{
+				StopPartitionSessionResponse: m.toProto(),
+			},
+		}
+		return s.Stream.Send(grpcMess)
 	case *CommitOffsetRequest:
 		grpcMess := &Ydb_Topic.StreamReadMessage_FromClient{
 			ClientMessage: &Ydb_Topic.StreamReadMessage_FromClient_CommitOffsetRequest{

--- a/internal/topic/topicreaderinternal/batcher.go
+++ b/internal/topic/topicreaderinternal/batcher.go
@@ -191,7 +191,12 @@ func (b *batcher) Pop(ctx context.Context, opts batcherGetOptions) (_ batcherMes
 			// new iteration
 		case <-b.closeChan:
 			return batcherMessageOrderItem{},
-				xerrors.WithStackTrace(fmt.Errorf("ydb: batcher close while pop wait new messages: %w", b.closeErr))
+				xerrors.WithStackTrace(
+					fmt.Errorf(
+						"ydb: batcher close while pop wait new messages: %w",
+						b.closeErr,
+					),
+				)
 		case <-ctx.Done():
 			return batcherMessageOrderItem{}, ctx.Err()
 		}

--- a/internal/topic/topicreaderinternal/batcher.go
+++ b/internal/topic/topicreaderinternal/batcher.go
@@ -12,11 +12,16 @@ import (
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xsync"
 )
 
-var errRemoveUnexpectedWaiter = xerrors.Wrap(errors.New("ydb: remove unexpected waiter"))
+var (
+	errRemoveUnexpectedWaiter = xerrors.Wrap(errors.New("ydb: remove unexpected waiter"))
+	errBatcherPopConcurency   = xerrors.Wrap(errors.New("ydb: batch pop concurency, internal state error"))
+)
 
 type batcher struct {
-	waiterID uint64
-	closeErr error
+	popInFlight    int64
+	waiterID       uint64
+	closeErr       error
+	hasNewMessages empty.Chan
 
 	m xsync.Mutex
 
@@ -24,13 +29,13 @@ type batcher struct {
 	closed                                        bool
 	closeChan                                     empty.Chan
 	messages                                      batcherMessagesMap
-	waiters                                       []batcherWaiter
 }
 
 func newBatcher() *batcher {
 	return &batcher{
-		messages:  make(batcherMessagesMap),
-		closeChan: make(empty.Chan),
+		messages:       make(batcherMessagesMap),
+		closeChan:      make(empty.Chan),
+		hasNewMessages: make(empty.Chan, 1),
 	}
 }
 
@@ -48,14 +53,20 @@ func (b *batcher) Close(err error) error {
 	return nil
 }
 
-func (b *batcher) PushBatch(batch *PublicBatch) error {
+func (b *batcher) PushBatches(batches ...*PublicBatch) error {
 	b.m.Lock()
 	defer b.m.Unlock()
 	if b.closed {
 		return xerrors.WithStackTrace(fmt.Errorf("ydb: push batch to closed batcher :%w", b.closeErr))
 	}
 
-	return b.addNeedLock(batch.commitRange.partitionSession, newBatcherItemBatch(batch))
+	for _, batch := range batches {
+		if err := b.addNeedLock(batch.commitRange.partitionSession, newBatcherItemBatch(batch)); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (b *batcher) PushRawMessage(session *partitionSession, m rawtopicreader.ServerMessage) error {
@@ -83,7 +94,7 @@ func (b *batcher) addNeedLock(session *partitionSession, item batcherMessageOrde
 
 	b.messages[session] = currentItems
 
-	b.fireWaitersNeedLock()
+	b.notifyAboutNewMessages()
 
 	return nil
 }
@@ -143,117 +154,61 @@ func (o batcherGetOptions) splitBatch(batch *PublicBatch) (head, rest *PublicBat
 }
 
 func (b *batcher) Pop(ctx context.Context, opts batcherGetOptions) (_ batcherMessageOrderItem, err error) {
+	counter := atomic.AddInt64(&b.popInFlight, 1)
+	defer atomic.AddInt64(&b.popInFlight, -1)
+
+	if counter != 1 {
+		return batcherMessageOrderItem{}, xerrors.WithStackTrace(errBatcherPopConcurency)
+	}
+
 	if err = ctx.Err(); err != nil {
 		return batcherMessageOrderItem{}, err
 	}
-	var findRes batcherResultCandidate
-	var closed bool
 
-	var waiter batcherWaiter
-	defer func() {
-		removeWaiterErr := b.RemoveWaiter(waiter)
-		if err == nil {
-			err = removeWaiterErr
-		}
-	}()
-
-	b.m.WithLock(func() {
-		closed = b.closed
-		if closed {
-			return
-		}
-
-		findRes = b.findNeedLock(0, []batcherWaiter{{Options: opts}})
-		if findRes.Ok {
-			b.applyNeedLock(findRes)
-			return
-		}
-
-		waiter = b.createWaiterNeedLock(opts)
-	})
-	if closed {
-		return batcherMessageOrderItem{},
-			xerrors.WithStackTrace(fmt.Errorf("ydb: try pop messages from closed batcher: %w", b.closeErr))
-	}
-	if findRes.Ok {
-		return findRes.Result, nil
-	}
-
-	select {
-	case batch := <-waiter.Result:
-		return batch, nil
-	case <-b.closeChan:
-		return batcherMessageOrderItem{}, xerrors.WithStackTrace(fmt.Errorf("ydb: batcher closed: %w", b.closeErr))
-	case <-ctx.Done():
-		return batcherMessageOrderItem{}, ctx.Err()
-	}
-}
-
-func (b *batcher) createWaiterNeedLock(opts batcherGetOptions) batcherWaiter {
-	waiter := batcherWaiter{
-		Options:          opts,
-		Result:           make(chan batcherMessageOrderItem),
-		finishWaitSignal: make(empty.Chan),
-	}
-
-	// defend from overflow
-	for waiter.ID == 0 {
-		waiter.ID = atomic.AddUint64(&b.waiterID, 1)
-	}
-
-	b.waiters = append(b.waiters, waiter)
-
-	return waiter
-}
-
-func (b *batcher) RemoveWaiter(waiter batcherWaiter) error {
-	if waiter.ID == 0 {
-		return nil
-	}
-
-	close(waiter.finishWaitSignal)
-
-	return b.removeWaiterByID(waiter.ID)
-}
-
-func (b *batcher) removeWaiterByID(waiterID uint64) error {
-	b.m.Lock()
-	defer b.m.Unlock()
-
-	for i := 0; i < len(b.waiters); i++ {
-		if b.waiters[i].ID == waiterID {
-			b.removeWaiterByIndexNeedLock(i)
-			return nil
-		}
-	}
-
-	return xerrors.WithStackTrace(errRemoveUnexpectedWaiter)
-}
-
-func (b *batcher) fireWaitersNeedLock() {
-	startIndex := 0
 	for {
-		resCandidate := b.findNeedLock(startIndex, b.waiters)
-		if !resCandidate.Ok {
-			return
+		var findRes batcherResultCandidate
+		var closed bool
+
+		b.m.WithLock(func() {
+			closed = b.closed
+			if closed {
+				return
+			}
+
+			findRes = b.findNeedLock(0, []batcherWaiter{{Options: opts}})
+			if findRes.Ok {
+				b.applyNeedLock(findRes)
+				return
+			}
+		})
+		if closed {
+			return batcherMessageOrderItem{},
+				xerrors.WithStackTrace(fmt.Errorf("ydb: try pop messages from closed batcher: %w", b.closeErr))
+		}
+		if findRes.Ok {
+			return findRes.Result, nil
 		}
 
-		waiter := b.waiters[resCandidate.WaiterIndex]
-
+		// wait new messages for next iteration
 		select {
-		case waiter.Result <- resCandidate.Result:
-			// waiter receive the result, commit it
-			b.applyNeedLock(resCandidate)
-			return
-		case <-waiter.finishWaitSignal:
-			startIndex = resCandidate.WaiterIndex + 1
+		case <-b.hasNewMessages:
+			// new iteration
+		case <-b.closeChan:
+			return batcherMessageOrderItem{},
+				xerrors.WithStackTrace(fmt.Errorf("ydb: batcher close while pop wait new messages: %w", b.closeErr))
+		case <-ctx.Done():
+			return batcherMessageOrderItem{}, ctx.Err()
 		}
 	}
 }
 
-func (b *batcher) removeWaiterByIndexNeedLock(index int) {
-	copy(b.waiters[index:], b.waiters[index+1:])
-	b.waiters = b.waiters[:len(b.waiters)-1]
+func (b *batcher) notifyAboutNewMessages() {
+	select {
+	case b.hasNewMessages <- empty.Struct{}:
+		// sent signal
+	default:
+		// signal already in progress
+	}
 }
 
 type batcherResultCandidate struct {
@@ -339,7 +294,7 @@ func (b *batcher) IgnoreMinRestrictionsOnNextPop() {
 	defer b.m.Unlock()
 
 	b.forceIgnoreMinRestrictionsOnNextMessagesBatch = true
-	b.fireWaitersNeedLock()
+	b.notifyAboutNewMessages()
 }
 
 type batcherMessagesMap map[*partitionSession]batcherMessageOrderItems

--- a/internal/topic/topicreaderinternal/batcher_test.go
+++ b/internal/topic/topicreaderinternal/batcher_test.go
@@ -333,7 +333,11 @@ func TestBatcherConcurency(t *testing.T) {
 		for i := 0; i < count; i++ {
 			res, err := b.Pop(ctx, batcherGetOptions{MinCount: 1})
 			require.NoError(tb, err)
-			require.Equal(tb, rawtopicreader.NewOffset(int64(i)), res.RawMessage.(*rawtopicreader.StartPartitionSessionRequest).CommittedOffset)
+			require.Equal(
+				tb,
+				rawtopicreader.NewOffset(int64(i)),
+				res.RawMessage.(*rawtopicreader.StartPartitionSessionRequest).CommittedOffset,
+			)
 		}
 	})
 }

--- a/internal/topic/topicreaderinternal/batcher_test.go
+++ b/internal/topic/topicreaderinternal/batcher_test.go
@@ -40,9 +40,9 @@ func TestBatcher_PushBatch(t *testing.T) {
 	batch3 := mustNewBatch(session2, []*PublicMessage{m22})
 
 	b := newBatcher()
-	require.NoError(t, b.PushBatch(batch1))
-	require.NoError(t, b.PushBatch(batch2))
-	require.NoError(t, b.PushBatch(batch3))
+	require.NoError(t, b.PushBatches(batch1))
+	require.NoError(t, b.PushBatches(batch2))
+	require.NoError(t, b.PushBatches(batch3))
 
 	expectedSession1 := newBatcherItemBatch(mustNewBatch(session1, []*PublicMessage{m11, m12}))
 	expectedSession2 := newBatcherItemBatch(mustNewBatch(session2, []*PublicMessage{m21, m22}))
@@ -74,7 +74,7 @@ func TestBatcher_PushRawMessage(t *testing.T) {
 			PartitionSessionID: 1,
 		}
 
-		require.NoError(t, b.PushBatch(batch))
+		require.NoError(t, b.PushBatches(batch))
 		require.NoError(t, b.PushRawMessage(session, m))
 
 		expectedMap := batcherMessagesMap{session: batcherMessageOrderItems{
@@ -94,10 +94,10 @@ func TestBatcher_PushRawMessage(t *testing.T) {
 			PartitionSessionID: 1,
 		}
 
-		require.NoError(t, b.PushBatch(batch1))
+		require.NoError(t, b.PushBatches(batch1))
 		require.NoError(t, b.PushRawMessage(session, m))
-		require.NoError(t, b.PushBatch(batch2))
-		require.NoError(t, b.PushBatch(batch3))
+		require.NoError(t, b.PushBatches(batch2))
+		require.NoError(t, b.PushBatches(batch3))
 
 		expectedMap := batcherMessagesMap{session: batcherMessageOrderItems{
 			newBatcherItemBatch(batch1),
@@ -114,7 +114,7 @@ func TestBatcher_Pop(t *testing.T) {
 		batch := mustNewBatch(nil, []*PublicMessage{{WrittenAt: testTime(1)}})
 
 		b := newBatcher()
-		require.NoError(t, b.PushBatch(batch))
+		require.NoError(t, b.PushBatches(batch))
 
 		res, err := b.Pop(ctx, batcherGetOptions{})
 		require.NoError(t, err)
@@ -135,8 +135,8 @@ func TestBatcher_Pop(t *testing.T) {
 		)
 
 		b := newBatcher()
-		require.NoError(t, b.PushBatch(batch))
-		require.NoError(t, b.PushBatch(batch2))
+		require.NoError(t, b.PushBatches(batch))
+		require.NoError(t, b.PushBatches(batch2))
 
 		possibleResults := []batcherMessageOrderItem{newBatcherItemBatch(batch), newBatcherItemBatch(batch2)}
 
@@ -157,12 +157,13 @@ func TestBatcher_Pop(t *testing.T) {
 		batch := mustNewBatch(nil, []*PublicMessage{{WrittenAt: testTime(1)}})
 
 		b := newBatcher()
+		b.notifyAboutNewMessages()
 
 		go func() {
 			xtest.SpinWaitCondition(t, &b.m, func() bool {
-				return len(b.waiters) > 0
+				return len(b.hasNewMessages) == 0
 			})
-			_ = b.PushBatch(batch)
+			_ = b.PushBatches(batch)
 		}()
 
 		res, err := b.Pop(ctx, batcherGetOptions{})
@@ -179,7 +180,7 @@ func TestBatcher_Pop(t *testing.T) {
 		batch := mustNewBatch(nil, []*PublicMessage{m1, m2})
 
 		b := newBatcher()
-		require.NoError(t, b.PushBatch(batch))
+		require.NoError(t, b.PushBatches(batch))
 
 		res, err := b.Pop(ctx, batcherGetOptions{MaxCount: 1})
 		require.NoError(t, err)
@@ -196,7 +197,7 @@ func TestBatcher_Pop(t *testing.T) {
 	t.Run("GetFirstMessageFromSameSession", func(t *testing.T) {
 		b := newBatcher()
 		batch := mustNewBatch(nil, []*PublicMessage{{WrittenAt: testTime(1)}})
-		require.NoError(t, b.PushBatch(batch))
+		require.NoError(t, b.PushBatches(batch))
 		require.NoError(t, b.PushRawMessage(nil, &rawtopicreader.StopPartitionSessionRequest{PartitionSessionID: 1}))
 
 		res, err := b.Pop(context.Background(), batcherGetOptions{})
@@ -211,7 +212,7 @@ func TestBatcher_Pop(t *testing.T) {
 		b := newBatcher()
 		m := &rawtopicreader.StopPartitionSessionRequest{PartitionSessionID: 1}
 
-		require.NoError(t, b.PushBatch(mustNewBatch(session1, []*PublicMessage{{WrittenAt: testTime(1)}})))
+		require.NoError(t, b.PushBatches(mustNewBatch(session1, []*PublicMessage{{WrittenAt: testTime(1)}})))
 		require.NoError(t, b.PushRawMessage(session2, m))
 
 		res, err := b.Pop(context.Background(), batcherGetOptions{})
@@ -224,6 +225,8 @@ func TestBatcher_Pop(t *testing.T) {
 		testErr := errors.New("test")
 
 		b := newBatcher()
+		b.notifyAboutNewMessages()
+
 		var err error
 
 		popFinished := make(empty.Chan)
@@ -234,7 +237,7 @@ func TestBatcher_Pop(t *testing.T) {
 
 		// loop for wait Pop start wait message
 		xtest.SpinWaitCondition(t, &b.m, func() bool {
-			return len(b.waiters) > 0
+			return len(b.hasNewMessages) == 0
 		})
 
 		require.NoError(t, b.Close(testErr))
@@ -248,7 +251,7 @@ func TestBatcher_Pop(t *testing.T) {
 func TestBatcher_PopMinIgnored(t *testing.T) {
 	t.Run("PopAfterForce", func(t *testing.T) {
 		b := newBatcher()
-		require.NoError(t, b.PushBatch(&PublicBatch{Messages: []*PublicMessage{
+		require.NoError(t, b.PushBatches(&PublicBatch{Messages: []*PublicMessage{
 			{
 				SeqNo: 1,
 			},
@@ -267,7 +270,7 @@ func TestBatcher_PopMinIgnored(t *testing.T) {
 
 	xtest.TestManyTimesWithName(t, "ForceAfterPop", func(t testing.TB) {
 		b := newBatcher()
-		require.NoError(t, b.PushBatch(&PublicBatch{Messages: []*PublicMessage{
+		require.NoError(t, b.PushBatches(&PublicBatch{Messages: []*PublicMessage{
 			{
 				SeqNo: 1,
 			},
@@ -278,7 +281,7 @@ func TestBatcher_PopMinIgnored(t *testing.T) {
 			defer atomic.AddInt64(&IgnoreMinRestrictionsOnNextPopDone, 1)
 
 			xtest.SpinWaitCondition(t, &b.m, func() bool {
-				return len(b.waiters) > 0
+				return len(b.hasNewMessages) == 0
 			})
 			b.IgnoreMinRestrictionsOnNextPop()
 		}()
@@ -295,19 +298,43 @@ func TestBatcher_PopMinIgnored(t *testing.T) {
 }
 
 func TestBatcherConcurency(t *testing.T) {
-	xtest.TestManyTimes(t, func(t testing.TB) {
+	xtest.TestManyTimesWithName(t, "OneBatch", func(tb testing.TB) {
 		b := newBatcher()
 
 		go func() {
-			_ = b.PushBatch(&PublicBatch{Messages: []*PublicMessage{{SeqNo: 1}}})
+			_ = b.PushBatches(&PublicBatch{Messages: []*PublicMessage{{SeqNo: 1}}})
 		}()
 
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
 
 		batch, err := b.Pop(ctx, batcherGetOptions{MinCount: 1})
-		require.NoError(t, err)
-		require.Equal(t, int64(1), batch.Batch.Messages[0].SeqNo)
+		require.NoError(tb, err)
+		require.Equal(tb, int64(1), batch.Batch.Messages[0].SeqNo)
+	})
+
+	xtest.TestManyTimesWithName(t, "ManyRawMessages", func(tb testing.TB) {
+		const count = 10
+		b := newBatcher()
+		session := &partitionSession{}
+
+		go func() {
+			for i := 0; i < count; i++ {
+				_ = b.PushRawMessage(session, &rawtopicreader.StartPartitionSessionRequest{
+					CommittedOffset:  rawtopicreader.NewOffset(int64(i)),
+					PartitionOffsets: rawtopicreader.OffsetRange{},
+				})
+			}
+		}()
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		for i := 0; i < count; i++ {
+			res, err := b.Pop(ctx, batcherGetOptions{MinCount: 1})
+			require.NoError(tb, err)
+			require.Equal(tb, rawtopicreader.NewOffset(int64(i)), res.RawMessage.(*rawtopicreader.StartPartitionSessionRequest).CommittedOffset)
+		}
 	})
 }
 
@@ -323,7 +350,7 @@ func TestBatcher_Find(t *testing.T) {
 
 		b := newBatcher()
 
-		require.NoError(t, b.PushBatch(batch))
+		require.NoError(t, b.PushBatches(batch))
 
 		findRes := b.findNeedLock(0, []batcherWaiter{{}})
 		expectedResult := batcherResultCandidate{
@@ -342,7 +369,7 @@ func TestBatcher_Find(t *testing.T) {
 
 		b := newBatcher()
 
-		require.NoError(t, b.PushBatch(batch))
+		require.NoError(t, b.PushBatches(batch))
 
 		findRes := b.findNeedLock(0, []batcherWaiter{{Options: batcherGetOptions{MaxCount: 1}}})
 
@@ -456,7 +483,7 @@ func TestBatcherGetOptions_Split(t *testing.T) {
 func TestBatcher_Fire(t *testing.T) {
 	t.Run("Empty", func(t *testing.T) {
 		b := newBatcher()
-		b.fireWaitersNeedLock()
+		b.notifyAboutNewMessages()
 	})
 }
 

--- a/internal/topic/topicreaderinternal/batcher_test.go
+++ b/internal/topic/topicreaderinternal/batcher_test.go
@@ -341,7 +341,7 @@ func TestBatcherConcurency(t *testing.T) {
 func TestBatcher_Find(t *testing.T) {
 	t.Run("Empty", func(t *testing.T) {
 		b := newBatcher()
-		findRes := b.findNeedLock(0, nil)
+		findRes := b.findNeedLock(batcherGetOptions{})
 		require.False(t, findRes.Ok)
 	})
 	t.Run("FoundEmptyFilter", func(t *testing.T) {
@@ -352,7 +352,7 @@ func TestBatcher_Find(t *testing.T) {
 
 		require.NoError(t, b.PushBatches(batch))
 
-		findRes := b.findNeedLock(0, []batcherWaiter{{}})
+		findRes := b.findNeedLock(batcherGetOptions{})
 		expectedResult := batcherResultCandidate{
 			Key:         session,
 			Result:      newBatcherItemBatch(batch),
@@ -371,7 +371,7 @@ func TestBatcher_Find(t *testing.T) {
 
 		require.NoError(t, b.PushBatches(batch))
 
-		findRes := b.findNeedLock(0, []batcherWaiter{{Options: batcherGetOptions{MaxCount: 1}}})
+		findRes := b.findNeedLock(batcherGetOptions{MaxCount: 1})
 
 		expectedResult := newBatcherItemBatch(mustNewBatch(session, []*PublicMessage{{WrittenAt: testTime(1)}}))
 		expectedRestBatch := newBatcherItemBatch(mustNewBatch(session, []*PublicMessage{{WrittenAt: testTime(2)}}))

--- a/internal/topic/topicreaderinternal/stream_reader_impl.go
+++ b/internal/topic/topicreaderinternal/stream_reader_impl.go
@@ -615,7 +615,7 @@ func (r *topicStreamReaderImpl) onReadResponse(msg *rawtopicreader.ReadResponse)
 	}
 
 	for i := range batches {
-		if err := r.batcher.PushBatch(batches[i]); err != nil {
+		if err := r.batcher.PushBatches(batches[i]); err != nil {
 			return err
 		}
 	}

--- a/internal/topic/topicreaderinternal/stream_reader_impl_test.go
+++ b/internal/topic/topicreaderinternal/stream_reader_impl_test.go
@@ -577,9 +577,10 @@ func TestTopicStreamReadImpl_BatchReaderWantMoreMessagesThenBufferCanHold(t *tes
 			batch, readErr = e.reader.ReadMessageBatch(readCtx, opts)
 		}()
 
-		// wait to add read to waiters
+		// wait to start pop
+		e.reader.batcher.notifyAboutNewMessages()
 		xtest.SpinWaitCondition(t, &e.reader.batcher.m, func() bool {
-			return len(e.reader.batcher.waiters) > 0
+			return len(e.reader.batcher.hasNewMessages) == 0
 		})
 
 		nextDataRequested := sendMessageWithFullBuffer(&e)

--- a/internal/xtest/manytimes.go
+++ b/internal/xtest/manytimes.go
@@ -30,11 +30,14 @@ func TestManyTimes(t testing.TB, test TestFunc, opts ...TestManyTimesOption) {
 	}
 
 	start := time.Now()
+	testCounter := 0
 	for {
+		testCounter++
 		// run test, then check timeout for guarantee run test least once
 		runTest(t, test)
 
 		if time.Since(start) > options.timeout {
+			t.Log("test run counter:", testCounter)
 			return
 		}
 	}

--- a/internal/xtest/waiters.go
+++ b/internal/xtest/waiters.go
@@ -26,7 +26,13 @@ func WaitChannelClosed(t testing.TB, ch empty.Chan) {
 // l can be nil - then locker use for check conditions
 func SpinWaitCondition(t testing.TB, l sync.Locker, cond func() bool) {
 	t.Helper()
-	const condWaitTimeout = time.Second
+	SpinWaitConditionWithTimeout(t, l, time.Second, cond)
+}
+
+// SpinWaitConditionWithTimeout wait while cond return true with check it in loop
+// l can be nil - then locker use for check conditions
+func SpinWaitConditionWithTimeout(t testing.TB, l sync.Locker, condWaitTimeout time.Duration, cond func() bool) {
+	t.Helper()
 
 	checkConditin := func() bool {
 		if l != nil {

--- a/internal/xtest/waiters.go
+++ b/internal/xtest/waiters.go
@@ -24,15 +24,15 @@ func WaitChannelClosed(t testing.TB, ch empty.Chan) {
 
 // SpinWaitCondition wait while cond return true with check it in loop
 // l can be nil - then locker use for check conditions
-func SpinWaitCondition(t testing.TB, l sync.Locker, cond func() bool) {
-	t.Helper()
-	SpinWaitConditionWithTimeout(t, l, time.Second, cond)
+func SpinWaitCondition(tb testing.TB, l sync.Locker, cond func() bool) {
+	tb.Helper()
+	SpinWaitConditionWithTimeout(tb, l, time.Second, cond)
 }
 
 // SpinWaitConditionWithTimeout wait while cond return true with check it in loop
 // l can be nil - then locker use for check conditions
-func SpinWaitConditionWithTimeout(t testing.TB, l sync.Locker, condWaitTimeout time.Duration, cond func() bool) {
-	t.Helper()
+func SpinWaitConditionWithTimeout(tb testing.TB, l sync.Locker, condWaitTimeout time.Duration, cond func() bool) {
+	tb.Helper()
 
 	checkConditin := func() bool {
 		if l != nil {
@@ -49,7 +49,7 @@ func SpinWaitConditionWithTimeout(t testing.TB, l sync.Locker, condWaitTimeout t
 		}
 
 		if time.Since(start) > condWaitTimeout {
-			t.Fatal()
+			tb.Fatal()
 		}
 
 		runtime.Gosched()

--- a/internal/xtest/waiters.go
+++ b/internal/xtest/waiters.go
@@ -10,6 +10,8 @@ import (
 )
 
 func WaitChannelClosed(t testing.TB, ch empty.Chan) {
+	t.Helper()
+
 	const condWaitTimeout = time.Second
 
 	select {
@@ -23,6 +25,7 @@ func WaitChannelClosed(t testing.TB, ch empty.Chan) {
 // SpinWaitCondition wait while cond return true with check it in loop
 // l can be nil - then locker use for check conditions
 func SpinWaitCondition(t testing.TB, l sync.Locker, cond func() bool) {
+	t.Helper()
 	const condWaitTimeout = time.Second
 
 	checkConditin := func() bool {

--- a/topic/client_e2e_test.go
+++ b/topic/client_e2e_test.go
@@ -39,7 +39,7 @@ func TestClient_CreateDropTopic(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func connect(t *testing.T) ydb.Connection {
+func connect(t testing.TB) ydb.Connection {
 	connectionString := "grpc://localhost:2136/local"
 	if cs := os.Getenv("YDB_CONNECTION_STRING"); cs != "" {
 		connectionString = cs

--- a/topic/reader_e2e_test.go
+++ b/topic/reader_e2e_test.go
@@ -119,9 +119,6 @@ func TestCDCFeedSendTopicPathSameAsSubscribed(t *testing.T) {
 }
 
 func TestTopicPath(t *testing.T) {
-	t.Skip("LOGBROKER-7625")
-	t.Skip("KIKIMR-14966")
-
 	ctx := testCtx(t)
 	db := connect(t)
 

--- a/topic/reader_e2e_test.go
+++ b/topic/reader_e2e_test.go
@@ -151,11 +151,11 @@ func TestPartitionsBalanced(t *testing.T) {
 
 	connectedPartitions := int32(0)
 	tracer := trace.Topic{
-		OnReaderPartitionReadStartResponse: func(startInfo trace.TopicReaderPartitionReadStartResponseStartInfo) func(doneInfo trace.TopicReaderPartitionReadStartResponseDoneInfo) {
+		OnReaderPartitionReadStartResponse: func(startInfo trace.TopicReaderPartitionReadStartResponseStartInfo) func(doneInfo trace.TopicReaderPartitionReadStartResponseDoneInfo) { //nolint:lll
 			atomic.AddInt32(&connectedPartitions, 1)
 			return nil
 		},
-		OnReaderPartitionReadStopResponse: func(startInfo trace.TopicReaderPartitionReadStopResponseStartInfo) func(doneInfo trace.TopicReaderPartitionReadStopResponseDoneInfo) {
+		OnReaderPartitionReadStopResponse: func(startInfo trace.TopicReaderPartitionReadStopResponseStartInfo) func(doneInfo trace.TopicReaderPartitionReadStopResponseDoneInfo) { //nolint:lll
 			atomic.AddInt32(&connectedPartitions, -1)
 			return nil
 		},

--- a/topic/reader_e2e_test.go
+++ b/topic/reader_e2e_test.go
@@ -181,20 +181,20 @@ func TestPartitionsBalanced(t *testing.T) {
 		}
 	}()
 
-	xtest.SpinWaitCondition(t, nil, func() bool {
+	xtest.SpinWaitConditionWithTimeout(t, nil, time.Minute, func() bool {
 		return atomic.LoadInt32(&connectedPartitions) == 2
 	})
 
 	readerSecond, err := db.Topic().StartReader(consumer, topicoptions.ReadTopic(topicPath))
 	require.NoError(t, err)
 
-	xtest.SpinWaitCondition(t, nil, func() bool {
+	xtest.SpinWaitConditionWithTimeout(t, nil, time.Minute, func() bool {
 		return atomic.LoadInt32(&connectedPartitions) == 1
 	})
 
 	require.NoError(t, readerSecond.Close(ctx))
 
-	xtest.SpinWaitCondition(t, nil, func() bool {
+	xtest.SpinWaitConditionWithTimeout(t, nil, time.Minute, func() bool {
 		return atomic.LoadInt32(&connectedPartitions) == 2
 	})
 

--- a/topic/reader_e2e_test.go
+++ b/topic/reader_e2e_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"runtime/pprof"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -132,75 +133,96 @@ func TestTopicPath(t *testing.T) {
 }
 
 func TestPartitionsBalanced(t *testing.T) {
-	ctx := testCtx(t)
-	db := connect(t)
-	topicPath := db.Name() + "/topic-" + t.Name()
+	xtest.TestManyTimes(t, func(t testing.TB) {
+		ctx := testCtx(t)
+		db := connect(t)
+		defer func() {
+			_ = db.Close(context.Background())
+		}()
+		topicPath := db.Name() + "/topic-" + t.Name()
 
-	err := db.Topic().Drop(ctx, topicPath)
-	if err != nil {
-		require.True(t, ydb.IsOperationErrorSchemeError(err))
-	}
-
-	consumer := "test"
-	err = db.Topic().Create(ctx, topicPath, []topictypes.Codec{topictypes.CodecRaw},
-		topicoptions.CreateWithMinActivePartitions(2),
-		topicoptions.CreateWithPartitionCountLimit(2),
-		topicoptions.CreateWithConsumer(topictypes.Consumer{Name: consumer}),
-	)
-	require.NoError(t, err)
-
-	connectedPartitions := int32(0)
-	tracer := trace.Topic{
-		OnReaderPartitionReadStartResponse: func(startInfo trace.TopicReaderPartitionReadStartResponseStartInfo) func(doneInfo trace.TopicReaderPartitionReadStartResponseDoneInfo) { //nolint:lll
-			atomic.AddInt32(&connectedPartitions, 1)
-			return nil
-		},
-		OnReaderPartitionReadStopResponse: func(startInfo trace.TopicReaderPartitionReadStopResponseStartInfo) func(doneInfo trace.TopicReaderPartitionReadStopResponseDoneInfo) { //nolint:lll
-			atomic.AddInt32(&connectedPartitions, -1)
-			return nil
-		},
-	}
-	firstReader, err := db.Topic().StartReader(consumer, topicoptions.ReadTopic(topicPath),
-		topicoptions.WithReaderTrace(tracer),
-	)
-	require.NoError(t, err)
-
-	readCtx, firstReaderStopRead := context.WithCancel(ctx)
-	firstReaderReadStopped := make(empty.Chan)
-	go func() {
-		defer close(firstReaderReadStopped)
-
-		for {
-			if readCtx.Err() != nil {
-				return
-			}
-			_, err = firstReader.ReadMessage(readCtx)
-			if readCtx.Err() == nil {
-				require.NoError(t, err)
-			}
+		err := db.Topic().Drop(ctx, topicPath)
+		if err != nil {
+			require.True(t, ydb.IsOperationErrorSchemeError(err))
 		}
-	}()
 
-	xtest.SpinWaitConditionWithTimeout(t, nil, time.Minute, func() bool {
-		return atomic.LoadInt32(&connectedPartitions) == 2
+		consumer := "test"
+		err = db.Topic().Create(ctx, topicPath, []topictypes.Codec{topictypes.CodecRaw},
+			topicoptions.CreateWithMinActivePartitions(2),
+			topicoptions.CreateWithPartitionCountLimit(2),
+			topicoptions.CreateWithConsumer(topictypes.Consumer{Name: consumer}),
+		)
+		require.NoError(t, err)
+
+		connectedPartitions := int32(0)
+		var handled int32
+
+		var sessionsMutex sync.Mutex
+		sessions := map[int64]bool{}
+
+		tracer := trace.Topic{
+			OnReaderPartitionReadStartResponse: func(startInfo trace.TopicReaderPartitionReadStartResponseStartInfo) func(doneInfo trace.TopicReaderPartitionReadStartResponseDoneInfo) { //nolint:lll
+				atomic.StoreInt32(&handled, 1)
+
+				atomic.AddInt32(&connectedPartitions, 1)
+				return nil
+			},
+			OnReaderPartitionReadStopResponse: func(startInfo trace.TopicReaderPartitionReadStopResponseStartInfo) func(doneInfo trace.TopicReaderPartitionReadStopResponseDoneInfo) { //nolint:lll
+				atomic.StoreInt32(&handled, 1)
+
+				sessionsMutex.Lock()
+				defer sessionsMutex.Unlock()
+				if sessions[startInfo.PartitionSessionID] {
+					return nil
+				}
+				sessions[startInfo.PartitionSessionID] = true
+
+				atomic.AddInt32(&connectedPartitions, -1)
+				return nil
+			},
+		}
+		firstReader, err := db.Topic().StartReader(consumer, topicoptions.ReadTopic(topicPath),
+			topicoptions.WithReaderTrace(tracer),
+		)
+		require.NoError(t, err)
+
+		readCtx, firstReaderStopRead := context.WithCancel(ctx)
+		firstReaderReadStopped := make(empty.Chan)
+		go func() {
+			defer close(firstReaderReadStopped)
+
+			for {
+				if readCtx.Err() != nil {
+					return
+				}
+				_, err = firstReader.ReadMessage(readCtx)
+				if readCtx.Err() == nil {
+					require.NoError(t, err)
+				}
+			}
+		}()
+
+		xtest.SpinWaitConditionWithTimeout(t, nil, time.Second, func() bool {
+			return atomic.LoadInt32(&connectedPartitions) == 2
+		})
+
+		readerSecond, err := db.Topic().StartReader(consumer, topicoptions.ReadTopic(topicPath))
+		require.NoError(t, err)
+
+		xtest.SpinWaitConditionWithTimeout(t, nil, time.Second, func() bool {
+			return atomic.LoadInt32(&connectedPartitions) == 1
+		})
+
+		require.NoError(t, readerSecond.Close(ctx))
+
+		xtest.SpinWaitConditionWithTimeout(t, nil, time.Second, func() bool {
+			return atomic.LoadInt32(&connectedPartitions) == 2
+		})
+
+		firstReaderStopRead()
+		xtest.WaitChannelClosed(t, firstReaderReadStopped)
+		require.NoError(t, firstReader.Close(ctx))
 	})
-
-	readerSecond, err := db.Topic().StartReader(consumer, topicoptions.ReadTopic(topicPath))
-	require.NoError(t, err)
-
-	xtest.SpinWaitConditionWithTimeout(t, nil, time.Minute, func() bool {
-		return atomic.LoadInt32(&connectedPartitions) == 1
-	})
-
-	require.NoError(t, readerSecond.Close(ctx))
-
-	xtest.SpinWaitConditionWithTimeout(t, nil, time.Minute, func() bool {
-		return atomic.LoadInt32(&connectedPartitions) == 2
-	})
-
-	firstReaderStopRead()
-	xtest.WaitChannelClosed(t, firstReaderReadStopped)
-	require.NoError(t, firstReader.Close(ctx))
 }
 
 func createCDCFeed(ctx context.Context, t *testing.T, db ydb.Connection) {
@@ -286,7 +308,7 @@ func sendCDCMessage(ctx context.Context, t *testing.T, db ydb.Connection) {
 	require.NoError(t, err)
 }
 
-func testCtx(t *testing.T) context.Context {
+func testCtx(t testing.TB) context.Context {
 	ctx, cancel := xcontext.WithErrCancel(context.Background())
 	t.Cleanup(func() {
 		cancel(fmt.Errorf("ydb e2e test finished: %v", t.Name()))

--- a/topic/topicoptions/topicoptions_create.go
+++ b/topic/topicoptions/topicoptions_create.go
@@ -21,7 +21,7 @@ type CreateOption func(request *rawtopic.CreateTopicRequest)
 // Notice: This API is EXPERIMENTAL and may be changed or removed in a later release.
 func CreateWithMinActivePartitions(count int64) CreateOption {
 	return func(request *rawtopic.CreateTopicRequest) {
-		request.PartitionSettings.PartitionCountLimit = count
+		request.PartitionSettings.MinActivePartitions = count
 	}
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
1. Close with error if receive signal about stop partition.
```
Read stream error: ydb: send unexpected message type: *rawtopicreader.StopPartitionSessionResponse at `github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawtopic/rawtopicreader.StreamReader.Send(rawtopicreader.go:140)
```

2. Deadlock if same time add raw messages to internal topic batcher and read from it.

## What is the new behavior?
1. Handle stop partition fine
2. Work good
