### PR TITLE
* Added simple transaction control constructors `table.OnlineReadOnly…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+* Added simple transaction control constructors `table.OnlineReadOnlyTxControl()` and `table.StaleReadOnlyTxControl()`
+* Added transaction control specifier with context `ydb.WithTxControl`
+* Added value constructors `types.BytesValue`, `types.BytesValueFromString`, `types.TextValue`
+* Removed auto-prepending declare section on `xsql` queries
+* Supports `time.Time` as type destination in `xsql` queries
 * Defined default dial timeout (5 seconds)
 
 ## v3.35.1

--- a/internal/xsql/valuer.go
+++ b/internal/xsql/valuer.go
@@ -1,0 +1,16 @@
+package xsql
+
+import "github.com/ydb-platform/ydb-go-sdk/v3/table/types"
+
+type valuer struct {
+	v interface{}
+}
+
+func (p *valuer) UnmarshalYDB(raw types.RawValue) error {
+	p.v = raw.Any()
+	return nil
+}
+
+func (p *valuer) Value() interface{} {
+	return p.v
+}

--- a/internal/xsql/xsql.go
+++ b/internal/xsql/xsql.go
@@ -3,7 +3,6 @@ package xsql
 import (
 	"database/sql/driver"
 
-	internal "github.com/ydb-platform/ydb-go-sdk/v3/internal/table"
 	"github.com/ydb-platform/ydb-go-sdk/v3/table"
 	"github.com/ydb-platform/ydb-go-sdk/v3/table/types"
 )
@@ -20,8 +19,4 @@ func toQueryParams(values []driver.NamedValue) *table.QueryParameters {
 		)
 	}
 	return table.NewQueryParameters(opts...)
-}
-
-func queryWithDeclares(query string, params *table.QueryParameters) string {
-	return internal.GenerateDeclareSection(params) + query
 }

--- a/sql.go
+++ b/sql.go
@@ -92,6 +92,10 @@ func WithQueryMode(ctx context.Context, mode QueryMode) context.Context {
 	return xsql.WithQueryMode(ctx, mode)
 }
 
+func WithTxControl(ctx context.Context, txc *table.TransactionControl) context.Context {
+	return xsql.WithTxControl(ctx, txc)
+}
+
 type ConnectorOption = xsql.ConnectorOption
 
 func WithDefaultQueryMode(mode QueryMode) ConnectorOption {

--- a/table/table.go
+++ b/table/table.go
@@ -364,6 +364,22 @@ func DefaultTxControl() *TransactionControl {
 	)
 }
 
+// OnlineReadOnlyTxControl returns online read-only transaction control
+func OnlineReadOnlyTxControl(opts ...TxOnlineReadOnlyOption) *TransactionControl {
+	return TxControl(
+		BeginTx(WithOnlineReadOnly(opts...)),
+		CommitTx(), // open transactions not supported for OnlineReadOnly
+	)
+}
+
+// StaleReadOnlyTxControl returns stale read-only transaction control
+func StaleReadOnlyTxControl() *TransactionControl {
+	return TxControl(
+		BeginTx(WithStaleReadOnly()),
+		CommitTx(), // open transactions not supported for StaleReadOnly
+	)
+}
+
 // QueryParameters
 
 type (

--- a/table/types/value.go
+++ b/table/types/value.go
@@ -113,6 +113,10 @@ func TzTimestampValueFromTime(v time.Time) Value {
 
 func StringValue(v []byte) Value { return value.StringValue(v) }
 
+func BytesValue(v []byte) Value { return value.StringValue(v) }
+
+func BytesValueFromString(v string) Value { return value.StringValue([]byte(v)) }
+
 // StringValueFromString makes String value from string
 //
 // Warning: all *From* helpers will be removed at next major release
@@ -120,6 +124,8 @@ func StringValue(v []byte) Value { return value.StringValue(v) }
 func StringValueFromString(v string) Value { return value.StringValue([]byte(v)) }
 
 func UTF8Value(v string) Value { return value.UTF8Value(v) }
+
+func TextValue(v string) Value { return value.UTF8Value(v) }
 
 func YSONValue(v string) Value { return value.YSONValue(v) }
 


### PR DESCRIPTION
…TxControl()` and `table.StaleReadOnlyTxControl()`

* Added transaction control specifier with context `ydb.WithTxControl`
* Added value constructors `types.BytesValue`, `types.BytesValueFromString`, `types.TextValue`
* Removed auto-prepending declare section on `xsql` queries
* Supports `time.Time` as type destination in `xsql` queries

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
