### PR TITLE
change operation status from bitmask to enum.

### DIFF
--- a/internal/operation/status.go
+++ b/internal/operation/status.go
@@ -7,7 +7,7 @@ type Status uint8
 
 // Binary flags that used as Status
 const (
-	Finished  = Status(1 << iota >> 1)
+	Finished  = Status(iota)
 	Undefined // may be true or may be false
 	NotFinished
 )


### PR DESCRIPTION
bitmask not used not and no reason for use

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Operation status as difficult bitmask formula

## What is the new behavior?

Status as usual iota-based enum