### PR TITLE
Fix flaky test TestStreamReaderImpl_OnPartitionCloseHandle/TraceGracefulTrue

### DIFF
--- a/internal/xtest/manytimes.go
+++ b/internal/xtest/manytimes.go
@@ -36,7 +36,7 @@ func TestManyTimes(t testing.TB, test TestFunc, opts ...TestManyTimesOption) {
 		// run test, then check stopAfter for guarantee run test least once
 		runTest(t, test)
 
-		if time.Since(start) > options.stopAfter {
+		if time.Since(start) > options.stopAfter || t.Failed() {
 			t.Log("test run counter:", testCounter)
 			return
 		}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe):

## What is the current behavior?
Exit from test right after check errors

## What is the new behavior?
Explicit wait for stop partition response sent.