### PR TITLE
add listening discovery results for closing sessions on removed nodes early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Added listening node status from session and close session early if node not found in balancer
+
 ## v3.37.5
 * Refactoring of `xsql` errors checking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-* Added listening node status from session and close session early if node not found in balancer
+* Added to balancer notifying mechanism for listening in table client event about removing some nodes and closing sessions on them 
+* Removed from public client interfaces `closer.Closer` (for exclude undefined behaviour on client-side)
 
 ## v3.37.5
 * Refactoring of `xsql` errors checking

--- a/coordination/coordination.go
+++ b/coordination/coordination.go
@@ -3,13 +3,10 @@ package coordination
 import (
 	"context"
 
-	"github.com/ydb-platform/ydb-go-sdk/v3/internal/closer"
 	"github.com/ydb-platform/ydb-go-sdk/v3/scheme"
 )
 
 type Client interface {
-	closer.Closer
-
 	CreateNode(ctx context.Context, path string, config NodeConfig) (err error)
 	AlterNode(ctx context.Context, path string, config NodeConfig) (err error)
 	DropNode(ctx context.Context, path string) (err error)

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ydb-platform/ydb-go-sdk/v3/internal/closer"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/endpoint"
 )
 
@@ -19,8 +18,6 @@ func (w WhoAmI) String() string {
 }
 
 type Client interface {
-	closer.Closer
-
 	Discover(ctx context.Context) ([]endpoint.Endpoint, error)
 	WhoAmI(ctx context.Context) (*WhoAmI, error)
 }

