### PR TITLE
Add queue len limit for send messages to topic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Added queue limit for sent messages and split large grpc messages while send to topic service
 * Improved control plane for topic services: Allow list topic in schema, read cdc feeds in table, retry on contol plane operations in topic client, full info in topic describe result
 * Allowed to write zero messages to topic writer
 

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
+	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f // indirect
 	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
 	golang.org/x/text v0.3.3 // indirect
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/jonboulle/clockwork v0.2.2
 	github.com/stretchr/testify v1.7.1
 	github.com/ydb-platform/ydb-go-genproto v0.0.0-20220922065549-66df47a830ba
+	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
 	google.golang.org/grpc v1.47.0
 	google.golang.org/protobuf v1.28.0
 )
@@ -17,7 +18,6 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
-	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f // indirect
 	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
 	golang.org/x/text v0.3.3 // indirect
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,8 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f h1:Ax0t5p6N38Ga0dThY21weqDEyz2oklo4IvDkpigvkD8=
+golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/go.sum
+++ b/go.sum
@@ -61,10 +61,6 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/ydb-platform/ydb-go-genproto v0.0.0-20220801095836-cf975531fd1f h1:QmTU3AtCBOI8zarYB4N3q+VQQxpVxu8pRHJN5Fd8WKc=
-github.com/ydb-platform/ydb-go-genproto v0.0.0-20220801095836-cf975531fd1f/go.mod h1:Er+FePu1dNUieD+XTMDduGpQuCPssK5Q4BjF+IIXJ3I=
-github.com/ydb-platform/ydb-go-genproto v0.0.0-20220916101045-1c4d1accabb6 h1:SysuVdFz3CjwLAuf8JzHCpnV1MpEfGygqHEuwK4nB+g=
-github.com/ydb-platform/ydb-go-genproto v0.0.0-20220916101045-1c4d1accabb6/go.mod h1:Er+FePu1dNUieD+XTMDduGpQuCPssK5Q4BjF+IIXJ3I=
 github.com/ydb-platform/ydb-go-genproto v0.0.0-20220922065549-66df47a830ba h1:htUAISxEY5MfCLmubsf2EMgN+H62cQTNcTseK5F4cJ0=
 github.com/ydb-platform/ydb-go-genproto v0.0.0-20220922065549-66df47a830ba/go.mod h1:Er+FePu1dNUieD+XTMDduGpQuCPssK5Q4BjF+IIXJ3I=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=

--- a/internal/grpcwrapper/rawtopic/rawtopicwriter/streamwriter_test.go
+++ b/internal/grpcwrapper/rawtopic/rawtopicwriter/streamwriter_test.go
@@ -1,0 +1,99 @@
+package rawtopicwriter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Topic"
+	"google.golang.org/grpc/codes"
+	grpcStatus "google.golang.org/grpc/status"
+)
+
+func TestSendWriteRequest(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		expected := &Ydb_Topic.StreamWriteMessage_FromClient_WriteRequest{
+			WriteRequest: &Ydb_Topic.StreamWriteMessage_WriteRequest{
+				Codec: 123,
+				Messages: []*Ydb_Topic.StreamWriteMessage_WriteRequest_MessageData{
+					{
+						SeqNo: 1,
+					},
+				},
+			},
+		}
+
+		sendCounter := 0
+		var send sendFunc = func(req *Ydb_Topic.StreamWriteMessage_FromClient) error {
+			sendCounter++
+			require.Equal(t, expected, req.ClientMessage)
+			return nil
+		}
+		err := sendWriteRequest(send, expected)
+		require.NoError(t, err)
+		require.Equal(t, 1, sendCounter)
+	})
+
+	t.Run("Split", func(t *testing.T) {
+		originalMessage := &Ydb_Topic.StreamWriteMessage_WriteRequest{
+			Codec: 123,
+			Messages: []*Ydb_Topic.StreamWriteMessage_WriteRequest_MessageData{
+				{
+					SeqNo: 1,
+				},
+				{
+					SeqNo: 2,
+				},
+				{
+					SeqNo: 3,
+				},
+			},
+		}
+
+		split1 := &Ydb_Topic.StreamWriteMessage_WriteRequest{
+			Codec: 123,
+			Messages: []*Ydb_Topic.StreamWriteMessage_WriteRequest_MessageData{
+				{
+					SeqNo: 1,
+				},
+			},
+		}
+
+		split2 := &Ydb_Topic.StreamWriteMessage_WriteRequest{
+			Codec: 123,
+			Messages: []*Ydb_Topic.StreamWriteMessage_WriteRequest_MessageData{
+				{
+					SeqNo: 2,
+				},
+				{
+					SeqNo: 3,
+				},
+			},
+		}
+
+		getWriteRequest := func(req *Ydb_Topic.StreamWriteMessage_FromClient) *Ydb_Topic.StreamWriteMessage_WriteRequest {
+			return req.ClientMessage.(*Ydb_Topic.StreamWriteMessage_FromClient_WriteRequest).WriteRequest
+		}
+
+		sendCounter := 0
+		var send sendFunc = func(commonReq *Ydb_Topic.StreamWriteMessage_FromClient) error {
+			sendCounter++
+			req := getWriteRequest(commonReq)
+			switch sendCounter {
+			case 1:
+				require.Equal(t, originalMessage, req)
+				return grpcStatus.Error(codes.ResourceExhausted, "test resource exhausted")
+			case 2:
+				require.Equal(t, split1, req)
+			case 3:
+				require.Equal(t, split2, req)
+			default:
+				t.Fatal()
+			}
+			return nil
+		}
+
+		err := sendWriteRequest(send, &Ydb_Topic.StreamWriteMessage_FromClient_WriteRequest{WriteRequest: originalMessage})
+		require.NoError(t, err)
+		require.Equal(t, 3, sendCounter)
+	})
+}

