### PR TITLE
* Changed `database/sql` driver `prepare` behaviour to `nop` with pro…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Changed `database/sql` driver `prepare` behaviour to `nop` with proxing call to conn exec/query with keep-in-cache flag 
+
 ## v3.34.0
 * Improved the `xsql` errors mapping to `driver.ErrBadConn` 
 * Extended `retry.DoTx` test for to achieve equivalence with `retry.Retry` behaviour

--- a/internal/table/statement.go
+++ b/internal/table/statement.go
@@ -18,10 +18,6 @@ type statement struct {
 	params  map[string]*Ydb.Type
 }
 
-func Params(s table.Statement) map[string]*Ydb.Type {
-	return s.(*statement).params
-}
-
 // Execute executes prepared data query.
 func (s *statement) Execute(
 	ctx context.Context, tx *table.TransactionControl,

--- a/internal/xsql/conn.go
+++ b/internal/xsql/conn.go
@@ -8,7 +8,6 @@ import (
 	"sync/atomic"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/retry"
-	internal "github.com/ydb-platform/ydb-go-sdk/v3/internal/table"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xsql/badconn"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xsql/isolation"
@@ -160,16 +159,10 @@ func (c *conn) PrepareContext(ctx context.Context, query string) (_ driver.Stmt,
 	if c.isClosed() {
 		return nil, errClosedConn
 	}
-	var s table.Statement
-	s, err = c.session.Prepare(ctx, query)
-	if err != nil {
-		return nil, c.checkClosed(err)
-	}
 	return &stmt{
-		conn:   c,
-		params: internal.Params(s),
-		query:  query,
-		trace:  c.trace,
+		conn:  c,
+		query: query,
+		trace: c.trace,
 	}, nil
 }
 

--- a/internal/xsql/connector.go
+++ b/internal/xsql/connector.go
@@ -103,7 +103,7 @@ var (
 
 func (c *Connector) Close() (err error) {
 	defer c.driver.Detach(c)
-	return c.connection.Close(context.Background())
+	return nil
 }
 
 func (c *Connector) Connection() connection {

--- a/log/driver.go
+++ b/log/driver.go
@@ -422,7 +422,7 @@ func Driver(l Logger, details trace.Details) (t trace.Driver) {
 	//nolint:nestif
 	if details&trace.DriverBalancerEvents != 0 {
 		//nolint:govet
-		l := l.WithName(`cluster`)
+		l := l.WithName(`balancer`)
 		t.OnBalancerInit = func(info trace.DriverBalancerInitStartInfo) func(trace.DriverBalancerInitDoneInfo) {
 			l.Tracef(`init start`)
 			start := time.Now()

--- a/retry/sql_test.go
+++ b/retry/sql_test.go
@@ -85,6 +85,7 @@ func (m *mockConn) Close() error {
 }
 
 func (m *mockConn) Begin() (driver.Tx, error) {
+	m.t.Log(xerrors.StackRecord(0))
 	return nil, driver.ErrSkip
 }
 
@@ -141,7 +142,7 @@ func (m *mockStmt) Close() error {
 
 func (m *mockStmt) NumInput() int {
 	m.t.Log(xerrors.StackRecord(0))
-	return 0
+	return -1
 }
 
 func (m *mockStmt) Exec(args []driver.Value) (driver.Result, error) {


### PR DESCRIPTION
…xing call to conn exec/query with keep-in-cache flag

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
