### PR TITLE
fix flaky test TestWorkerConcurrentStartAndClose

### DIFF
--- a/internal/xtest/context.go
+++ b/internal/xtest/context.go
@@ -20,3 +20,13 @@ func Context(t testing.TB) context.Context {
 	})
 	return ctx
 }
+
+func ContextWithCommonTimeout(ctx context.Context, t testing.TB) context.Context {
+	if ctx.Done() == nil {
+		t.Fatal("Use context with timeout only with context, cancelled on finish test, for example xtest.Context")
+	}
+
+	ctx, ctxCancel := context.WithTimeout(ctx, commonWaitTimeout)
+	_ = ctxCancel // suppress linters, it is ok for leak for small amount of time: it will cancel by parent context
+	return ctx
+}


### PR DESCRIPTION
https://github.com/ydb-platform/ydb-go-sdk/issues/578

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
1. Fixed number of parallels starters (workload) = 10
2. Wait close in separate goroutine

## What is the new behavior?
* Limit parallel by GOMAXPROCS (current  2 or 3 for [github runner](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners))
* Use context with timeout in main goroutine