--- a/internal/topic/topicwriterinternal/message.go
+++ b/internal/topic/topicwriterinternal/message.go
@@ -57,7 +57,7 @@ type messageWithDataContent struct {
 	hasEncodedContent   bool
 	bufCodec            rawtopiccommon.Codec
 	bufEncoded          bytes.Buffer
-	bufUncompressedSize int64
+	BufUncompressedSize int
 }
 
 func (m *messageWithDataContent) GetEncodedBytes(codec rawtopiccommon.Codec) ([]byte, error) {
@@ -107,7 +107,7 @@ func (m *messageWithDataContent) readDataToRawBuf() error {
 		if err != nil {
 			return xerrors.WithStackTrace(err)
 		}
-		m.bufUncompressedSize = writtenBytes
+		m.BufUncompressedSize = int(writtenBytes)
 		m.Data = nil
 	}
 	return nil
@@ -139,7 +139,7 @@ func (m *messageWithDataContent) readDataToTargetCodec(codec rawtopiccommon.Code
 			err,
 		)))
 	}
-	m.bufUncompressedSize = bytesCount
+	m.BufUncompressedSize = int(bytesCount)
 	m.Data = nil
 	return nil
 }

--- a/internal/topic/topicwriterinternal/writer_options.go
+++ b/internal/topic/topicwriterinternal/writer_options.go
@@ -88,6 +88,12 @@ func WithAutosetCreatedTime(enable bool) PublicWriterOption {
 	}
 }
 
