### PR TITLE
issue-826: write to log offset ranges for OnReaderSendCommitMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Improved OnReaderSendCommitMessage logs
 * Added `table.Session.CopyTables` method
 * Added `x-ydb-trace-id` header into grpc calls
 * Improved topic reader logs

--- a/internal/topic/topicreaderinternal/commit_range.go
+++ b/internal/topic/topicreaderinternal/commit_range.go
@@ -24,10 +24,11 @@ func (r *CommitRanges) len() int {
 	return len(r.ranges)
 }
 
-func (r *CommitRanges) toTopicReaderStreamSendCommitMessageStartMessageInfo() []trace.TopicReaderStreamSendCommitMessageStartMessageInfo { //nolint:lll
-	res := make([]trace.TopicReaderStreamSendCommitMessageStartMessageInfo, len(r.ranges))
+func (r *CommitRanges) GetCommitedInfo() []trace.TopicReaderCommitStartInfo {
+	res := make([]trace.TopicReaderCommitStartInfo, len(r.ranges))
 	for i := range res {
-		res[i] = trace.TopicReaderStreamSendCommitMessageStartMessageInfo{
+		res[i] = trace.TopicReaderCommitStartInfo{
+			RequestContext:     r.ranges[i].partitionSession.ctx,
 			Topic:              r.ranges[i].partitionSession.Topic,
 			PartitionID:        r.ranges[i].partitionSession.PartitionID,
 			PartitionSessionID: r.ranges[i].partitionSession.partitionSessionID.ToInt64(),

--- a/internal/topic/topicreaderinternal/commit_range.go
+++ b/internal/topic/topicreaderinternal/commit_range.go
@@ -24,12 +24,11 @@ func (r *CommitRanges) len() int {
 	return len(r.ranges)
 }
 
-// GetCommitedInfo implements trace.TopicReaderStreamSendCommitMessageStartMessageInfo
-func (r *CommitRanges) GetCommitedInfo() []trace.TopicReaderCommitStartInfo {
-	res := make([]trace.TopicReaderCommitStartInfo, len(r.ranges))
+// GetCommitsInfo implements trace.TopicReaderStreamSendCommitMessageStartMessageInfo
+func (r *CommitRanges) GetCommitsInfo() []trace.TopicReaderStreamCommitInfo {
+	res := make([]trace.TopicReaderStreamCommitInfo, len(r.ranges))
 	for i := range res {
-		res[i] = trace.TopicReaderCommitStartInfo{
-			RequestContext:     r.ranges[i].partitionSession.ctx,
+		res[i] = trace.TopicReaderStreamCommitInfo{
 			Topic:              r.ranges[i].partitionSession.Topic,
 			PartitionID:        r.ranges[i].partitionSession.PartitionID,
 			PartitionSessionID: r.ranges[i].partitionSession.partitionSessionID.ToInt64(),

--- a/internal/topic/topicreaderinternal/commit_range.go
+++ b/internal/topic/topicreaderinternal/commit_range.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawtopic/rawtopicreader"
+	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
 )
 
 // PublicCommitRangeGetter return data piece for commit messages range
@@ -23,20 +24,16 @@ func (r *CommitRanges) len() int {
 	return len(r.ranges)
 }
 
-// PartitionIDs implements trace.TopicReaderStreamSendCommitMessageStartMessageInfo
-func (r *CommitRanges) PartitionIDs() []int64 {
-	res := make([]int64, len(r.ranges))
+func (r *CommitRanges) toTopicReaderStreamSendCommitMessageStartMessageInfo() []trace.TopicReaderStreamSendCommitMessageStartMessageInfo {
+	res := make([]trace.TopicReaderStreamSendCommitMessageStartMessageInfo, len(r.ranges))
 	for i := range res {
-		res[i] = r.ranges[i].partitionSession.PartitionID
-	}
-	return res
-}
-
-// PartitionSessionIDs implements trace.TopicReaderStreamSendCommitMessageStartMessageInfo
-func (r *CommitRanges) PartitionSessionIDs() []int64 {
-	res := make([]int64, len(r.ranges))
-	for i := range res {
-		res[i] = r.ranges[i].partitionSession.partitionSessionID.ToInt64()
+		res[i] = trace.TopicReaderStreamSendCommitMessageStartMessageInfo{
+			Topic:              r.ranges[i].partitionSession.Topic,
+			PartitionID:        r.ranges[i].partitionSession.PartitionID,
+			PartitionSessionID: r.ranges[i].partitionSession.partitionSessionID.ToInt64(),
+			StartOffset:        r.ranges[i].commitOffsetStart.ToInt64(),
+			EndOffset:          r.ranges[i].commitOffsetEnd.ToInt64(),
+		}
 	}
 	return res
 }

--- a/internal/topic/topicreaderinternal/commit_range.go
+++ b/internal/topic/topicreaderinternal/commit_range.go
@@ -24,6 +24,7 @@ func (r *CommitRanges) len() int {
 	return len(r.ranges)
 }
 
+// GetCommitedInfo implements trace.TopicReaderStreamSendCommitMessageStartMessageInfo
 func (r *CommitRanges) GetCommitedInfo() []trace.TopicReaderCommitStartInfo {
 	res := make([]trace.TopicReaderCommitStartInfo, len(r.ranges))
 	for i := range res {

--- a/internal/topic/topicreaderinternal/commit_range.go
+++ b/internal/topic/topicreaderinternal/commit_range.go
@@ -24,7 +24,7 @@ func (r *CommitRanges) len() int {
 	return len(r.ranges)
 }
 
-func (r *CommitRanges) toTopicReaderStreamSendCommitMessageStartMessageInfo() []trace.TopicReaderStreamSendCommitMessageStartMessageInfo {
+func (r *CommitRanges) toTopicReaderStreamSendCommitMessageStartMessageInfo() []trace.TopicReaderStreamSendCommitMessageStartMessageInfo { //nolint:lll
 	res := make([]trace.TopicReaderStreamSendCommitMessageStartMessageInfo, len(r.ranges))
 	for i := range res {
 		res[i] = trace.TopicReaderStreamSendCommitMessageStartMessageInfo{

--- a/internal/topic/topicreaderinternal/committer.go
+++ b/internal/topic/topicreaderinternal/committer.go
@@ -146,7 +146,7 @@ func (c *committer) pushCommitsLoop(ctx context.Context) {
 
 		onDone := trace.TopicOnReaderSendCommitMessage(
 			c.tracer,
-			commits.toTopicReaderStreamSendCommitMessageStartMessageInfo(),
+			&commits,
 		)
 		err := sendCommitMessage(c.send, commits)
 		onDone(err)

--- a/internal/topic/topicreaderinternal/committer.go
+++ b/internal/topic/topicreaderinternal/committer.go
@@ -144,7 +144,10 @@ func (c *committer) pushCommitsLoop(ctx context.Context) {
 
 		commits.optimize()
 
-		onDone := trace.TopicOnReaderSendCommitMessage(c.tracer, commits.toTopicReaderStreamSendCommitMessageStartMessageInfo())
+		onDone := trace.TopicOnReaderSendCommitMessage(
+			c.tracer,
+			commits.toTopicReaderStreamSendCommitMessageStartMessageInfo(),
+		)
 		err := sendCommitMessage(c.send, commits)
 		onDone(err)
 

--- a/internal/topic/topicreaderinternal/committer.go
+++ b/internal/topic/topicreaderinternal/committer.go
@@ -144,7 +144,7 @@ func (c *committer) pushCommitsLoop(ctx context.Context) {
 
 		commits.optimize()
 
-		onDone := trace.TopicOnReaderSendCommitMessage(c.tracer, &commits)
+		onDone := trace.TopicOnReaderSendCommitMessage(c.tracer, commits.toTopicReaderStreamSendCommitMessageStartMessageInfo())
 		err := sendCommitMessage(c.send, commits)
 		onDone(err)
 

--- a/log/topic.go
+++ b/log/topic.go
@@ -163,23 +163,23 @@ func internalTopic(l *wrapper, d trace.Detailer) (t trace.Topic) { //nolint:gocy
 		ctx := with(context.Background(), TRACE, "ydb", "topic", "reader", "send", "commit", "message")
 		start := time.Now()
 
-		for _, commitInfo := range info.CommitsInfo {
+		for i := range info.CommitsInfo {
 			l.Log(ctx, "start",
-				String("topic", commitInfo.Topic),
-				Int64("partitions_id", commitInfo.PartitionID),
-				Int64("partitions_session_id", commitInfo.PartitionSessionID),
-				Int64("commit_start_offset", commitInfo.StartOffset),
-				Int64("commit_end_offset", commitInfo.EndOffset),
+				String("topic", info.CommitsInfo[i].Topic),
+				Int64("partitions_id", info.CommitsInfo[i].PartitionID),
+				Int64("partitions_session_id", info.CommitsInfo[i].PartitionSessionID),
+				Int64("commit_start_offset", info.CommitsInfo[i].StartOffset),
+				Int64("commit_end_offset", info.CommitsInfo[i].EndOffset),
 			)
 		}
 		return func(doneInfo trace.TopicReaderSendCommitMessageDoneInfo) {
-			for _, commitInfo := range info.CommitsInfo {
+			for i := range info.CommitsInfo {
 				fields := []Field{
-					String("topic", commitInfo.Topic),
-					Int64("partitions_id", commitInfo.PartitionID),
-					Int64("partitions_session_id", commitInfo.PartitionSessionID),
-					Int64("commit_start_offset", commitInfo.StartOffset),
-					Int64("commit_end_offset", commitInfo.EndOffset),
+					String("topic", info.CommitsInfo[i].Topic),
+					Int64("partitions_id", info.CommitsInfo[i].PartitionID),
+					Int64("partitions_session_id", info.CommitsInfo[i].PartitionSessionID),
+					Int64("commit_start_offset", info.CommitsInfo[i].StartOffset),
+					Int64("commit_end_offset", info.CommitsInfo[i].EndOffset),
 					latencyField(start),
 				}
 				if doneInfo.Error == nil {

--- a/log/topic.go
+++ b/log/topic.go
@@ -163,23 +163,24 @@ func internalTopic(l *wrapper, d trace.Detailer) (t trace.Topic) { //nolint:gocy
 		ctx := with(context.Background(), TRACE, "ydb", "topic", "reader", "send", "commit", "message")
 		start := time.Now()
 
-		for i := range info.CommitsInfo {
+		commitedInfo := info.CommitsInfo.GetCommitedInfo()
+		for i := range commitedInfo {
 			l.Log(ctx, "start",
-				String("topic", info.CommitsInfo[i].Topic),
-				Int64("partitions_id", info.CommitsInfo[i].PartitionID),
-				Int64("partitions_session_id", info.CommitsInfo[i].PartitionSessionID),
-				Int64("commit_start_offset", info.CommitsInfo[i].StartOffset),
-				Int64("commit_end_offset", info.CommitsInfo[i].EndOffset),
+				String("topic", commitedInfo[i].Topic),
+				Int64("partitions_id", commitedInfo[i].PartitionID),
+				Int64("partitions_session_id", commitedInfo[i].PartitionSessionID),
+				Int64("commit_start_offset", commitedInfo[i].StartOffset),
+				Int64("commit_end_offset", commitedInfo[i].EndOffset),
 			)
 		}
 		return func(doneInfo trace.TopicReaderSendCommitMessageDoneInfo) {
-			for i := range info.CommitsInfo {
+			for i := range commitedInfo {
 				fields := []Field{
-					String("topic", info.CommitsInfo[i].Topic),
-					Int64("partitions_id", info.CommitsInfo[i].PartitionID),
-					Int64("partitions_session_id", info.CommitsInfo[i].PartitionSessionID),
-					Int64("commit_start_offset", info.CommitsInfo[i].StartOffset),
-					Int64("commit_end_offset", info.CommitsInfo[i].EndOffset),
+					String("topic", commitedInfo[i].Topic),
+					Int64("partitions_id", commitedInfo[i].PartitionID),
+					Int64("partitions_session_id", commitedInfo[i].PartitionSessionID),
+					Int64("commit_start_offset", commitedInfo[i].StartOffset),
+					Int64("commit_end_offset", commitedInfo[i].EndOffset),
 					latencyField(start),
 				}
 				if doneInfo.Error == nil {

--- a/log/topic.go
+++ b/log/topic.go
@@ -163,24 +163,24 @@ func internalTopic(l *wrapper, d trace.Detailer) (t trace.Topic) { //nolint:gocy
 		ctx := with(context.Background(), TRACE, "ydb", "topic", "reader", "send", "commit", "message")
 		start := time.Now()
 
-		commitedInfo := info.CommitsInfo.GetCommitedInfo()
-		for i := range commitedInfo {
+		commitInfo := info.CommitsInfo.GetCommitsInfo()
+		for i := range commitInfo {
 			l.Log(ctx, "start",
-				String("topic", commitedInfo[i].Topic),
-				Int64("partitions_id", commitedInfo[i].PartitionID),
-				Int64("partitions_session_id", commitedInfo[i].PartitionSessionID),
-				Int64("commit_start_offset", commitedInfo[i].StartOffset),
-				Int64("commit_end_offset", commitedInfo[i].EndOffset),
+				String("topic", commitInfo[i].Topic),
+				Int64("partitions_id", commitInfo[i].PartitionID),
+				Int64("partitions_session_id", commitInfo[i].PartitionSessionID),
+				Int64("commit_start_offset", commitInfo[i].StartOffset),
+				Int64("commit_end_offset", commitInfo[i].EndOffset),
 			)
 		}
 		return func(doneInfo trace.TopicReaderSendCommitMessageDoneInfo) {
-			for i := range commitedInfo {
+			for i := range commitInfo {
 				fields := []Field{
-					String("topic", commitedInfo[i].Topic),
-					Int64("partitions_id", commitedInfo[i].PartitionID),
-					Int64("partitions_session_id", commitedInfo[i].PartitionSessionID),
-					Int64("commit_start_offset", commitedInfo[i].StartOffset),
-					Int64("commit_end_offset", commitedInfo[i].EndOffset),
+					String("topic", commitInfo[i].Topic),
+					Int64("partitions_id", commitInfo[i].PartitionID),
+					Int64("partitions_session_id", commitInfo[i].PartitionSessionID),
+					Int64("commit_start_offset", commitInfo[i].StartOffset),
+					Int64("commit_end_offset", commitInfo[i].EndOffset),
 					latencyField(start),
 				}
 				if doneInfo.Error == nil {

--- a/trace/topic.go
+++ b/trace/topic.go
@@ -134,7 +134,7 @@ type (
 	// Notice: This API is EXPERIMENTAL and may be changed or removed in a
 	// later release.
 	TopicReaderSendCommitMessageStartInfo struct {
-		CommitsInfo []TopicReaderStreamSendCommitMessageStartMessageInfo
+		CommitsInfo TopicReaderStreamSendCommitMessageStartMessageInfo
 	}
 
 	// TopicReaderStreamSendCommitMessageStartMessageInfo
@@ -143,12 +143,8 @@ type (
 	//
 	// Notice: This API is EXPERIMENTAL and may be changed or removed in a
 	// later release.
-	TopicReaderStreamSendCommitMessageStartMessageInfo struct {
-		Topic              string
-		PartitionID        int64
-		PartitionSessionID int64
-		StartOffset        int64
-		EndOffset          int64
+	TopicReaderStreamSendCommitMessageStartMessageInfo interface {
+		GetCommitedInfo() []TopicReaderCommitStartInfo
 	}
 
 	// TopicReaderSendCommitMessageDoneInfo

--- a/trace/topic.go
+++ b/trace/topic.go
@@ -134,8 +134,7 @@ type (
 	// Notice: This API is EXPERIMENTAL and may be changed or removed in a
 	// later release.
 	TopicReaderSendCommitMessageStartInfo struct {
-		// ReaderConnectionID string unimplemented yet - need some internal changes
-		CommitsInfo TopicReaderStreamSendCommitMessageStartMessageInfo
+		CommitsInfo []TopicReaderStreamSendCommitMessageStartMessageInfo
 	}
 
 	// TopicReaderStreamSendCommitMessageStartMessageInfo
@@ -144,9 +143,12 @@ type (
 	//
 	// Notice: This API is EXPERIMENTAL and may be changed or removed in a
 	// later release.
-	TopicReaderStreamSendCommitMessageStartMessageInfo interface {
-		PartitionIDs() []int64
-		PartitionSessionIDs() []int64
+	TopicReaderStreamSendCommitMessageStartMessageInfo struct {
+		Topic              string
+		PartitionID        int64
+		PartitionSessionID int64
+		StartOffset        int64
+		EndOffset          int64
 	}
 
 	// TopicReaderSendCommitMessageDoneInfo

--- a/trace/topic.go
+++ b/trace/topic.go
@@ -137,6 +137,20 @@ type (
 		CommitsInfo TopicReaderStreamSendCommitMessageStartMessageInfo
 	}
 
+	// TopicReaderStreamCommitInfo
+	//
+	// Experimental
+	//
+	// Notice: This API is EXPERIMENTAL and may be changed or removed in a
+	// later release.
+	TopicReaderStreamCommitInfo struct {
+		Topic              string
+		PartitionID        int64
+		PartitionSessionID int64
+		StartOffset        int64
+		EndOffset          int64
+	}
+
 	// TopicReaderStreamSendCommitMessageStartMessageInfo
 	//
 	// Experimental
@@ -144,7 +158,7 @@ type (
 	// Notice: This API is EXPERIMENTAL and may be changed or removed in a
 	// later release.
 	TopicReaderStreamSendCommitMessageStartMessageInfo interface {
-		GetCommitedInfo() []TopicReaderCommitStartInfo
+		GetCommitsInfo() []TopicReaderStreamCommitInfo
 	}
 
 	// TopicReaderSendCommitMessageDoneInfo

--- a/trace/topic_gtrace.go
+++ b/trace/topic_gtrace.go
@@ -1061,7 +1061,7 @@ func TopicOnReaderCommit(t *Topic, requestContext context.Context, topic string,
 		res(p)
 	}
 }
-func TopicOnReaderSendCommitMessage(t *Topic, commitsInfo []TopicReaderStreamSendCommitMessageStartMessageInfo) func(error) {
+func TopicOnReaderSendCommitMessage(t *Topic, commitsInfo TopicReaderStreamSendCommitMessageStartMessageInfo) func(error) {
 	var p TopicReaderSendCommitMessageStartInfo
 	p.CommitsInfo = commitsInfo
 	res := t.onReaderSendCommitMessage(p)

--- a/trace/topic_gtrace.go
+++ b/trace/topic_gtrace.go
@@ -1061,7 +1061,7 @@ func TopicOnReaderCommit(t *Topic, requestContext context.Context, topic string,
 		res(p)
 	}
 }
-func TopicOnReaderSendCommitMessage(t *Topic, commitsInfo TopicReaderStreamSendCommitMessageStartMessageInfo) func(error) {
+func TopicOnReaderSendCommitMessage(t *Topic, commitsInfo []TopicReaderStreamSendCommitMessageStartMessageInfo) func(error) {
 	var p TopicReaderSendCommitMessageStartInfo
 	p.CommitsInfo = commitsInfo
 	res := t.onReaderSendCommitMessage(p)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Start and end offset omitted in logs

Issue Number: issue-826

## What is the new behavior?

- Add new fields for each commit message (topic, partition, start offset, end offset)
- Log each commit range in message separetly (for consistency with TopicReaderCommitStartInfo and easier log investigation) 

