### PR TITLE
fix flaky test TestWorkerConcurrentStartAndClose

### DIFF
--- a/internal/background/worker_test.go
+++ b/internal/background/worker_test.go
@@ -3,6 +3,7 @@ package background
 import (
 	"context"
 	"runtime"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -97,8 +98,9 @@ func TestWorkerClose(t *testing.T) {
 
 func TestWorkerConcurrentStartAndClose(t *testing.T) {
 	xtest.TestManyTimes(t, func(t testing.TB) {
-		targetClose := int64(100)
-		parallel := 10
+		targetClose := int64(10)
+
+		parallel := runtime.GOMAXPROCS(0)
 
 		var counter int64
 
@@ -106,22 +108,14 @@ func TestWorkerConcurrentStartAndClose(t *testing.T) {
 		w := NewWorker(ctx)
 
 		closeIndex := int64(0)
-		closed := make(empty.Chan)
-
-		go func() {
-			defer close(closed)
-
-			xtest.SpinWaitCondition(t, nil, func() bool {
-				return atomic.LoadInt64(&counter) > targetClose
-			})
-
-			require.NoError(t, w.Close(ctx, nil))
-			closeIndex = atomic.LoadInt64(&counter)
-		}()
 
 		stopNewStarts := xatomic.Bool{}
+		var wgStarters sync.WaitGroup
 		for i := 0; i < parallel; i++ {
+			wgStarters.Add(1)
 			go func() {
+				defer wgStarters.Done()
+
 				for {
 					if stopNewStarts.Load() {
 						return
@@ -134,10 +128,18 @@ func TestWorkerConcurrentStartAndClose(t *testing.T) {
 			}()
 		}
 
-		xtest.WaitChannelClosed(t, closed)
-		runtime.Gosched()
+		// wait start some backgrounds - for ensure about process worked
+		xtest.SpinWaitCondition(t, nil, func() bool {
+			return atomic.LoadInt64(&counter) > targetClose
+		})
+
+		require.NoError(t, w.Close(xtest.ContextWithCommonTimeout(t, ctx), nil))
+
+		closeIndex = atomic.LoadInt64(&counter)
 		require.Equal(t, closeIndex, atomic.LoadInt64(&counter))
+
 		stopNewStarts.Store(true)
+		xtest.WaitGroup(t, &wgStarters)
 	})
 }
 

--- a/internal/xtest/context.go
+++ b/internal/xtest/context.go
@@ -20,3 +20,13 @@ func Context(t testing.TB) context.Context {
 	})
 	return ctx
 }
+
+func ContextWithCommonTimeout(t testing.TB, ctx context.Context) context.Context {
+	if ctx.Done() == nil {
+		t.Fatal("Use context with timeout only with context, cancelled on finish test, for example xtest.Context")
+	}
+
+	ctx, ctxCancel := context.WithTimeout(ctx, commonWaitTimeout)
+	_ = ctxCancel // suppress linters, it is ok for leak for small amount of time: it will cancel by parent context
+	return ctx
+}


### PR DESCRIPTION
https://github.com/ydb-platform/ydb-go-sdk/issues/578

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
1. Fixed number of parallels starters (workload) = 10
2. Wait close in separate goroutine

## What is the new behavior?
* Limit parallel by GOMAXPROCS (current  2 or 3 for [github runner](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners))
* Use context with timeout in main goroutine