+func WithMaxQueueLen(num int) PublicWriterOption {
+	return func(cfg *WriterReconnectorConfig) {
+		cfg.MaxQueueLen = num
+	}
+}
+
 func WithPartitioning(partitioning PublicPartitioning) PublicWriterOption {
 	return func(cfg *WriterReconnectorConfig) {
 		cfg.defaultPartitioning = partitioning.ToRaw()

--- a/internal/topic/topicwriterinternal/writer_reconnector.go
+++ b/internal/topic/topicwriterinternal/writer_reconnector.go
@@ -184,6 +184,14 @@ func (w *WriterReconnector) Write(ctx context.Context, messages []Message) error
 	}
 
 	semaphoreWeight := int64(len(messages))
+	if semaphoreWeight > int64(w.cfg.MaxQueueLen) {
+		return xerrors.WithStackTrace(fmt.Errorf(
+			"ydb: add more messages, then max queue limit. max queue: %v, try to add: %v: %w",
+			w.cfg.MaxQueueLen,
+			semaphoreWeight,
+			PublicErrQueueIsFull,
+		))
+	}
 	if err := w.semaphore.Acquire(ctx, semaphoreWeight); err != nil {
 		return xerrors.WithStackTrace(
 			fmt.Errorf("ydb: add new messages exceed max queue size limit. Add count: %v, max size: %v: %w",

--- a/internal/topic/topicwriterinternal/writer_reconnector_test.go
+++ b/internal/topic/topicwriterinternal/writer_reconnector_test.go
@@ -66,6 +66,23 @@ func TestWriterImpl_AutoSeq(t *testing.T) {
 	})
 }
 
+func TestWriterImpl_CheckMessages(t *testing.T) {
+	t.Run("MessageSize", func(t *testing.T) {
+		ctx := xtest.Context(t)
+		w := newWriterReconnectorStopped(newWriterReconnectorConfig())
+		w.firstConnectionHandled.Store(true)
+
+		maxSize := 5
+		w.cfg.MaxMessageSize = maxSize
+
+		err := w.Write(ctx, []Message{{Data: bytes.NewReader(make([]byte, maxSize))}})
+		require.NoError(t, err)
+
+		err = w.Write(ctx, []Message{{Data: bytes.NewReader(make([]byte, maxSize+1))}})
+		require.Error(t, err)
+	})
+}
+
 func TestWriterImpl_Write(t *testing.T) {
 	t.Run("PushToQueue", func(t *testing.T) {
 		ctx := context.Background()

--- a/internal/topic/topicwriterinternal/writer_reconnector_test.go
+++ b/internal/topic/topicwriterinternal/writer_reconnector_test.go
@@ -262,6 +262,50 @@ func TestWriterImpl_WriteCodecs(t *testing.T) {
 	})
 }
 
+func TestWriterReconnector_Write_QueueLimit(t *testing.T) {
+	ctx := xtest.Context(t)
+	w := newWriterReconnectorStopped(newWriterReconnectorConfig(
+		WithAutoSetSeqNo(false),
+		WithMaxQueueLen(2),
+	))
+	w.firstConnectionHandled.Store(true)
+
+	waitStartQueueWait := func() {
+		xtest.SpinWaitCondition(t, nil, func() bool {
+			if w.semaphore.TryAcquire(1) {
+				w.semaphore.Release(1)
+				return false
+			}
+			return true
+		})
+	}
+
+	err := w.Write(ctx, newTestMessages(1, 2))
+	require.NoError(t, err)
+
+	ctxNoQueueSpace, ctxNoQueueSpaceCancel := context.WithCancel(ctx)
+
+	go func() {
+		waitStartQueueWait()
+		ctxNoQueueSpaceCancel()
+	}()
+	err = w.Write(ctxNoQueueSpace, newTestMessages(3))
+	require.ErrorIs(t, err, PublicErrQueueIsFull)
+
+	go func() {
+		waitStartQueueWait()
+		ackErr := w.queue.AcksReceived([]rawtopicwriter.WriteAck{
+			{
+				SeqNo: 1,
+			},
+		})
+		require.NoError(t, ackErr)
+	}()
+
+	err = w.Write(ctx, newTestMessages(3))
+	require.NoError(t, err)
+}
+
 func TestEnv(t *testing.T) {
 	xtest.TestManyTimes(t, func(t testing.TB) {
 		env := newTestEnv(t, nil)

--- a/topic/topicoptions/topicoptions_writer.go
+++ b/topic/topicoptions/topicoptions_writer.go
@@ -34,6 +34,15 @@ func WithWriterCompressorCount(num int) WriterOption {
 	return topicwriterinternal.WithCompressorCount(num)
 }
 
+// WithWriterMaxQueueLen set max len of queue for wait ack
+//
+// # Experimental
+//
+// Notice: This API is EXPERIMENTAL and may be changed or removed in a later release.
+func WithWriterMaxQueueLen(num int) WriterOption {
+	return topicwriterinternal.WithMaxQueueLen(num)
+}
+
 // WithWriterMessageMaxBytesSize set max body size of one message in bytes
 //
 // # Experimental

--- a/topic/topicoptions/topicoptions_writer.go
+++ b/topic/topicoptions/topicoptions_writer.go
@@ -34,6 +34,17 @@ func WithWriterCompressorCount(num int) WriterOption {
 	return topicwriterinternal.WithCompressorCount(num)
 }
 
+// WithWriterMessageMaxBytesSize set max body size of one message in bytes
+//
+// # Experimental
+//
+// Notice: This API is EXPERIMENTAL and may be changed or removed in a later release.
+func WithWriterMessageMaxBytesSize(size int) WriterOption {
+	return func(cfg *topicwriterinternal.WriterReconnectorConfig) {
+		cfg.MaxMessageSize = size
+	}
+}
+
 // WithWriteSessionMeta set session metadata
 //
 // # Experimental

--- a/topic/topicwriter/topicwriter.go
+++ b/topic/topicwriter/topicwriter.go
@@ -11,6 +11,8 @@ type (
 	Partitioning = topicwriterinternal.PublicPartitioning
 )
 
+var ErrQueueLimitExceed = topicwriterinternal.PublicErrQueueIsFull
+
 // Writer represent write session to topic
 // It handles connection problems, reconnect to server when need and resend buffered messages
 type Writer struct {
@@ -24,13 +26,13 @@ func NewWriter(writer *topicwriterinternal.Writer) *Writer {
 }
 
 // Write send messages to topic
-// return fast in async mode (default) and wait ack from server in sync mode.
+// return after save messages into buffer in async mode (default) and after ack from server in sync mode.
 // see topicoptions.WithSyncWrite
 //
 // The method will wait first initial connection even for async mode, that mean first write may be slower.
 // especially when connection has problems.
 //
-// ctx cancelation mean cancel of wait ack only, it will not cancel of send messages
+// It returns ErrQueueLimitExceed (must be checked by errors.Is) if ctx cancelled before messages put to internal buffer.
 //
 // # Experimental
 //

--- a/topic/topicwriter/topicwriter.go
+++ b/topic/topicwriter/topicwriter.go
@@ -32,7 +32,8 @@ func NewWriter(writer *topicwriterinternal.Writer) *Writer {
 // The method will wait first initial connection even for async mode, that mean first write may be slower.
 // especially when connection has problems.
 //
-// It returns ErrQueueLimitExceed (must be checked by errors.Is) if ctx cancelled before messages put to internal buffer.
+// It returns ErrQueueLimitExceed (must be checked by errors.Is)
+// if ctx cancelled before messages put to internal buffer or try to add more messages, that can be put to queue
 //
 // # Experimental
 //


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
No limit - add new messages to queue while it can stored in process memory.

## What is the new behavior?
If queue is full - sender will pause and wait free space in buffer.