### PR TITLE
Add DataColumns to IndexDescription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Upgraded `ydb-go-genproto` dependency
 * Fixed duplicating of traces in `table.Client.Do()` call
 * Supported `table.Transaction.WithCommit()` method for execute query and auto-commit after
+* Added DataColumns to IndexDescription
 
 ## v3.40.1
 * Added constructor of `options.TimeToLiveSettings` and fluent modifiers

--- a/internal/table/session.go
+++ b/internal/table/session.go
@@ -394,6 +394,7 @@ func (s *session) DescribeTable(
 		indexes[i] = options.IndexDescription{
 			Name:         idx.GetName(),
 			IndexColumns: idx.GetIndexColumns(),
+			DataColumns:  idx.GetDataColumns(),
 			Status:       idx.GetStatus(),
 		}
 	}

--- a/table/options/models.go
+++ b/table/options/models.go
@@ -38,6 +38,7 @@ func NewTableColumn(name string, typ types.Type, family string) Column {
 type IndexDescription struct {
 	Name         string
 	IndexColumns []string
+	DataColumns  []string
 	Status       Ydb_Table.TableIndexDescription_Status
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
IndexDescription does not contain DataColumns attribute, although it is available in protobuf message

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->
DataColumns are set to IndexDescription from protobuf messate
-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
