### PR TITLE
* Fixed default state of `internal/xerrors.retryableError`: it inheri…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* Fixed default state of `internal/xerrors.retryableError`: it inherit properties from parent error as possible
+* Marked event `grpc/stats.End` as ignored at observing status of grpc connection
+
 ## v3.42.12
 * Replaced the balancer connection to discovery service from short-lived grpc connection to `internal/conn` lazy connection (revert related changes from `v3.42.6`)
 * Marked as deprecated `trace.Driver.OnBalancerDialEntrypoint` event callback

--- a/internal/xerrors/retryable.go
+++ b/internal/xerrors/retryable.go
@@ -62,9 +62,16 @@ func WithDeleteSession() RetryableErrorOption {
 }
 
 func Retryable(err error, opts ...RetryableErrorOption) error {
-	re := &retryableError{
-		err:  err,
-		name: "CUSTOM",
+	var (
+		e  Error
+		re = &retryableError{
+			err:  err,
+			name: "CUSTOM",
+		}
+	)
+	if As(err, &e) {
+		re.backoffType = e.BackoffType()
+		re.mustDeleteSession = e.MustDeleteSession()
 	}
 	for _, o := range opts {
 		if o != nil {


### PR DESCRIPTION
…t properties from parent error as possible

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
