### PR TITLE
separate commit for expired session and other reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Separated errors of commit from other reader and to expired session
+
 ## v3.42.4
 * Added `ydb.WithDisableServerBalancer()` database/sql connector option
 

--- a/internal/topic/topicreaderinternal/committer.go
+++ b/internal/topic/topicreaderinternal/committer.go
@@ -208,7 +208,7 @@ func (c *committer) waitCommitAck(ctx context.Context, waiter commitWaiter) erro
 	case <-ctx.Done():
 		return ctx.Err()
 	case <-waiter.Session.Context().Done():
-		return waiter.Session.Context().Err()
+		return PublicErrCommitSessionToExpiredSession
 	case <-waiter.Committed:
 		return nil
 	}

--- a/internal/topic/topicreaderinternal/committer_test.go
+++ b/internal/topic/topicreaderinternal/committer_test.go
@@ -189,7 +189,7 @@ func TestCommitterCommitSync(t *testing.T) {
 		sessionCancel(testErr)
 
 		commitErr := <-waitErr
-		require.ErrorIs(t, commitErr, testErr)
+		require.ErrorIs(t, commitErr, PublicErrCommitSessionToExpiredSession)
 	})
 }
 

--- a/internal/topic/topicreaderinternal/partition_session.go
+++ b/internal/topic/topicreaderinternal/partition_session.go
@@ -21,6 +21,9 @@ type partitionSession struct {
 	Topic       string
 	PartitionID int64
 
+	readerID     int64
+	connectionID string
+
 	ctx                context.Context
 	ctxCancel          xcontext.CancelErrFunc
 	partitionSessionID rawtopicreader.PartitionSessionID
@@ -33,6 +36,8 @@ func newPartitionSession(
 	partitionContext context.Context,
 	topic string,
 	partitionID int64,
+	readerID int64,
+	connectionID string,
 	partitionSessionID rawtopicreader.PartitionSessionID,
 	committedOffset rawtopicreader.Offset,
 ) *partitionSession {
@@ -41,6 +46,8 @@ func newPartitionSession(
 	return &partitionSession{
 		Topic:                    topic,
 		PartitionID:              partitionID,
+		readerID:                 readerID,
+		connectionID:             connectionID,
 		ctx:                      partitionContext,
 		ctxCancel:                cancel,
 		partitionSessionID:       partitionSessionID,

--- a/internal/topic/topicreaderinternal/reader_test.go
+++ b/internal/topic/topicreaderinternal/reader_test.go
@@ -69,7 +69,11 @@ func TestReader_Close(t *testing.T) {
 		readerReadMessageBatchState := newCallState()
 
 		go func() {
-			readerCommitState.err = reader.Commit(context.Background(), &PublicMessage{})
+			readerCommitState.err = reader.Commit(context.Background(), &PublicMessage{
+				commitRange: commitRange{
+					partitionSession: &partitionSession{},
+				},
+			})
 			close(readerCommitState.callCompleted)
 		}()
 

--- a/internal/topic/topicreaderinternal/stream_reconnector_test.go
+++ b/internal/topic/topicreaderinternal/stream_reconnector_test.go
@@ -244,7 +244,7 @@ func TestTopicReaderReconnectorConnectionLoop(t *testing.T) {
 			return reconnector.streamVal == newStream2
 		})
 
-		require.NoError(t, reconnector.CloseWithError(ctx, ErrReaderClosed))
+		require.NoError(t, reconnector.CloseWithError(ctx, errReaderClosed))
 	})
 
 	t.Run("StartWithCancelledContext", func(t *testing.T) {

--- a/topic/topicreader/errors.go
+++ b/topic/topicreader/errors.go
@@ -21,3 +21,10 @@ var ErrUnexpectedCodec = topicreaderinternal.PublicErrUnexpectedCodec
 //
 // Notice: This API is EXPERIMENTAL and may be changed or removed in a later release.
 var ErrConcurrencyCall = xerrors.Wrap(errors.New("ydb: concurrency call denied"))
+
+// ErrCommitToExpiredSession it is not fatal error and reader can continue work
+//
+// # Experimental
+//
+// Notice: This API is EXPERIMENTAL and may be changed or removed in a later release.
+var ErrCommitToExpiredSession = topicreaderinternal.PublicErrCommitSessionToExpiredSession

--- a/topic/topicreader/errors.go
+++ b/topic/topicreader/errors.go
@@ -16,6 +16,7 @@ import (
 var ErrUnexpectedCodec = topicreaderinternal.PublicErrUnexpectedCodec
 
 // ErrConcurrencyCall return if method on reader called in concurrency
+// client side must check error with errors.Is
 //
 // # Experimental
 //
@@ -23,6 +24,7 @@ var ErrUnexpectedCodec = topicreaderinternal.PublicErrUnexpectedCodec
 var ErrConcurrencyCall = xerrors.Wrap(errors.New("ydb: concurrency call denied"))
 
 // ErrCommitToExpiredSession it is not fatal error and reader can continue work
+// client side must check error with errors.Is
 //
 // # Experimental
 //

--- a/topic/topicreader/reader.go
+++ b/topic/topicreader/reader.go
@@ -71,6 +71,11 @@ type MessageContentUnmarshaler = topicreaderinternal.PublicMessageContentUnmarsh
 // It can be fast (by default) or sync and waite response from server
 // see topicoptions.CommitMode for details
 //
+// for topicoptions.CommitModeSync mode sync the method can return ErrCommitToExpiredSession
+// it means about the message/batch was not committed because connection broken or partition routed to
+// other reader by server.
+// Client code should continue work normally
+//
 // # Experimental
 //
 // Notice: This API is EXPERIMENTAL and may be changed or removed in a later release.


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
All commits from unknows session threaded as error with commit from other reader

## What is the new behavior?
track session's reader by reader id and unknown session for right reader thread as commit to expired session
