### PR TITLE
use function to check os env flag before test start

### DIFF
--- a/internal/xtest/test_condition.go
+++ b/internal/xtest/test_condition.go
@@ -1,0 +1,21 @@
+package xtest
+
+import (
+	"os"
+	"testing"
+)
+
+// enableAllTestsFlag set the env var for run all tests
+// some of them may take a lot ot time (hours) or use functions
+// not published to common test docker image
+const enableAllTestsFlag = "YDB_GO_SDK_ENABLE_ALL_TESTS"
+
+func AllowByFlag(t testing.TB, flag string) {
+	if os.Getenv(flag) != "" {
+		return
+	}
+	if os.Getenv(enableAllTestsFlag) != "" {
+		return
+	}
+	t.Skipf("Skip test, because it need flag to run: '%v'", flag)
+}

--- a/table/table_e2e_test.go
+++ b/table/table_e2e_test.go
@@ -172,9 +172,7 @@ func (s *stats) removeFromInFlight(t testing.TB, id string) {
 }
 
 func TestTableMultiple(t *testing.T) {
-	if _, ok := os.LookupEnv("LOCAL_TESTING"); !ok {
-		t.Skip("only for local testing")
-	}
+	xtest.AllowByFlag(t, "HUGE_TEST")
 	xtest.TestManyTimes(t, func(t testing.TB) {
 		testTable(t)
 	}, xtest.StopAfter(time.Hour))


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Direct check os env var for allow/deny run special tests

## What is the new behavior?

use spec function for check allow/skip test flag