--- a/internal/balancer/connections_state.go
+++ b/internal/balancer/connections_state.go
@@ -79,7 +79,10 @@ func (s *connectionsState) preferConnection(ctx context.Context) conn.Conn {
 	if e, hasPreferEndpoint := ContextEndpoint(ctx); hasPreferEndpoint {
 		c := s.connByNodeID[e.NodeID()]
 		if c != nil && isOkConnection(c, true) {
+			e.Choose(true)
 			return c
+		} else {
+			e.Choose(false)
 		}
 	}
 

--- a/internal/balancer/connections_state.go
+++ b/internal/balancer/connections_state.go
@@ -79,10 +79,7 @@ func (s *connectionsState) preferConnection(ctx context.Context) conn.Conn {
 	if e, hasPreferEndpoint := ContextEndpoint(ctx); hasPreferEndpoint {
 		c := s.connByNodeID[e.NodeID()]
 		if c != nil && isOkConnection(c, true) {
-			e.Choose(true)
 			return c
-		} else {
-			e.Choose(false)
 		}
 	}
 

--- a/internal/balancer/ctx.go
+++ b/internal/balancer/ctx.go
@@ -8,9 +8,6 @@ type (
 
 type Endpoint interface {
 	NodeID() uint32
-
-	// Choose calls from balancer if this endpoint to request chosen or not
-	Choose(chosen bool)
 }
 
 func WithEndpoint(ctx context.Context, endpoint Endpoint) context.Context {

--- a/internal/balancer/ctx.go
+++ b/internal/balancer/ctx.go
@@ -8,20 +8,13 @@ type (
 
 type Endpoint interface {
 	NodeID() uint32
+
+	// Choose calls from balancer if this endpoint to request chosen or not
+	Choose(chosen bool)
 }
 
 func WithEndpoint(ctx context.Context, endpoint Endpoint) context.Context {
 	return context.WithValue(ctx, ctxEndpointKey{}, endpoint)
-}
-
-type nodeID uint32
-
-func (n nodeID) NodeID() uint32 {
-	return uint32(n)
-}
-
-func WithNodeID(ctx context.Context, id uint32) context.Context {
-	return WithEndpoint(ctx, nodeID(id))
 }
 
 func ContextEndpoint(ctx context.Context) (e Endpoint, ok bool) {

--- a/internal/mock/conn.go
+++ b/internal/mock/conn.go
@@ -82,6 +82,9 @@ type Endpoint struct {
 	LocalDCField  bool
 }
 
+func (e *Endpoint) Choose(bool) {
+}
+
 func (e *Endpoint) NodeID() uint32 {
 	return e.NodeIDField
 }

--- a/internal/table/client.go
+++ b/internal/table/client.go
@@ -66,7 +66,9 @@ func newClient(
 		},
 		done: make(chan struct{}),
 	}
-	balancer.OnDiscovery(c.onDiscovery)
+	if balancer != nil {
+		balancer.OnDiscovery(c.onDiscovery)
+	}
 	if idleThreshold := config.IdleThreshold(); idleThreshold > 0 {
 		c.spawnedGoroutines.Add(1)
 		go c.internalPoolGC(ctx, idleThreshold)

--- a/internal/table/client_test.go
+++ b/internal/table/client_test.go
@@ -880,16 +880,16 @@ type StubBuilder struct {
 
 func newClientWithStubBuilder(
 	t testing.TB,
-	cc grpc.ClientConnInterface,
+	balancer balancerNotifier,
 	stubLimit int,
 	options ...config.Option,
 ) *Client {
 	return newClient(
-		cc,
+		balancer,
 		(&StubBuilder{
 			T:     t,
 			Limit: stubLimit,
-			cc:    cc,
+			cc:    balancer,
 		}).createSession,
 		config.New(options...),
 	)

--- a/internal/table/session.go
+++ b/internal/table/session.go
@@ -53,6 +53,15 @@ type session struct {
 	closeOnce sync.Once
 }
 
+func (s *session) Choose(chosen bool) {
+	if s == nil {
+		return
+	}
+	if !chosen {
+		s.SetStatus(options.SessionClosing)
+	}
+}
+
 func (s *session) NodeID() uint32 {
 	if s == nil {
 		return 0
@@ -165,7 +174,7 @@ func (s *session) Close(ctx context.Context) (err error) {
 		onDone := trace.TableOnSessionDelete(s.config.Trace(), &ctx, s)
 
 		_, err = s.tableService.DeleteSession(
-			balancer.WithEndpoint(ctx, s),
+			ctx,
 			&Ydb_Table.DeleteSessionRequest{
 				SessionId: s.id,
 				OperationParams: operation.Params(ctx,

--- a/internal/table/session.go
+++ b/internal/table/session.go
@@ -53,15 +53,6 @@ type session struct {
 	closeOnce sync.Once
 }
 
-func (s *session) Choose(chosen bool) {
-	if s == nil {
-		return
-	}
-	if !chosen {
-		s.SetStatus(options.SessionClosing)
-	}
-}
-
 func (s *session) NodeID() uint32 {
 	if s == nil {
 		return 0

--- a/ratelimiter/ratelimiter.go
+++ b/ratelimiter/ratelimiter.go
@@ -4,13 +4,10 @@ import (
 	"context"
 	"time"
 
-	"github.com/ydb-platform/ydb-go-sdk/v3/internal/closer"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/ratelimiter/options"
 )
 
 type Client interface {
-	closer.Closer
-
 	CreateResource(
 		ctx context.Context,
 		coordinationNodePath string,

--- a/scheme/scheme.go
+++ b/scheme/scheme.go
@@ -4,13 +4,9 @@ import (
 	"context"
 
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Scheme"
-
-	"github.com/ydb-platform/ydb-go-sdk/v3/internal/closer"
 )
 
 type Client interface {
-	closer.Closer
-
 	DescribePath(ctx context.Context, path string) (e Entry, err error)
 	MakeDirectory(ctx context.Context, path string) (err error)
 	ListDirectory(ctx context.Context, path string) (d Directory, err error)

--- a/scripting/scripting.go
+++ b/scripting/scripting.go
@@ -3,7 +3,6 @@ package scripting
 import (
 	"context"
 
-	"github.com/ydb-platform/ydb-go-sdk/v3/internal/closer"
 	"github.com/ydb-platform/ydb-go-sdk/v3/table"
 	"github.com/ydb-platform/ydb-go-sdk/v3/table/result"
 )
@@ -19,8 +18,6 @@ const (
 )
 
 type Client interface {
-	closer.Closer
-
 	Execute(
 		ctx context.Context,
 		query string,

--- a/table/table.go
+++ b/table/table.go
@@ -34,8 +34,6 @@ type ClosableSession interface {
 }
 
 type Client interface {
-	closer.Closer
-
 	// CreateSession returns session or error for manually control of session lifecycle
 	//
 	// CreateSession implements internal busy loop until one of the following conditions is met:

--- a/testutil/driver.go
+++ b/testutil/driver.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/endpoint"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
 )
 
@@ -282,12 +283,15 @@ func WithClose(onClose func(ctx context.Context) error) balancerOption {
 	}
 }
 
-func NewBalancer(opts ...balancerOption) grpc.ClientConnInterface {
+func NewBalancer(opts ...balancerOption) *balancerStub {
 	c := &balancerStub{}
 	for _, opt := range opts {
 		opt(c)
 	}
 	return c
+}
+
+func (b *balancerStub) OnDiscovery(func(context.Context, []endpoint.Info)) {
 }
 
 type clientConn struct {

--- a/topic/client.go
+++ b/topic/client.go
@@ -14,14 +14,6 @@ import (
 //
 // Notice: This API is EXPERIMENTAL and may be changed or removed in a later release.
 type Client interface {
-	// Close stop client
-	//
-	// Experimental
-	//
-	// Notice: This API is EXPERIMENTAL and may be changed or removed in a
-	// later release.
-	Close(context.Context) error
-
 	// Alter change topic options
 	//
 	// Experimental


### PR DESCRIPTION
* Added to balancer notifying mechanism for listening in table client event about removing some nodes and closing sessions on them 
* Removed from public client interfaces `closer.Closer` (for exclude undefined behaviour on client-side)

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #372 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
