### PR TITLE
allow set force partition for topic writer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Fixed validation error for topicoptions.WithPartitionID option of start topic writer.
 * Supported binding parameters for `database/sql` driver
 * Added packaged `bind` with bindings options `WithTablePathPrefix(tablePathPrefix)` and `Params()`
 * Added `ydb.WithBindings` connector option

--- a/internal/topic/topicwriterinternal/writer_reconnector.go
+++ b/internal/topic/topicwriterinternal/writer_reconnector.go
@@ -66,7 +66,8 @@ type WriterReconnectorConfig struct {
 }
 
 func (cfg *WriterReconnectorConfig) validate() error {
-	if cfg.defaultPartitioning.Type == rawtopicwriter.PartitioningMessageGroupID && cfg.producerID != cfg.defaultPartitioning.MessageGroupID {
+	if cfg.defaultPartitioning.Type == rawtopicwriter.PartitioningMessageGroupID &&
+		cfg.producerID != cfg.defaultPartitioning.MessageGroupID {
 		return xerrors.WithStackTrace(errProducerIDNotEqualMessageGroupID)
 	}
 	return nil

--- a/internal/topic/topicwriterinternal/writer_reconnector.go
+++ b/internal/topic/topicwriterinternal/writer_reconnector.go
@@ -66,7 +66,7 @@ type WriterReconnectorConfig struct {
 }
 
 func (cfg *WriterReconnectorConfig) validate() error {
-	if cfg.producerID != cfg.defaultPartitioning.MessageGroupID {
+	if cfg.defaultPartitioning.Type == rawtopicwriter.PartitioningMessageGroupID && cfg.producerID != cfg.defaultPartitioning.MessageGroupID {
 		return xerrors.WithStackTrace(errProducerIDNotEqualMessageGroupID)
 	}
 	return nil

--- a/tests/integration/topic_read_writer_test.go
+++ b/tests/integration/topic_read_writer_test.go
@@ -388,6 +388,22 @@ func TestUpdateToken(t *testing.T) {
 	xtest.WaitChannelClosed(t, activityStopped)
 }
 
+func TestTopicWriterWithManualPartitionSelect(t *testing.T) {
+	ctx := xtest.Context(t)
+	db := connect(t)
+	topicPath := createTopic(ctx, t, db)
+
+	writer, err := db.Topic().StartWriter(
+		"producer-id",
+		topicPath,
+		topicoptions.WithPartitionID(0),
+		topicoptions.WithSyncWrite(true),
+	)
+	require.NoError(t, err)
+	err = writer.Write(ctx, topicwriter.Message{Data: strings.NewReader("asd")})
+	require.NoError(t, err)
+}
+
 var topicCounter int
 
 func createTopic(ctx context.Context, t testing.TB, db ydb.Connection) (topicPath string) {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Deny start writer with partition number instead of message group id with error "ydb: producer id not equal to message group id, use option WithMessageGroupID(producerID) for create writer"

## What is the new behavior?
Allow set partition number to writer
