### PR TITLE
topic api changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* BROKEN CHANGE in experimantal topic api: producer id on start writer now is optional
+* BROKEN CHANGE in experimantal topic api: remove WithMessageGroupID option (because not supported now)
+
 ## v3.42.12
 * Replaced the balancer connection to discovery service from short-lived grpc connection to `internal/conn` lazy connection (revert related changes from `v3.42.6`)
 * Marked as deprecated `trace.Driver.OnBalancerDialEntrypoint` event callback
@@ -8,7 +11,7 @@
 * Fixed validation error for topicoptions.WithPartitionID option of start topic writer.
 
 ## v3.42.10
-* Added exit from retryer if got grpc-error `Unauthenticated` on `discovery/ListEndpoints` call  
+* Added exit from retryer if got grpc-error `Unauthenticated` on `discovery/ListEndpoints` call
 
 ## v3.42.9
 * Added `internal/xerrors.Errorf` error for wrap multiple errors and check them with `errors.Is` of `errors.As`

--- a/internal/topic/topicclientinternal/client.go
+++ b/internal/topic/topicclientinternal/client.go
@@ -224,7 +224,7 @@ func (c *Client) StartReader(
 // # Experimental
 //
 // Notice: This API is EXPERIMENTAL and may be changed or removed in a later release.
-func (c *Client) StartWriter(producerID, path string, opts ...topicoptions.WriterOption) (*topicwriter.Writer, error) {
+func (c *Client) StartWriter(topicPath string, opts ...topicoptions.WriterOption) (*topicwriter.Writer, error) {
 	var connector topicwriterinternal.ConnectFunc = func(ctx context.Context) (
 		topicwriterinternal.RawTopicWriterStream,
 		error,
@@ -234,8 +234,7 @@ func (c *Client) StartWriter(producerID, path string, opts ...topicoptions.Write
 
 	options := []topicoptions.WriterOption{
 		topicwriterinternal.WithConnectFunc(connector),
-		topicwriterinternal.WithTopic(path),
-		topicwriterinternal.WithProducerID(producerID),
+		topicwriterinternal.WithTopic(topicPath),
 		topicwriterinternal.WithCommonConfig(c.cfg.Common),
 		topicwriterinternal.WithTrace(c.cfg.Trace),
 	}

--- a/internal/topic/topicwriterinternal/writer_options.go
+++ b/internal/topic/topicwriterinternal/writer_options.go
@@ -1,6 +1,7 @@
 package topicwriterinternal
 
 import (
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawtopic/rawtopicwriter"
 	"time"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/credentials"
@@ -109,6 +110,11 @@ func WithPartitioning(partitioning PublicFuturePartitioning) PublicWriterOption 
 func WithProducerID(producerID string) PublicWriterOption {
 	return func(cfg *WriterReconnectorConfig) {
 		cfg.producerID = producerID
+		oldPartitioningType := cfg.defaultPartitioning.Type
+		if oldPartitioningType == rawtopicwriter.PartitioningUndefined ||
+			oldPartitioningType == rawtopicwriter.PartitioningMessageGroupID {
+			WithPartitioning(NewPartitioningWithMessageGroupID(producerID))(cfg)
+		}
 	}
 }
 

--- a/internal/topic/topicwriterinternal/writer_options.go
+++ b/internal/topic/topicwriterinternal/writer_options.go
@@ -1,12 +1,12 @@
 package topicwriterinternal
 
 import (
-	"github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawtopic/rawtopicwriter"
 	"time"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/credentials"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/config"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawtopic/rawtopiccommon"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawtopic/rawtopicwriter"
 	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
 )
 

--- a/internal/topic/topicwriterinternal/writer_reconnector.go
+++ b/internal/topic/topicwriterinternal/writer_reconnector.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"github.com/google/uuid"
 	"math"
 	"math/big"
 	"runtime"
@@ -100,8 +101,13 @@ func newWriterReconnectorConfig(options ...PublicWriterOption) WriterReconnector
 	if cfg.connectTimeout == 0 {
 		cfg.connectTimeout = cfg.Common.OperationTimeout()
 	}
+
 	if cfg.connectTimeout == 0 {
 		cfg.connectTimeout = value.InfiniteDuration
+	}
+
+	if cfg.producerID == "" {
+		WithProducerID(uuid.NewString())(&cfg)
 	}
 
 	return cfg

--- a/internal/topic/topicwriterinternal/writer_reconnector.go
+++ b/internal/topic/topicwriterinternal/writer_reconnector.go
@@ -5,12 +5,12 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
-	"github.com/google/uuid"
 	"math"
 	"math/big"
 	"runtime"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/jonboulle/clockwork"
 	"golang.org/x/sync/semaphore"
 

--- a/tests/integration/topic_stress_test.go
+++ b/tests/integration/topic_stress_test.go
@@ -98,8 +98,8 @@ func stressTestInATopic(
 			wg.Done()
 		}()
 
-		writer, err := db.Topic().StartWriter(producerID, topicPath,
-			topicoptions.WithMessageGroupID(producerID),
+		writer, err := db.Topic().StartWriter(topicPath,
+			topicoptions.WithProducerID(producerID),
 			topicoptions.WithSyncWrite(true),
 		)
 		if err != nil {

--- a/topic/client.go
+++ b/topic/client.go
@@ -67,5 +67,5 @@ type Client interface {
 	//
 	// Notice: This API is EXPERIMENTAL and may be changed or removed in a
 	// later release.
-	StartWriter(producerID, path string, opts ...topicoptions.WriterOption) (*topicwriter.Writer, error)
+	StartWriter(topicPath string, opts ...topicoptions.WriterOption) (*topicwriter.Writer, error)
 }

--- a/topic/topicoptions/topicoptions_writer.go
+++ b/topic/topicoptions/topicoptions_writer.go
@@ -79,13 +79,13 @@ func WithWriteSessionMeta(meta map[string]string) WriterOption {
 	return topicwriterinternal.WithSessionMeta(meta)
 }
 
-// WithMessageGroupID set message groupid on write session level
+// WithProducerID set producer for write session
 //
 // # Experimental
 //
 // Notice: This API is EXPERIMENTAL and may be changed or removed in a later release.
-func WithMessageGroupID(groupID string) WriterOption {
-	return topicwriterinternal.WithPartitioning(topicwriterinternal.NewPartitioningWithMessageGroupID(groupID))
+func WithProducerID(producerID string) WriterOption {
+	return topicwriterinternal.WithProducerID(producerID)
 }
 
 // WithPartitionID set direct partition id on write session level

--- a/topic/topicoptions/topicoptions_writer_example_test.go
+++ b/topic/topicoptions/topicoptions_writer_example_test.go
@@ -9,7 +9,6 @@ func ExampleWithWriterCheckRetryErrorFunction() {
 	var db ydb.Connection
 	writer, err := db.Topic().StartWriter(
 		"",
-		"",
 		topicoptions.WithWriterCheckRetryErrorFunction(
 			func(errInfo topicoptions.CheckErrorRetryArgs) topicoptions.CheckErrorRetryResult {
 				// Retry for all transport errors

--- a/topic/topicwriter/topicwriter_test.go
+++ b/topic/topicwriter/topicwriter_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3"
-	"github.com/ydb-platform/ydb-go-sdk/v3/topic/topicoptions"
 	"github.com/ydb-platform/ydb-go-sdk/v3/topic/topicwriter"
 )
 
@@ -19,10 +18,7 @@ func ExampleWriter_Write() {
 		log.Fatalf("failed ydb connection: %v", err)
 	}
 
-	producerAndGroupID := "group-id"
-	writer, err := db.Topic().StartWriter(producerAndGroupID, "topicName",
-		topicoptions.WithMessageGroupID(producerAndGroupID),
-	)
+	writer, err := db.Topic().StartWriter("topicName")
 	if err != nil {
 		log.Fatalf("failed to create topic writer: %v", err)
 	}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
producer id must be as first parameter to start topic writer
WithMessageGroupID option id must be explicit set to equals with producer id

## What is the new behavior?
No need explicit set producer id
Option WithMessageGroupID was removed because difference ProducerID and MessageGroupID are not supported now.
Explicit set producerID available with option WithProducerID