### PR TITLE
fix logging for internal test wrapper

### DIFF
--- a/internal/xtest/manytimes.go
+++ b/internal/xtest/manytimes.go
@@ -21,6 +21,11 @@ func StopAfter(stopAfter time.Duration) TestManyTimesOption {
 func TestManyTimes(t testing.TB, test TestFunc, opts ...TestManyTimesOption) {
 	t.Helper()
 
+	testCounter := 0
+	defer func() {
+		t.Log("test run counter:", testCounter)
+	}()
+
 	options := testManyTimesOptions{
 		stopAfter: time.Second,
 	}
@@ -30,14 +35,12 @@ func TestManyTimes(t testing.TB, test TestFunc, opts ...TestManyTimesOption) {
 	}
 
 	start := time.Now()
-	testCounter := 0
 	for {
 		testCounter++
 		// run test, then check stopAfter for guarantee run test least once
 		runTest(t, test)
 
 		if time.Since(start) > options.stopAfter || t.Failed() {
-			t.Log("test run counter:", testCounter)
 			return
 		}
 	}
@@ -109,6 +112,20 @@ func (tw *testWrapper) Fatalf(format string, args ...interface{}) {
 
 	tw.flushLogs()
 	tw.TB.Fatalf(format, args...)
+}
+
+func (tw *testWrapper) Fail() {
+	tw.TB.Helper()
+
+	tw.flushLogs()
+	tw.TB.Fail()
+}
+
+func (tw *testWrapper) FailNow() {
+	tw.TB.Helper()
+
+	tw.flushLogs()
+	tw.TB.FailNow()
 }
 
 func (tw *testWrapper) Log(args ...interface{}) {


### PR DESCRIPTION
flush logs on fail test with Fail function

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
log test counter only when test completed by usual return

## What is the new behavior?
log test counter even test finished by fatal/panic
flush logs for Fail, FailNow functions
