### PR TITLE
* Replaced the balancer connection to discovery service from short-li…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* Replaced the balancer connection to discovery service from short-lived grpc connection to `internal/conn` lazy connection (revert related changes from `v3.42.6`)
+* Marked as deprecated `trace.Driver.OnBalancerDialEntrypoint` event callback
+
 ## v3.42.11
 * Fixed validation error for topicoptions.WithPartitionID option of start topic writer.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 * Replaced the balancer connection to discovery service from short-lived grpc connection to `internal/conn` lazy connection (revert related changes from `v3.42.6`)
 * Marked as deprecated `trace.Driver.OnBalancerDialEntrypoint` event callback
+* Deprecated `trace.Driver.OnConnTake` event callback
+* Added `trace.Driver.OnConnDial` event callback
 
 ## v3.42.11
 * Fixed validation error for topicoptions.WithPartitionID option of start topic writer.

--- a/internal/balancer/local_dc_test.go
+++ b/internal/balancer/local_dc_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/balancers"
 	"github.com/ydb-platform/ydb-go-sdk/v3/config"
-	"github.com/ydb-platform/ydb-go-sdk/v3/discovery"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/conn"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/endpoint"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/mock"
@@ -29,10 +28,6 @@ func (d discoveryMock) Close(ctx context.Context) error {
 
 func (d discoveryMock) Discover(ctx context.Context) ([]endpoint.Endpoint, error) {
 	return d.endpoints, nil
-}
-
-func (d discoveryMock) WhoAmI(ctx context.Context) (*discovery.WhoAmI, error) {
-	panic("not implemented")
 }
 
 func TestCheckFastestAddress(t *testing.T) {
@@ -142,13 +137,11 @@ func TestLocalDCDiscovery(t *testing.T) {
 		driverConfig:   cfg,
 		balancerConfig: *cfg.Balancer(),
 		pool:           conn.NewPool(cfg),
-		discoveryClient: func(context.Context, string) (discoveryClient, error) {
-			return discoveryMock{endpoints: []endpoint.Endpoint{
-				&mock.Endpoint{AddrField: "a:123", LocationField: "a"},
-				&mock.Endpoint{AddrField: "b:234", LocationField: "b"},
-				&mock.Endpoint{AddrField: "c:456", LocationField: "c"},
-			}}, nil
-		},
+		discoveryClient: discoveryMock{endpoints: []endpoint.Endpoint{
+			&mock.Endpoint{AddrField: "a:123", LocationField: "a"},
+			&mock.Endpoint{AddrField: "b:234", LocationField: "b"},
+			&mock.Endpoint{AddrField: "c:456", LocationField: "c"},
+		}},
 		localDCDetector: func(ctx context.Context, endpoints []endpoint.Endpoint) (string, error) {
 			return "b", nil
 		},

--- a/log/driver.go
+++ b/log/driver.go
@@ -101,20 +101,20 @@ func Driver(l Logger, details trace.Details) (t trace.Driver) {
 	if details&trace.DriverConnEvents != 0 {
 		//nolint:govet
 		l := l.WithName(`conn`)
-		t.OnConnTake = func(info trace.DriverConnTakeStartInfo) func(trace.DriverConnTakeDoneInfo) {
+		t.OnConnDial = func(info trace.DriverConnDialStartInfo) func(trace.DriverConnDialDoneInfo) {
 			endpoint := info.Endpoint.String()
-			l.Tracef(`take start {endpoint:%v}`,
+			l.Tracef(`dial start {endpoint:%v}`,
 				endpoint,
 			)
 			start := time.Now()
-			return func(info trace.DriverConnTakeDoneInfo) {
+			return func(info trace.DriverConnDialDoneInfo) {
 				if info.Error == nil {
-					l.Tracef(`take done {endpoint:%v,latency:"%v"}`,
+					l.Tracef(`dial done {endpoint:%v,latency:"%v"}`,
 						endpoint,
 						time.Since(start),
 					)
 				} else {
-					l.Warnf(`take failed {endpoint:%v,latency:"%v",error:"%s",version:"%s"}`,
+					l.Warnf(`dial failed {endpoint:%v,latency:"%v",error:"%s",version:"%s"}`,
 						endpoint,
 						time.Since(start),
 						info.Error,

--- a/log/driver.go
+++ b/log/driver.go
@@ -378,27 +378,6 @@ func Driver(l Logger, details trace.Details) (t trace.Driver) {
 				}
 			}
 		}
-		t.OnBalancerDialEntrypoint = func(
-			info trace.DriverBalancerDialEntrypointStartInfo,
-		) func(
-			trace.DriverBalancerDialEntrypointDoneInfo,
-		) {
-			l.Tracef(`trying to dial entrypoint {address:"%s"}`, info.Address)
-			start := time.Now()
-			return func(info trace.DriverBalancerDialEntrypointDoneInfo) {
-				if info.Error == nil {
-					l.Tracef(`dial entrypoint done {latency:"%v"}`,
-						time.Since(start),
-					)
-				} else {
-					l.Errorf(`dial entrypoint failed {latency:"%v",error:"%s",version:"%s"}`,
-						time.Since(start),
-						info.Error,
-						meta.Version,
-					)
-				}
-			}
-		}
 		t.OnBalancerClusterDiscoveryAttempt = func(
 			info trace.DriverBalancerClusterDiscoveryAttemptStartInfo,
 		) func(

--- a/trace/driver.go
+++ b/trace/driver.go
@@ -43,6 +43,7 @@ type (
 		)
 		// Deprecated: driver not notificate about this event
 		OnConnTake  func(DriverConnTakeStartInfo) func(DriverConnTakeDoneInfo)
+		OnConnDial  func(DriverConnDialStartInfo) func(DriverConnDialDoneInfo)
 		OnConnPark  func(DriverConnParkStartInfo) func(DriverConnParkDoneInfo)
 		OnConnBan   func(DriverConnBanStartInfo) func(DriverConnBanDoneInfo)
 		OnConnAllow func(DriverConnAllowStartInfo) func(DriverConnAllowDoneInfo)
@@ -209,6 +210,17 @@ type (
 		Endpoint EndpointInfo
 	}
 	DriverConnTakeDoneInfo struct {
+		Error error
+	}
+	DriverConnDialStartInfo struct {
+		// Context make available context in trace callback function.
+		// Pointer to context provide replacement of context in trace callback function.
+		// Warning: concurrent access to pointer on client side must be excluded.
+		// Safe replacement of context are provided only inside callback function
+		Context  *context.Context
+		Endpoint EndpointInfo
+	}
+	DriverConnDialDoneInfo struct {
 		Error error
 	}
 	DriverConnParkStartInfo struct {

--- a/trace/driver.go
+++ b/trace/driver.go
@@ -19,14 +19,13 @@ type (
 		OnInit  func(DriverInitStartInfo) func(DriverInitDoneInfo)
 		OnClose func(DriverCloseStartInfo) func(DriverCloseDoneInfo)
 
-		// Network events
-		// Deprecated: driver not support logging of net events
+		// Deprecated: driver not notificate about this event
 		OnNetRead func(DriverNetReadStartInfo) func(DriverNetReadDoneInfo)
-		// Deprecated: driver not support logging of net events
+		// Deprecated: driver not notificate about this event
 		OnNetWrite func(DriverNetWriteStartInfo) func(DriverNetWriteDoneInfo)
-		// Deprecated: driver not support logging of net events
+		// Deprecated: driver not notificate about this event
 		OnNetDial func(DriverNetDialStartInfo) func(DriverNetDialDoneInfo)
-		// Deprecated: driver not support logging of net events
+		// Deprecated: driver not notificate about this event
 		OnNetClose func(DriverNetCloseStartInfo) func(DriverNetCloseDoneInfo)
 
 		// Resolver events
@@ -42,6 +41,7 @@ type (
 		) func(
 			DriverConnNewStreamDoneInfo,
 		)
+		// Deprecated: driver not notificate about this event
 		OnConnTake  func(DriverConnTakeStartInfo) func(DriverConnTakeDoneInfo)
 		OnConnPark  func(DriverConnParkStartInfo) func(DriverConnParkDoneInfo)
 		OnConnBan   func(DriverConnBanStartInfo) func(DriverConnBanDoneInfo)
@@ -52,7 +52,9 @@ type (
 		OnRepeaterWakeUp func(DriverRepeaterWakeUpStartInfo) func(DriverRepeaterWakeUpDoneInfo)
 
 		// Balancer events
-		OnBalancerInit           func(DriverBalancerInitStartInfo) func(DriverBalancerInitDoneInfo)
+		OnBalancerInit func(DriverBalancerInitStartInfo) func(DriverBalancerInitDoneInfo)
+
+		// Deprecated: driver not notificate about this event
 		OnBalancerDialEntrypoint func(
 			DriverBalancerDialEntrypointStartInfo,
 		) func(


### PR DESCRIPTION
…ved grpc connection to `internal/conn` lazy connection (revert related changes from `v3.42.6`)

* Marked as deprecated `trace.Driver.OnBalancerDialEntrypoint` event callback

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
