### PR TITLE
more stable TestTopicStreamReaderImpl_CommitStolen/SimpleCommit test

### DIFF
--- a/internal/topic/topicreaderinternal/batcher.go
+++ b/internal/topic/topicreaderinternal/batcher.go
@@ -179,7 +179,7 @@ func (b *batcher) Pop(ctx context.Context, opts batcherGetOptions) (_ batcherMes
 		})
 		if closed {
 			return batcherMessageOrderItem{},
-				xerrors.WithStackTrace(fmt.Errorf("ydb: try pop messages from closed batcher: %w", b.closeErr))
+				xerrors.WithStackTrace(xerrors.Wrap(fmt.Errorf("ydb: try pop messages from closed batcher: %w", b.closeErr)))
 		}
 		if findRes.Ok {
 			return findRes.Result, nil


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
exit without wait data request message

## What is the new behavior?
explicit wait data request message