### PR TITLE
fix flack send initial size

### DIFF
--- a/internal/topic/topicreaderinternal/stream_reader_impl_test.go
+++ b/internal/topic/topicreaderinternal/stream_reader_impl_test.go
@@ -787,7 +787,7 @@ func newTopicReaderTestEnv(t testing.TB) streamEnv {
 	stream.EXPECT().Recv().AnyTimes().DoAndReturn(env.receiveMessageHandler)
 
 	// initial data request
-	stream.EXPECT().Send(&rawtopicreader.ReadRequest{BytesSize: initialBufferSizeBytes})
+	stream.EXPECT().Send(&rawtopicreader.ReadRequest{BytesSize: initialBufferSizeBytes}).MaxTimes(1)
 
 	// allow in test send data without explicit sizes
 	stream.EXPECT().Send(&rawtopicreader.ReadRequest{BytesSize: 0}).AnyTimes()


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe):

## What is the current behavior?
Common env require send init request package by test client.
But some times test can finished before initial size request sent.

## What is the new behavior?
send initial request is optional.

Common env not test the initial state - it is stub only for common client work good.