### PR TITLE
* Changed default output stream of internal logger to `io.Stderr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 * Renamed private `ydb.connection` type to public `ydb.Driver` type
 * Marked as deprecated `ydb.Connection` interface
 * Changed result type of `ydb.Open` from `ydb.Connection` interface to `*ydb.Driver`
+* Changed default output stream of internal logger to `io.Stderr`
+* Marked as deprecated `ydb.WithErrWriter(w)` and `ydb.WithOutWriter(w)` logger options
+* Added `ydb.WithWriter(w)` logger option
 
 ## v3.42.11
 * Fixed validation error for topicoptions.WithPartitionID option of start topic writer.

--- a/internal/logger/log.go
+++ b/internal/logger/log.go
@@ -21,16 +21,14 @@ type logger struct {
 	namespace string
 	minLevel  level.Level
 	coloring  bool
-	out       io.Writer
-	err       io.Writer
+	w         io.Writer
 }
 
 func New(opts ...Option) *logger {
 	l := &logger{
 		minLevel: level.INFO,
 		coloring: false,
-		out:      os.Stdout,
-		err:      os.Stderr,
+		w:        os.Stderr,
 	}
 	for _, o := range opts {
 		if o != nil {
@@ -70,7 +68,7 @@ func (l *logger) Tracef(format string, args ...interface{}) {
 	if l.external != nil {
 		l.external.Tracef(l.format(format, level.TRACE), args...)
 	} else {
-		fmt.Fprintf(l.out, l.format(format, level.TRACE), args...)
+		fmt.Fprintf(l.w, l.format(format, level.TRACE), args...)
 	}
 }
 
@@ -81,7 +79,7 @@ func (l *logger) Debugf(format string, args ...interface{}) {
 	if l.external != nil {
 		l.external.Debugf(l.format(format, level.DEBUG), args...)
 	} else {
-		fmt.Fprintf(l.out, l.format(format, level.DEBUG), args...)
+		fmt.Fprintf(l.w, l.format(format, level.DEBUG), args...)
 	}
 }
 
@@ -92,7 +90,7 @@ func (l *logger) Infof(format string, args ...interface{}) {
 	if l.external != nil {
 		l.external.Infof(l.format(format, level.INFO), args...)
 	} else {
-		fmt.Fprintf(l.out, l.format(format, level.INFO), args...)
+		fmt.Fprintf(l.w, l.format(format, level.INFO), args...)
 	}
 }
 
@@ -103,7 +101,7 @@ func (l *logger) Warnf(format string, args ...interface{}) {
 	if l.external != nil {
 		l.external.Warnf(l.format(format, level.WARN), args...)
 	} else {
-		fmt.Fprintf(l.out, l.format(format, level.WARN), args...)
+		fmt.Fprintf(l.w, l.format(format, level.WARN), args...)
 	}
 }
 
@@ -114,7 +112,7 @@ func (l *logger) Errorf(format string, args ...interface{}) {
 	if l.external != nil {
 		l.external.Errorf(l.format(format, level.ERROR), args...)
 	} else {
-		fmt.Fprintf(l.err, l.format(format, level.ERROR), args...)
+		fmt.Fprintf(l.w, l.format(format, level.ERROR), args...)
 	}
 }
 
@@ -125,7 +123,7 @@ func (l *logger) Fatalf(format string, args ...interface{}) {
 	if l.external != nil {
 		l.external.Fatalf(l.format(format, level.FATAL), args...)
 	} else {
-		fmt.Fprintf(l.err, l.format(format, level.FATAL), args...)
+		fmt.Fprintf(l.w, l.format(format, level.FATAL), args...)
 	}
 }
 
@@ -142,8 +140,7 @@ func join(a, b string) string {
 func (l *logger) WithName(name string) log.Logger {
 	return &logger{
 		external:  l.external,
-		out:       l.out,
-		err:       l.err,
+		w:         l.w,
 		namespace: join(l.namespace, name),
 		minLevel:  l.minLevel,
 		coloring:  l.coloring,

--- a/internal/logger/options.go
+++ b/internal/logger/options.go
@@ -37,14 +37,8 @@ func WithExternalLogger(external log.Logger) Option {
 	}
 }
 
-func WithOutWriter(out io.Writer) Option {
+func WithWriter(w io.Writer) Option {
 	return func(l *logger) {
-		l.out = out
-	}
-}
-
-func WithErrWriter(err io.Writer) Option {
-	return func(l *logger) {
-		l.err = err
+		l.w = w
 	}
 }

--- a/logger_options.go
+++ b/logger_options.go
@@ -33,10 +33,21 @@ func WithExternalLogger(external log.Logger) LoggerOption {
 	return LoggerOption(logger.WithExternalLogger(external))
 }
 
-func WithOutWriter(out io.Writer) LoggerOption {
-	return LoggerOption(logger.WithOutWriter(out))
+// WithOutWriter specified writer stream for internal logger
+//
+// Deprecated: use WithWriter instead
+func WithOutWriter(w io.Writer) LoggerOption {
+	return LoggerOption(logger.WithWriter(w))
 }
 
-func WithErrWriter(err io.Writer) LoggerOption {
-	return LoggerOption(logger.WithErrWriter(err))
+// WithErrWriter specified writer stream for internal logger error messages
+//
+// Deprecated: use WithWriter instead
+func WithErrWriter(io.Writer) LoggerOption {
+	return LoggerOption(logger.Nop())
+}
+
+// WithWriter specified writer stream for internal logger
+func WithWriter(w io.Writer) LoggerOption {
+	return LoggerOption(logger.WithWriter(w))
 }

--- a/tests/integration/connection_test.go
+++ b/tests/integration/connection_test.go
@@ -82,8 +82,7 @@ func TestConnection(t *testing.T) {
 		ydb.WithLogger(
 			trace.MatchDetails(`ydb\.(driver|discovery|retry|scheme).*`),
 			ydb.WithNamespace("ydb"),
-			ydb.WithOutWriter(logger),
-			ydb.WithErrWriter(logger),
+			ydb.WithWriter(logger),
 			ydb.WithMinLevel(log.WARN),
 		),
 		ydb.WithUserAgent(userAgent),

--- a/tests/integration/discovery_test.go
+++ b/tests/integration/discovery_test.go
@@ -71,8 +71,7 @@ func TestDiscovery(t *testing.T) {
 		ydb.WithLogger(
 			trace.MatchDetails(`ydb\.(driver|discovery|repeater).*`),
 			ydb.WithNamespace("ydb"),
-			ydb.WithOutWriter(logger),
-			ydb.WithErrWriter(logger),
+			ydb.WithWriter(logger),
 			ydb.WithMinLevel(log.WARN),
 			ydb.WithColoring(),
 		),

--- a/tests/integration/ratelimiter_test.go
+++ b/tests/integration/ratelimiter_test.go
@@ -43,8 +43,7 @@ func TestRatelimiter(t *testing.T) {
 		ydb.WithLogger(
 			trace.MatchDetails(`ydb\.(driver|discovery|retry|ratelimiter|coordination).*`),
 			ydb.WithNamespace("ydb"),
-			ydb.WithOutWriter(logger),
-			ydb.WithErrWriter(logger),
+			ydb.WithWriter(logger),
 			ydb.WithMinLevel(log.WARN),
 		),
 	)

--- a/tests/integration/scripting_test.go
+++ b/tests/integration/scripting_test.go
@@ -46,8 +46,7 @@ func TestScripting(t *testing.T) {
 		ydb.WithLogger(
 			trace.MatchDetails(`ydb\.(driver|discovery|retry|scheme).*`),
 			ydb.WithNamespace("ydb"),
-			ydb.WithOutWriter(logger),
-			ydb.WithErrWriter(logger),
+			ydb.WithWriter(logger),
 			ydb.WithMinLevel(log.TRACE),
 		),
 		ydb.WithUserAgent("scripting"),

--- a/tests/integration/table_bulk_upsert_test.go
+++ b/tests/integration/table_bulk_upsert_test.go
@@ -127,8 +127,7 @@ func TestTableBulkUpsert(t *testing.T) {
 		ydb.WithLogger(
 			trace.MatchDetails(`ydb\.(driver|discovery|retry|scheme).*`),
 			ydb.WithNamespace("ydb"),
-			ydb.WithOutWriter(logger),
-			ydb.WithErrWriter(logger),
+			ydb.WithWriter(logger),
 			ydb.WithMinLevel(log.TRACE),
 		),
 	)

--- a/tests/integration/table_create_table_description_test.go
+++ b/tests/integration/table_create_table_description_test.go
@@ -34,8 +34,7 @@ func TestCreateTableDescription(t *testing.T) {
 		ydb.WithLogger(
 			trace.MatchDetails(`ydb\.(driver|discovery|retry|scheme).*`),
 			ydb.WithNamespace("ydb"),
-			ydb.WithOutWriter(logger),
-			ydb.WithErrWriter(logger),
+			ydb.WithWriter(logger),
 			ydb.WithMinLevel(log.WARN),
 		),
 	)

--- a/tests/integration/table_long_stream_test.go
+++ b/tests/integration/table_long_stream_test.go
@@ -48,8 +48,7 @@ func TestLongStream(t *testing.T) {
 		ydb.WithLogger(
 			trace.MatchDetails(`ydb\.(driver|discovery|retry|scheme).*`),
 			ydb.WithNamespace("ydb"),
-			ydb.WithOutWriter(logger),
-			ydb.WithErrWriter(logger),
+			ydb.WithWriter(logger),
 			ydb.WithMinLevel(log.TRACE),
 		),
 	)

--- a/tests/integration/table_multiple_result_sets_test.go
+++ b/tests/integration/table_multiple_result_sets_test.go
@@ -51,8 +51,7 @@ func TestTableMultipleResultSets(t *testing.T) {
 		ydb.WithLogger(
 			trace.MatchDetails(`ydb\.(driver|discovery|retry|scheme).*`),
 			ydb.WithNamespace("ydb"),
-			ydb.WithOutWriter(logger),
-			ydb.WithErrWriter(logger),
+			ydb.WithWriter(logger),
 			ydb.WithMinLevel(log.TRACE),
 		),
 	)

--- a/tests/integration/table_test.go
+++ b/tests/integration/table_test.go
@@ -311,8 +311,7 @@ func TestTable(t *testing.T) { //nolint:gocyclo
 		ydb.WithLogger(
 			trace.MatchDetails(`ydb\.(driver|table|discovery|retry|scheme).*`),
 			ydb.WithNamespace("ydb"),
-			ydb.WithOutWriter(logger),
-			ydb.WithErrWriter(logger),
+			ydb.WithWriter(logger),
 			ydb.WithMinLevel(log.WARN),
 		),
 		ydb.WithPanicCallback(func(e interface{}) {

--- a/tests/integration/topic_read_writer_test.go
+++ b/tests/integration/topic_read_writer_test.go
@@ -140,8 +140,7 @@ func TestManyConcurentReadersWriters(t *testing.T) {
 	logger := xtest.Logger(tb)
 	db := connect(tb, ydb.WithLogger(trace.DetailsAll,
 		ydb.WithMinLevel(log.TRACE),
-		ydb.WithOutWriter(logger),
-		ydb.WithErrWriter(logger),
+		ydb.WithWriter(logger),
 	))
 
 	// create topic


### PR DESCRIPTION
* Marked as deprecated `ydb.WithErrWriter(w)` and `ydb.WithOutWriter(w)` logger options
* Added `ydb.WithWriter(w)` logger option

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
