### PR TITLE
* Fixed bug with parsing of `TzTimestamp` without microseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Fixed bug with parsing of `TzTimestamp` without microseconds
 * Fixed code -1 of retryable error if wrapped error with code
 * Added `ydb.WithCompression()` option
 * Added `ydb.MustOpen` and `ydb.MustConnector` helpers

--- a/internal/value/time.go
+++ b/internal/value/time.go
@@ -98,7 +98,11 @@ func TzTimestampToTime(s string) (t time.Time, err error) {
 	if err != nil {
 		return t, xerrors.WithStackTrace(err)
 	}
-	t, err = time.ParseInLocation(LayoutTzTimestamp, ss[0], location)
+	layout := LayoutTzTimestamp
+	if strings.IndexByte(ss[0], '.') < 0 {
+		layout = LayoutTzDatetime
+	}
+	t, err = time.ParseInLocation(layout, ss[0], location)
 	if err != nil {
 		return t, xerrors.WithStackTrace(fmt.Errorf("parse '%s' failed: %w", s, err))
 	}

--- a/internal/value/time_test.go
+++ b/internal/value/time_test.go
@@ -47,6 +47,17 @@ func TestTzSomeToTime(t *testing.T) {
 			),
 			TzTimestampToTime,
 		},
+		{
+			"TzTimestampToTime",
+			"2020-05-29T11:22:54,Europe/Berlin",
+			time.Date(2020, time.May, 29, 11, 22, 54, 0,
+				func() *time.Location {
+					l, _ := time.LoadLocation("Europe/Berlin")
+					return l
+				}(),
+			),
+			TzTimestampToTime,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			v, err := tt.converter(tt.src)

--- a/tests/integration/table_tz_timestamp_test.go
+++ b/tests/integration/table_tz_timestamp_test.go
@@ -1,0 +1,49 @@
+//go:build !fast
+// +build !fast
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3"
+	"github.com/ydb-platform/ydb-go-sdk/v3/table"
+)
+
+func TestTzTimestamp(t *testing.T) {
+	ctx := context.Background()
+	db, err := ydb.Open(ctx, os.Getenv("YDB_CONNECTION_STRING"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = db.Close(ctx)
+	}()
+	err = db.Table().DoTx(ctx, func(ctx context.Context, tx table.TransactionActor) (err error) {
+		microseconds := int64(1680021427000000)
+		res, err := tx.Execute(ctx, fmt.Sprintf(`SELECT CAST(CAST(%d AS Timestamp) AS TzTimestamp);`, microseconds), nil)
+		if err != nil {
+			return err
+		}
+		if err = res.NextResultSetErr(ctx); err != nil {
+			return err
+		}
+		if !res.NextRow() {
+			return fmt.Errorf("unexpected no rows in result set (err = %w)", res.Err())
+		}
+		var v *time.Time
+		if err = res.Scan(&v); err != nil {
+			return err
+		}
+		require.NotNil(t, v)
+		require.Equal(t, microseconds, v.UTC().UnixMicro())
+		return res.Err()
+	}, table.WithIdempotent())
+	require.NoError(t, err)
+}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
