### PR TITLE
Doesn't call checkerr callback with nil error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed topic retry policy callback call: not call it with nil error 
+
 ## v3.42.10
 * Added exit from retryer if got grpc-error `Unauthenticated` on `discovery/ListEndpoints` call  
 

--- a/internal/topic/retriable_error.go
+++ b/internal/topic/retriable_error.go
@@ -48,6 +48,11 @@ func CheckRetryMode(err error, settings RetrySettings, retriesDuration time.Dura
 	_ backoff.Backoff,
 	isRetriable bool,
 ) {
+	// nil is not error and doesn't need retry it.
+	if err == nil {
+		return nil, false
+	}
+
 	if retriesDuration > settings.StartTimeout {
 		return nil, false
 	}

--- a/internal/topic/retriable_error_test.go
+++ b/internal/topic/retriable_error_test.go
@@ -199,6 +199,19 @@ func TestCheckRetryMode(t *testing.T) {
 			resBackoff:   nil,
 			resRetriable: false,
 		},
+		{
+			name: "NotCallForNil",
+			err:  nil,
+			settings: RetrySettings{
+				StartTimeout: time.Second,
+				CheckError: func(errInfo PublicCheckErrorRetryArgs) PublicCheckRetryResult {
+					panic("must not call for nil err")
+				},
+			},
+			duration:     0,
+			resBackoff:   nil,
+			resRetriable: false,
+		},
 	}
 
 	for _, test := range table {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Call customer callback for retry policy for all error check, including check nil errors.

## What is the new behavior?
Not call callback if err == nil
