### PR TITLE
Stop sent empty support codec if customer not set it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Fixed alter topic request - stop send empty setSupportedCodecs if customer not set them 
 * Marked the context errors as required to delete session
 * Added log topic api reader for internal logger
 

--- a/internal/grpcwrapper/rawtopic/alter_topic.go
+++ b/internal/grpcwrapper/rawtopic/alter_topic.go
@@ -16,7 +16,8 @@ type AlterTopicRequest struct {
 	AlterPartitionSettings               AlterPartitioningSettings
 	SetRetentionPeriod                   rawoptional.Duration
 	SetRetentionStorageMB                rawoptional.Int64
-	SetSupportedCodecs                   rawtopiccommon.SupportedCodecs
+	SetSupportedCodecs                   bool
+	SetSupportedCodecsValue              rawtopiccommon.SupportedCodecs
 	SetPartitionWriteSpeedBytesPerSecond rawoptional.Int64
 	SetPartitionWriteBurstBytes          rawoptional.Int64
 	AlterAttributes                      map[string]string
@@ -32,10 +33,13 @@ func (req *AlterTopicRequest) ToProto() *Ydb_Topic.AlterTopicRequest {
 		AlterPartitioningSettings:            req.AlterPartitionSettings.ToProto(),
 		SetRetentionPeriod:                   req.SetRetentionPeriod.ToProto(),
 		SetRetentionStorageMb:                req.SetRetentionStorageMB.ToProto(),
-		SetSupportedCodecs:                   req.SetSupportedCodecs.ToProto(),
 		SetPartitionWriteSpeedBytesPerSecond: req.SetPartitionWriteSpeedBytesPerSecond.ToProto(),
 		SetPartitionWriteBurstBytes:          req.SetPartitionWriteBurstBytes.ToProto(),
 		AlterAttributes:                      req.AlterAttributes,
+	}
+
+	if req.SetSupportedCodecs {
+		res.SetSupportedCodecs = req.SetSupportedCodecsValue.ToProto()
 	}
 
 	res.AddConsumers = make([]*Ydb_Topic.Consumer, len(req.AddConsumers))

--- a/topic/topicoptions/topicoptions_alter.go
+++ b/topic/topicoptions/topicoptions_alter.go
@@ -70,9 +70,10 @@ func AlterWithRetentionStorageMB(retentionStorageMB int64) AlterOption {
 // Notice: This API is EXPERIMENTAL and may be changed or removed in a later release.
 func AlterWithSupportedCodecs(codecs ...topictypes.Codec) AlterOption {
 	return func(req *rawtopic.AlterTopicRequest) {
-		req.SetSupportedCodecs = make(rawtopiccommon.SupportedCodecs, len(codecs))
+		req.SetSupportedCodecs = true
+		req.SetSupportedCodecsValue = make(rawtopiccommon.SupportedCodecs, len(codecs))
 		for i, codec := range codecs {
-			req.SetSupportedCodecs[i] = rawtopiccommon.Codec(codec)
+			req.SetSupportedCodecsValue[i] = rawtopiccommon.Codec(codec)
 		}
 	}
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Always sent setSupportedCodecs field for alter topic request, even if them not set from customer (sent empty list)

## What is the new behavior?
Sent setSupportedCodecs only if them explicit set.
