### PR TITLE
fast error if producer_id not equal to message group id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 * Added `options.WithAddAttribute` and `options.WithDropAttribute` options for `session.AlterTable` request
+* Added return error while create topic writer with not equal producer id and message group id.
 
 ## v3.39.0
 * Removed message level partitioning from experimental topic API. It is unavailable on server side yet.

--- a/internal/topic/topicclientinternal/client.go
+++ b/internal/topic/topicclientinternal/client.go
@@ -231,6 +231,9 @@ func (c *Client) StartWriter(producerID, path string, opts ...topicoptions.Write
 
 	options = append(options, opts...)
 
-	writer := topicwriterinternal.NewWriter(c.cred, options)
+	writer, err := topicwriterinternal.NewWriter(c.cred, options)
+	if err != nil {
+		return nil, err
+	}
 	return topicwriter.NewWriter(writer), nil
 }

--- a/internal/topic/topicwriterinternal/writer.go
+++ b/internal/topic/topicwriterinternal/writer.go
@@ -23,18 +23,22 @@ type Writer struct {
 	clock        clockwork.Clock
 }
 
-func NewWriter(cred credentials.Credentials, options []PublicWriterOption) *Writer {
+func NewWriter(cred credentials.Credentials, options []PublicWriterOption) (*Writer, error) {
 	options = append(
 		options,
 		WithCredentials(cred),
 	)
 	cfg := newWriterReconnectorConfig(options...)
+	if err := cfg.validate(); err != nil {
+		return nil, err
+	}
+
 	writerImpl := newWriterReconnector(cfg)
 
 	return &Writer{
 		streamWriter: writerImpl,
 		clock:        clockwork.NewRealClock(),
-	}
+	}, nil
 }
 
 func (w *Writer) Write(ctx context.Context, messages ...Message) error {

--- a/internal/topic/topicwriterinternal/writer_reconnector.go
+++ b/internal/topic/topicwriterinternal/writer_reconnector.go
@@ -40,6 +40,13 @@ var (
 	errNoAllowedCodecs                      = xerrors.Wrap(errors.New("ydb: no allowed codecs for write to topic"))
 	errLargeMessage                         = xerrors.Wrap(errors.New("ydb: message uncompressed size more, then limit"))
 	PublicErrQueueIsFull                    = xerrors.Wrap(errors.New("ydb: queue is full"))
+
+	// errProducerIDNotEqualMessageGroupID is temporary
+	// WithMessageGroupID is optional parameter because it allowed to be skipped by protocol.
+	// But right not YDB server doesn't implement it.
+	// It is fast check for return error at writer create context instead of stream initialization
+	// The error will remove in the future, when skip message group id will be allowed by server.
+	errProducerIDNotEqualMessageGroupID = xerrors.Wrap(errors.New("ydb: producer id not equal to message group id, use option WithMessageGroupID(producerID) for create writer")) //nolint:lll
 )
 
 type WriterReconnectorConfig struct {
@@ -56,6 +63,13 @@ type WriterReconnectorConfig struct {
 	OnWriterInitResponseCallback PublicOnWriterInitResponseCallback
 
 	connectTimeout time.Duration
+}
+
+func (cfg *WriterReconnectorConfig) validate() error {
+	if cfg.producerID != cfg.defaultPartitioning.MessageGroupID {
+		return xerrors.WithStackTrace(errProducerIDNotEqualMessageGroupID)
+	}
+	return nil
 }
 
 func newWriterReconnectorConfig(options ...PublicWriterOption) WriterReconnectorConfig {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe):

## What is the current behavior?
Fast error on create writer

## What is the new behavior?
Error while connect to a server and return error on write message.