### PR TITLE
Remove extra allocations in types package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Deprecated WithOnWriterFirstConnected callback, use Writer.WaitInitInfo instead.
 * Changed topic Codec base type from int to int32 (was experimental code)
 * Added `WaitInit` and `WaitInitInfo` method to the topic reader and writer
+* Remove extra allocations in `types.TupleValue`, `types.ListValue` and `types.SetValue`
 
 ## v3.52.2
 * Removed support of placeholder "_" for ignoring columns in `database/sql` result sets

--- a/table/types/value.go
+++ b/table/types/value.go
@@ -200,21 +200,15 @@ func DecimalValueFromBigInt(v *big.Int, precision, scale uint32) Value {
 }
 
 func TupleValue(vs ...Value) Value {
-	return value.TupleValue(func() (vv []value.Value) {
-		return append(vv, vs...)
-	}()...)
+	return value.TupleValue(vs...)
 }
 
 func ListValue(vs ...Value) Value {
-	return value.ListValue(func() (vv []value.Value) {
-		return append(vv, vs...)
-	}()...)
+	return value.ListValue(vs...)
 }
 
 func SetValue(vs ...Value) Value {
-	return value.SetValue(func() (vv []value.Value) {
-		return append(vv, vs...)
-	}()...)
+	return value.SetValue(vs...)
 }
 
 type structValueFields struct {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Remove extra allocations in `types.TupleValue`, `types.ListValue` and `types.SetValue`

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Issue Number: N/A

## What is the new behavior?

## Other information
