### PR TITLE
* Added package `metrics` with SDK metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Added experimental package `metrics` with SDK metrics
 * Fixed redundant trace call for finished `database/sql` transactions
 * Added repeater event type to wake-up func context
 * Refactored default logger format

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -1,0 +1,3 @@
+# metrics
+
+Experimental package `metrics` contains adopter interfaces for monitoring system and common metrics of `ydb-go-sdk`

--- a/metrics/config.go
+++ b/metrics/config.go
@@ -1,0 +1,16 @@
+package metrics
+
+import "github.com/ydb-platform/ydb-go-sdk/v3/trace"
+
+// Config is experimental interface for metrics registry config
+type Config interface {
+	Registry
+
+	// Details returns bitmask for customize details of NewScope
+	// If zero - use full set of driver NewScope
+	Details() trace.Details
+
+	// WithSystem returns new Config with subsystem scope
+	// Separator for split scopes of NewScope provided Config implementation
+	WithSystem(subsystem string) Config
+}

--- a/metrics/coordination.go
+++ b/metrics/coordination.go
@@ -1,0 +1,9 @@
+package metrics
+
+import (
+	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
+)
+
+func coordination(config Config) (t trace.Coordination) {
+	return t
+}

--- a/metrics/counter.go
+++ b/metrics/counter.go
@@ -1,0 +1,11 @@
+package metrics
+
+// Counter counts value
+type Counter interface {
+	Inc()
+}
+
+// CounterVec returns Counter from CounterVec by labels
+type CounterVec interface {
+	With(labels map[string]string) Counter
+}

--- a/metrics/discovery.go
+++ b/metrics/discovery.go
@@ -1,0 +1,9 @@
+package metrics
+
+import (
+	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
+)
+
+func discovery(config Config) (t trace.Discovery) {
+	return t
+}

--- a/metrics/driver.go
+++ b/metrics/driver.go
@@ -1,0 +1,125 @@
+package metrics
+
+import (
+	"strconv"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/repeater"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
+	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
+)
+
+// driver makes driver with New publishing
+func driver(config Config) (t trace.Driver) {
+	type endpointKey struct {
+		localDC bool
+		az      string
+	}
+
+	config = config.WithSystem("driver")
+	endpoints := config.WithSystem("balancer").GaugeVec("endpoints", "local_dc", "az")
+	balancerUpdates := config.WithSystem("balancer").CounterVec("updates", "force")
+	conns := config.GaugeVec("conns", "address", "node_id")
+	banned := config.WithSystem("conn").GaugeVec("banned", "address", "node_id", "cause")
+	requests := config.WithSystem("conn").CounterVec("requests", "status", "method")
+	tli := config.CounterVec("transaction_locks_invalidated")
+	knownEndpoints := make(map[endpointKey]struct{})
+	t.OnConnInvoke = func(info trace.DriverConnInvokeStartInfo) func(trace.DriverConnInvokeDoneInfo) {
+		method := info.Method
+		return func(info trace.DriverConnInvokeDoneInfo) {
+			if config.Details()&trace.DriverConnEvents != 0 {
+				requests.With(map[string]string{
+					"status": errorBrief(info.Error),
+					"method": string(method),
+				}).Inc()
+				if xerrors.IsOperationErrorTransactionLocksInvalidated(info.Error) {
+					tli.With(nil).Inc()
+				}
+			}
+		}
+	}
+	t.OnConnNewStream = func(info trace.DriverConnNewStreamStartInfo) func(
+		trace.DriverConnNewStreamRecvInfo,
+	) func(
+		trace.DriverConnNewStreamDoneInfo,
+	) {
+		method := info.Method
+		return func(info trace.DriverConnNewStreamRecvInfo) func(trace.DriverConnNewStreamDoneInfo) {
+			return func(info trace.DriverConnNewStreamDoneInfo) {
+				if config.Details()&trace.DriverConnEvents != 0 {
+					requests.With(map[string]string{
+						"status": errorBrief(info.Error),
+						"method": string(method),
+					}).Inc()
+				}
+			}
+		}
+	}
+	t.OnConnBan = func(info trace.DriverConnBanStartInfo) func(trace.DriverConnBanDoneInfo) {
+		if config.Details()&trace.DriverConnEvents != 0 {
+			banned.With(map[string]string{
+				"address": info.Endpoint.Address(),
+				"node_id": idToString(info.Endpoint.NodeID()),
+				"cause":   errorBrief(info.Cause),
+			}).Add(1)
+		}
+		return nil
+	}
+	t.OnBalancerUpdate = func(info trace.DriverBalancerUpdateStartInfo) func(trace.DriverBalancerUpdateDoneInfo) {
+		eventType := repeater.EventType(*info.Context)
+		return func(info trace.DriverBalancerUpdateDoneInfo) {
+			if config.Details()&trace.DriverBalancerEvents != 0 {
+				balancerUpdates.With(map[string]string{
+					"force": strconv.FormatBool(eventType == repeater.EventForce),
+				}).Inc()
+				newEndpoints := make(map[endpointKey]int, len(info.Endpoints))
+				for _, e := range info.Endpoints {
+					e := endpointKey{
+						localDC: e.LocalDC(),
+						az:      e.Location(),
+					}
+					newEndpoints[e]++
+				}
+				for e := range knownEndpoints {
+					if _, has := newEndpoints[e]; !has {
+						delete(knownEndpoints, e)
+						endpoints.With(map[string]string{
+							"local_dc": strconv.FormatBool(e.localDC),
+							"az":       e.az,
+						}).Set(0)
+					}
+				}
+				for e, count := range newEndpoints {
+					knownEndpoints[e] = struct{}{}
+					endpoints.With(map[string]string{
+						"local_dc": strconv.FormatBool(e.localDC),
+						"az":       e.az,
+					}).Set(float64(count))
+				}
+			}
+		}
+	}
+	t.OnConnDial = func(info trace.DriverConnDialStartInfo) func(trace.DriverConnDialDoneInfo) {
+		address := info.Endpoint.Address()
+		nodeID := info.Endpoint.NodeID()
+		return func(info trace.DriverConnDialDoneInfo) {
+			if config.Details()&trace.DriverConnEvents != 0 {
+				if info.Error == nil {
+					conns.With(map[string]string{
+						"address": address,
+						"node_id": idToString(nodeID),
+					}).Add(1)
+				}
+			}
+		}
+	}
+	t.OnConnClose = func(info trace.DriverConnCloseStartInfo) func(trace.DriverConnCloseDoneInfo) {
+		if config.Details()&trace.DriverConnEvents != 0 {
+			conns.With(map[string]string{
+				"address": info.Endpoint.Address(),
+				"node_id": idToString(info.Endpoint.NodeID()),
+			}).Add(-1)
+		}
+		return nil
+	}
+	return t
+}

--- a/metrics/error.go
+++ b/metrics/error.go
@@ -1,0 +1,34 @@
+package metrics
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3"
+)
+
+func errorBrief(err error) string {
+	if err == nil {
+		return "OK"
+	}
+	var (
+		netErr *net.OpError
+		ydbErr ydb.Error
+	)
+	switch {
+	case errors.As(err, &netErr):
+		return "network/" + netErr.Op + " -> " + netErr.Err.Error()
+	case errors.Is(err, io.EOF):
+		return "io/EOF"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "context/DeadlineExceeded"
+	case errors.Is(err, context.Canceled):
+		return "context/Canceled"
+	case errors.As(err, &ydbErr):
+		return ydbErr.Name()
+	default:
+		return "unknown"
+	}
+}

--- a/metrics/example_test.go
+++ b/metrics/example_test.go
@@ -1,0 +1,25 @@
+package metrics_test
+
+import (
+	"context"
+	"os"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3"
+	"github.com/ydb-platform/ydb-go-sdk/v3/metrics"
+)
+
+func ExampleConfig() {
+	var registryConfig metrics.Config // registryConfig is an implementation registry.Config
+	db, err := ydb.Open(
+		context.TODO(),
+		os.Getenv("YDB_CONNECTION_STRING"),
+		metrics.WithTraces(registryConfig),
+	)
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		_ = db.Close(context.TODO())
+	}()
+	// work with db
+}

--- a/metrics/gauge.go
+++ b/metrics/gauge.go
@@ -1,0 +1,12 @@
+package metrics
+
+// Gauge tracks single float64 value.
+type Gauge interface {
+	Add(delta float64)
+	Set(value float64)
+}
+
+// GaugeVec returns Gauge from GaugeVec by labels
+type GaugeVec interface {
+	With(labels map[string]string) Gauge
+}

--- a/metrics/histogram.go
+++ b/metrics/histogram.go
@@ -1,0 +1,11 @@
+package metrics
+
+// HistogramVec stores multiple dynamically created timers
+type HistogramVec interface {
+	With(labels map[string]string) Histogram
+}
+
+// Histogram tracks distribution of value.
+type Histogram interface {
+	Record(value float64)
+}

--- a/metrics/node_id.go
+++ b/metrics/node_id.go
@@ -1,0 +1,9 @@
+package metrics
+
+import (
+	"strconv"
+)
+
+func idToString(id uint32) string {
+	return strconv.FormatUint(uint64(id), 10)
+}

--- a/metrics/ratelimiter.go
+++ b/metrics/ratelimiter.go
@@ -1,0 +1,9 @@
+package metrics
+
+import (
+	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
+)
+
+func ratelimiter(config Config) (t trace.Ratelimiter) {
+	return t
+}

--- a/metrics/registry.go
+++ b/metrics/registry.go
@@ -1,0 +1,24 @@
+package metrics
+
+// Registry is experimental interface for metrics registry
+type Registry interface {
+	// CounterVec returns CounterVec by name, subsystem and labels
+	// If counter by args already created - return counter from cache
+	// If counter by args nothing - create and return newest counter
+	CounterVec(name string, labelNames ...string) CounterVec
+
+	// GaugeVec returns GaugeVec by name, subsystem and labels
+	// If gauge by args already created - return gauge from cache
+	// If gauge by args nothing - create and return newest gauge
+	GaugeVec(name string, labelNames ...string) GaugeVec
+
+	// TimerVec returns TimerVec by name, subsystem and labels
+	// If timer by args already created - return timer from cache
+	// If timer by args nothing - create and return newest timer
+	TimerVec(name string, labelNames ...string) TimerVec
+
+	// HistogramVec returns HistogramVec by name, subsystem and labels
+	// If histogram by args already created - return histogram from cache
+	// If histogram by args nothing - create and return newest histogram
+	HistogramVec(name string, buckets []float64, labelNames ...string) HistogramVec
+}

--- a/metrics/retry.go
+++ b/metrics/retry.go
@@ -1,0 +1,10 @@
+package metrics
+
+import (
+	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
+)
+
+// Retry makes table.RetryTrace with New publishing
+func Retry(config Config) (t trace.Retry) {
+	return t
+}

--- a/metrics/scheme.go
+++ b/metrics/scheme.go
@@ -1,0 +1,9 @@
+package metrics
+
+import (
+	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
+)
+
+func scheme(config Config) (t trace.Scheme) {
+	return t
+}

--- a/metrics/scripting.go
+++ b/metrics/scripting.go
@@ -1,0 +1,9 @@
+package metrics
+
+import (
+	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
+)
+
+func scripting(config Config) (t trace.Scripting) {
+	return t
+}

--- a/metrics/sql.go
+++ b/metrics/sql.go
@@ -1,0 +1,63 @@
+package metrics
+
+import (
+	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
+)
+
+// databaseSQL makes trace.DatabaseSQL with measuring `database/sql` events
+func databaseSQL(config Config) (t trace.DatabaseSQL) {
+	config = config.WithSystem("database").WithSystem("sql")
+	conns := config.GaugeVec("conns")
+	txs := config.GaugeVec("txs")
+	t.OnConnectorConnect = func(info trace.DatabaseSQLConnectorConnectStartInfo) func(
+		trace.DatabaseSQLConnectorConnectDoneInfo,
+	) {
+		if config.Details()&trace.DatabaseSQLConnectorEvents != 0 {
+			return func(info trace.DatabaseSQLConnectorConnectDoneInfo) {
+				if info.Error == nil {
+					conns.With(nil).Add(1)
+				}
+			}
+		}
+		return nil
+	}
+	t.OnConnClose = func(info trace.DatabaseSQLConnCloseStartInfo) func(trace.DatabaseSQLConnCloseDoneInfo) {
+		if config.Details()&trace.DatabaseSQLConnectorEvents != 0 {
+			return func(info trace.DatabaseSQLConnCloseDoneInfo) {
+				conns.With(nil).Add(-1)
+			}
+		}
+		return nil
+	}
+	t.OnConnBegin = func(info trace.DatabaseSQLConnBeginStartInfo) func(trace.DatabaseSQLConnBeginDoneInfo) {
+		if config.Details()&trace.DatabaseSQLTxEvents != 0 {
+			return func(info trace.DatabaseSQLConnBeginDoneInfo) {
+				if info.Tx != nil {
+					txs.With(nil).Add(1)
+				}
+			}
+		}
+		return nil
+	}
+	t.OnTxCommit = func(info trace.DatabaseSQLTxCommitStartInfo) func(trace.DatabaseSQLTxCommitDoneInfo) {
+		if config.Details()&trace.DatabaseSQLTxEvents != 0 {
+			return func(info trace.DatabaseSQLTxCommitDoneInfo) {
+				if info.Error == nil {
+					txs.With(nil).Add(-1)
+				}
+			}
+		}
+		return nil
+	}
+	t.OnTxRollback = func(info trace.DatabaseSQLTxRollbackStartInfo) func(trace.DatabaseSQLTxRollbackDoneInfo) {
+		if config.Details()&trace.DatabaseSQLTxEvents != 0 {
+			return func(info trace.DatabaseSQLTxRollbackDoneInfo) {
+				if info.Error == nil {
+					txs.With(nil).Add(-1)
+				}
+			}
+		}
+		return nil
+	}
+	return t
+}

--- a/metrics/table.go
+++ b/metrics/table.go
@@ -1,0 +1,117 @@
+package metrics
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
+)
+
+func table(config Config) (t trace.Table) {
+	config = config.WithSystem("table")
+	limit := config.WithSystem("pool").GaugeVec("limit")
+	size := config.WithSystem("pool").GaugeVec("size")
+	inflight := config.WithSystem("pool").GaugeVec("inflight")
+	inflightLatency := config.WithSystem("pool").WithSystem("inflight").TimerVec("latency")
+	wait := config.WithSystem("pool").GaugeVec("wait")
+	waitLatency := config.WithSystem("pool").WithSystem("wait").TimerVec("latency")
+	alive := config.GaugeVec("sessions", "node_id")
+	doAttempts := config.WithSystem("do").HistogramVec("attempts", []float64{0, 1, 2, 5, 10})
+	doErrors := config.WithSystem("do").WithSystem("intermediate").CounterVec("errors", "status")
+	doTxAttempts := config.WithSystem("doTx").HistogramVec("attempts", []float64{0, 1, 2, 5, 10})
+	doTxErrors := config.WithSystem("doTx").WithSystem("intermediate").CounterVec("errors", "status")
+	t.OnInit = func(info trace.TableInitStartInfo) func(trace.TableInitDoneInfo) {
+		return func(info trace.TableInitDoneInfo) {
+			limit.With(nil).Set(float64(info.Limit))
+		}
+	}
+	t.OnDo = func(info trace.TableDoStartInfo) func(
+		info trace.TableDoIntermediateInfo,
+	) func(
+		trace.TableDoDoneInfo,
+	) {
+		return func(info trace.TableDoIntermediateInfo) func(trace.TableDoDoneInfo) {
+			if info.Error != nil && config.Details()&trace.TableEvents != 0 {
+				doErrors.With(map[string]string{
+					"status": errorBrief(info.Error),
+				}).Inc()
+			}
+			return func(info trace.TableDoDoneInfo) {
+				if config.Details()&trace.TableEvents != 0 {
+					doAttempts.With(nil).Record(float64(info.Attempts))
+				}
+			}
+		}
+	}
+	t.OnDoTx = func(info trace.TableDoTxStartInfo) func(
+		info trace.TableDoTxIntermediateInfo,
+	) func(
+		trace.TableDoTxDoneInfo,
+	) {
+		return func(info trace.TableDoTxIntermediateInfo) func(trace.TableDoTxDoneInfo) {
+			if info.Error != nil && config.Details()&trace.TableEvents != 0 {
+				doTxErrors.With(map[string]string{
+					"status": errorBrief(info.Error),
+				}).Inc()
+			}
+			return func(info trace.TableDoTxDoneInfo) {
+				if config.Details()&trace.TableEvents != 0 {
+					doTxAttempts.With(nil).Record(float64(info.Attempts))
+				}
+			}
+		}
+	}
+	t.OnSessionNew = func(info trace.TableSessionNewStartInfo) func(trace.TableSessionNewDoneInfo) {
+		return func(info trace.TableSessionNewDoneInfo) {
+			if info.Error == nil && config.Details()&trace.TableSessionEvents != 0 {
+				alive.With(map[string]string{
+					"node_id": idToString(info.Session.NodeID()),
+				}).Add(1)
+			}
+		}
+	}
+	t.OnSessionDelete = func(info trace.TableSessionDeleteStartInfo) func(trace.TableSessionDeleteDoneInfo) {
+		if config.Details()&trace.TableSessionEvents != 0 {
+			alive.With(map[string]string{
+				"node_id": idToString(info.Session.NodeID()),
+			}).Add(-1)
+		}
+		return nil
+	}
+	t.OnPoolSessionAdd = func(info trace.TablePoolSessionAddInfo) {
+		if config.Details()&trace.TablePoolEvents != 0 {
+			size.With(nil).Add(1)
+		}
+	}
+	t.OnPoolSessionRemove = func(info trace.TablePoolSessionRemoveInfo) {
+		if config.Details()&trace.TablePoolEvents != 0 {
+			size.With(nil).Add(-1)
+		}
+	}
+	var inflightStarts sync.Map
+	t.OnPoolGet = func(info trace.TablePoolGetStartInfo) func(trace.TablePoolGetDoneInfo) {
+		wait.With(nil).Add(1)
+		start := time.Now()
+		return func(info trace.TablePoolGetDoneInfo) {
+			wait.With(nil).Add(-1)
+			if info.Error == nil && config.Details()&trace.TablePoolEvents != 0 {
+				inflight.With(nil).Add(1)
+				inflightStarts.Store(info.Session.ID(), time.Now())
+				waitLatency.With(nil).Record(time.Since(start))
+			}
+		}
+	}
+	t.OnPoolPut = func(info trace.TablePoolPutStartInfo) func(trace.TablePoolPutDoneInfo) {
+		if config.Details()&trace.TablePoolEvents != 0 {
+			inflight.With(nil).Add(-1)
+			start, ok := inflightStarts.LoadAndDelete(info.Session.ID())
+			if !ok {
+				panic(fmt.Sprintf("unknown session '%s'", info.Session.ID()))
+			}
+			inflightLatency.With(nil).Record(time.Since(start.(time.Time)))
+		}
+		return nil
+	}
+	return t
+}

--- a/metrics/timer.go
+++ b/metrics/timer.go
@@ -1,0 +1,13 @@
+package metrics
+
+import "time"
+
+// TimerVec stores multiple dynamically created timers
+type TimerVec interface {
+	With(labels map[string]string) Timer
+}
+
+// Timer tracks distribution of value.
+type Timer interface {
+	Record(value time.Duration)
+}

--- a/metrics/traces.go
+++ b/metrics/traces.go
@@ -1,0 +1,22 @@
+package metrics
+
+import (
+	"github.com/ydb-platform/ydb-go-sdk/v3"
+)
+
+func WithTraces(config Config) ydb.Option {
+	if config == nil {
+		return nil
+	}
+	config = config.WithSystem("ydb")
+	return ydb.MergeOptions(
+		ydb.WithTraceDriver(driver(config)),
+		ydb.WithTraceTable(table(config)),
+		ydb.WithTraceScripting(scripting(config)),
+		ydb.WithTraceScheme(scheme(config)),
+		ydb.WithTraceCoordination(coordination(config)),
+		ydb.WithTraceRatelimiter(ratelimiter(config)),
+		ydb.WithTraceDiscovery(discovery(config)),
+		ydb.WithTraceDatabaseSQL(databaseSQL(config)),
+	)
+}

--- a/table/table.go
+++ b/table/table.go
@@ -81,6 +81,7 @@ const (
 
 type SessionInfo interface {
 	ID() string
+	NodeID() uint32
 	Status() SessionStatus
 	LastUsage() time.Time
 }

--- a/tests/integration/metrics_registry_go1.18_test.go
+++ b/tests/integration/metrics_registry_go1.18_test.go
@@ -1,0 +1,504 @@
+//go:build integration && go1.18
+// +build integration,go1.18
+
+package integration
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3"
+	"github.com/ydb-platform/ydb-go-sdk/v3/metrics"
+	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
+)
+
+func movingAverage[T interface {
+	time.Duration | float64
+}](
+	oldValue T, newValue T, α float64,
+) T {
+	return T(α*float64(newValue) + (1-α)*float64(oldValue))
+}
+
+func nameLabelValuesToString(name string, labelValues map[string]string) string {
+	var buffer bytes.Buffer
+	fmt.Fprintf(&buffer, name)
+	fmt.Fprintf(&buffer, "{")
+	labels := make([]string, 0, len(labelValues))
+	for k := range labelValues {
+		labels = append(labels, k)
+	}
+	sort.Strings(labels)
+	for i, l := range labels {
+		if i != 0 {
+			fmt.Fprintf(&buffer, ",")
+		}
+		fmt.Fprintf(&buffer, "%s=%s", l, labelValues[l])
+	}
+	fmt.Fprintf(&buffer, "}")
+	return buffer.String()
+}
+
+func nameLabelNamesToString(name string, labelNames []string) string {
+	var buffer bytes.Buffer
+	fmt.Fprintf(&buffer, name)
+	fmt.Fprintf(&buffer, "{")
+	sort.Strings(labelNames)
+	for i, name := range labelNames {
+		if i != 0 {
+			fmt.Fprintf(&buffer, ",")
+		}
+		fmt.Fprintf(&buffer, name)
+	}
+	fmt.Fprintf(&buffer, "}")
+	return buffer.String()
+}
+
+type counter struct {
+	name  string
+	value uint64
+	m     sync.RWMutex
+}
+
+func (c *counter) Inc() {
+	c.m.Lock()
+	defer c.m.Unlock()
+	c.value += 1
+}
+
+func (c *counter) Name() string {
+	return c.name
+}
+
+func (c *counter) Value() string {
+	c.m.RLock()
+	defer c.m.RUnlock()
+	return fmt.Sprintf("%d", c.value)
+}
+
+// define custom counterVec
+type counterVec struct {
+	name       string
+	labelNames []string
+	counters   map[string]*counter
+	m          sync.RWMutex
+}
+
+func (vec *counterVec) With(labels map[string]string) metrics.Counter {
+	name := nameLabelValuesToString(vec.name, labels)
+	vec.m.RLock()
+	c, has := vec.counters[name]
+	vec.m.RUnlock()
+	if has {
+		return c
+	}
+	if has {
+		return c
+	}
+	c = &counter{
+		name: name,
+	}
+	vec.m.Lock()
+	vec.counters[name] = c
+	vec.m.Unlock()
+	return c
+}
+
+func (vec *counterVec) Name() string {
+	return vec.name
+}
+
+func (vec *counterVec) Values() (values []string) {
+	vec.m.RLock()
+	defer vec.m.RUnlock()
+	for _, g := range vec.counters {
+		values = append(values, fmt.Sprintf("%s = %s", g.Name(), g.Value()))
+	}
+	return values
+}
+
+type timer struct {
+	name  string
+	value time.Duration
+	m     sync.RWMutex
+}
+
+func (t *timer) Record(value time.Duration) {
+	t.m.Lock()
+	defer t.m.Unlock()
+	t.value = movingAverage(t.value, value, 0.9)
+}
+
+func (t *timer) Name() string {
+	return t.name
+}
+
+func (t *timer) Value() string {
+	t.m.RLock()
+	defer t.m.RUnlock()
+	return fmt.Sprintf("%v", t.value)
+}
+
+// define custom timerVec
+type timerVec struct {
+	name       string
+	labelNames []string
+	timers     map[string]*timer
+	m          sync.RWMutex
+}
+
+func (vec *timerVec) With(labels map[string]string) metrics.Timer {
+	name := nameLabelValuesToString(vec.name, labels)
+	vec.m.RLock()
+	t, has := vec.timers[name]
+	vec.m.RUnlock()
+	if has {
+		return t
+	}
+	t = &timer{
+		name: name,
+	}
+	vec.m.Lock()
+	vec.timers[name] = t
+	vec.m.Unlock()
+	return t
+}
+
+func (vec *timerVec) Name() string {
+	return vec.name
+}
+
+func (vec *timerVec) Values() (values []string) {
+	vec.m.RLock()
+	defer vec.m.RUnlock()
+	for _, t := range vec.timers {
+		values = append(values, fmt.Sprintf("%s = %s", t.Name(), t.Value()))
+	}
+	return values
+}
+
+type bin struct {
+	value float64 // left corner of bucket
+	count uint64
+}
+
+type histogram struct {
+	name    string
+	buckets []*bin
+	m       sync.RWMutex
+}
+
+func (h *histogram) Record(value float64) {
+	h.m.Lock()
+	defer h.m.Unlock()
+	for i := len(h.buckets) - 1; i >= 0; i-- {
+		if h.buckets[i].value < value {
+			atomic.AddUint64(&h.buckets[i].count, 1)
+			return
+		}
+	}
+}
+
+func (h *histogram) Name() string {
+	return h.name
+}
+
+func (h *histogram) Value() string {
+	var buffer bytes.Buffer
+	h.m.RLock()
+	defer h.m.RUnlock()
+	buffer.WriteByte('[')
+	for i := 0; i < len(h.buckets); i++ {
+		if i > 0 {
+			buffer.WriteByte(',')
+		}
+		buffer.WriteByte('[')
+		buffer.WriteString(strconv.FormatFloat(h.buckets[i].value, 'f', -1, 64))
+		buffer.WriteString("..")
+		if i == len(h.buckets)-1 {
+			buffer.WriteString(".")
+		} else {
+			buffer.WriteString(strconv.FormatFloat(h.buckets[i+1].value, 'f', -1, 64))
+		}
+		buffer.WriteString("]:")
+		buffer.WriteString(strconv.FormatUint(atomic.LoadUint64(&h.buckets[i].count), 10))
+	}
+	buffer.WriteByte(']')
+	return buffer.String()
+}
+
+// define custom histogramVec
+type histogramVec struct {
+	name       string
+	labelNames []string
+	histograms map[string]*histogram
+	buckets    []float64
+	m          sync.RWMutex
+}
+
+func (vec *histogramVec) With(labels map[string]string) metrics.Histogram {
+	name := nameLabelValuesToString(vec.name, labels)
+	vec.m.RLock()
+	h, has := vec.histograms[name]
+	vec.m.RUnlock()
+	if has {
+		return h
+	}
+	h = &histogram{
+		name:    name,
+		buckets: make([]*bin, len(vec.buckets)),
+	}
+	for i, v := range vec.buckets {
+		h.buckets[i] = &bin{
+			value: v,
+		}
+	}
+	vec.m.Lock()
+	vec.histograms[name] = h
+	vec.m.Unlock()
+	return h
+}
+
+func (vec *histogramVec) Name() string {
+	return vec.name
+}
+
+func (vec *histogramVec) Values() (values []string) {
+	vec.m.RLock()
+	defer vec.m.RUnlock()
+	for _, t := range vec.histograms {
+		values = append(values, fmt.Sprintf("%s = %s", t.Name(), t.Value()))
+	}
+	return values
+}
+
+// define custom gaugeVec
+type gaugeVec struct {
+	name       string
+	labelNames []string
+	gauges     map[string]*gauge
+	m          sync.RWMutex
+}
+
+type gauge struct {
+	name  string
+	value float64
+	m     sync.RWMutex
+}
+
+func (g *gauge) Name() string {
+	return g.name
+}
+
+func (g *gauge) Value() string {
+	g.m.RLock()
+	defer g.m.RUnlock()
+	return fmt.Sprintf("%f", g.value)
+}
+
+func (vec *gaugeVec) With(labels map[string]string) metrics.Gauge {
+	name := nameLabelValuesToString(vec.name, labels)
+	vec.m.RLock()
+	g, has := vec.gauges[name]
+	vec.m.RUnlock()
+	if has {
+		return g
+	}
+	g = &gauge{
+		name: name,
+	}
+	vec.m.Lock()
+	vec.gauges[name] = g
+	vec.m.Unlock()
+	return g
+}
+
+func (g *gauge) Add(value float64) {
+	g.m.Lock()
+	defer g.m.Unlock()
+	g.value += value
+}
+
+func (g *gauge) Set(value float64) {
+	g.m.Lock()
+	defer g.m.Unlock()
+	g.value = value
+}
+
+func (vec *gaugeVec) Name() string {
+	return vec.name
+}
+
+func (vec *gaugeVec) Values() (values []string) {
+	vec.m.RLock()
+	defer vec.m.RUnlock()
+	for _, g := range vec.gauges {
+		values = append(values, fmt.Sprintf("%s = %s", g.Name(), g.Value()))
+	}
+	return values
+}
+
+type vec[T any] struct {
+	mtx  sync.RWMutex
+	data map[string]*T
+}
+
+func newVec[T any]() *vec[T] {
+	return &vec[T]{
+		data: make(map[string]*T, 0),
+	}
+}
+
+func (v *vec[T]) add(key string, element *T) *T {
+	v.mtx.Lock()
+	defer v.mtx.Unlock()
+	if _, has := v.data[key]; has {
+		panic(fmt.Sprintf("key = %s already exists", key))
+	}
+	v.data[key] = element
+	return element
+}
+
+func (v *vec[T]) iterate(f func(element *T)) {
+	v.mtx.RLock()
+	defer v.mtx.RUnlock()
+	for _, element := range v.data {
+		f(element)
+	}
+}
+
+// define custom registryConfig
+type registryConfig struct {
+	prefix     string
+	details    trace.Details
+	gauges     *vec[gaugeVec]
+	counters   *vec[counterVec]
+	timers     *vec[timerVec]
+	histograms *vec[histogramVec]
+}
+
+func (registry *registryConfig) CounterVec(name string, labelNames ...string) metrics.CounterVec {
+	return registry.counters.add(nameLabelNamesToString(registry.prefix+"."+name, labelNames), &counterVec{
+		name:       registry.prefix + "." + name,
+		labelNames: labelNames,
+		counters:   make(map[string]*counter),
+	})
+}
+
+func (registry *registryConfig) GaugeVec(name string, labelNames ...string) metrics.GaugeVec {
+	return registry.gauges.add(nameLabelNamesToString(registry.prefix+"."+name, labelNames), &gaugeVec{
+		name:       registry.prefix + "." + name,
+		labelNames: labelNames,
+		gauges:     make(map[string]*gauge),
+	})
+}
+
+func (registry *registryConfig) TimerVec(name string, labelNames ...string) metrics.TimerVec {
+	return registry.timers.add(nameLabelNamesToString(registry.prefix+"."+name, labelNames), &timerVec{
+		name:       registry.prefix + "." + name,
+		labelNames: labelNames,
+		timers:     make(map[string]*timer),
+	})
+}
+
+func (registry *registryConfig) HistogramVec(name string, buckets []float64, labelNames ...string) metrics.HistogramVec {
+	return registry.histograms.add(nameLabelNamesToString(registry.prefix+"."+name, labelNames), &histogramVec{
+		name:       registry.prefix + "." + name,
+		labelNames: labelNames,
+		histograms: make(map[string]*histogram),
+		buckets:    buckets,
+	})
+}
+
+func (registry *registryConfig) WithSystem(subsystem string) metrics.Config {
+	copy := *registry
+	if len(copy.prefix) == 0 {
+		copy.prefix = subsystem
+	} else {
+		copy.prefix = registry.prefix + "." + subsystem
+	}
+	return &copy
+}
+
+func (registry *registryConfig) Details() trace.Details {
+	return registry.details
+}
+
+func withMetrics(t *testing.T, details trace.Details, interval time.Duration) ydb.Option {
+	registry := &registryConfig{
+		details:    details,
+		gauges:     newVec[gaugeVec](),
+		counters:   newVec[counterVec](),
+		timers:     newVec[timerVec](),
+		histograms: newVec[histogramVec](),
+	}
+	var (
+		done       = make(chan struct{})
+		printState = func(log func(format string, args ...interface{}), header string) {
+			log(time.Now().Format("[2006-01-02 15:04:05] ") + header + ":\n")
+			var (
+				gaugesOnce     sync.Once
+				countersOnce   sync.Once
+				timersOnce     sync.Once
+				histogramsOnce sync.Once
+			)
+			registry.gauges.iterate(func(element *gaugeVec) {
+				for _, v := range element.Values() {
+					gaugesOnce.Do(func() {
+						log("- gauges:\n")
+					})
+					log("  - %s\n", v)
+				}
+			})
+			registry.counters.iterate(func(element *counterVec) {
+				for _, v := range element.Values() {
+					countersOnce.Do(func() {
+						log("- counters:\n")
+					})
+					log("  - %s\n", v)
+				}
+			})
+			registry.timers.iterate(func(element *timerVec) {
+				for _, v := range element.Values() {
+					timersOnce.Do(func() {
+						log("- timers:\n")
+					})
+					log("  - %s\n", v)
+				}
+			})
+			registry.histograms.iterate(func(element *histogramVec) {
+				for _, v := range element.Values() {
+					histogramsOnce.Do(func() {
+						log("- histograms:\n")
+					})
+					log("  - %s\n", v)
+				}
+			})
+		}
+	)
+	if interval > 0 {
+		go func() {
+			for {
+				select {
+				case <-done:
+					return
+				case <-time.After(interval):
+					printState(t.Logf, "registry state")
+				}
+			}
+		}()
+	}
+	t.Cleanup(func() {
+		close(done)
+		printState(func(format string, args ...interface{}) {
+			_, _ = fmt.Printf(format, args...)
+		}, "final registry state")
+	})
+	return metrics.WithTraces(registry)
+}

--- a/tests/integration/metrics_registry_test.go
+++ b/tests/integration/metrics_registry_test.go
@@ -1,0 +1,16 @@
+//go:build integration && !go1.18
+// +build integration,!go1.18
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3"
+	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
+)
+
+func withMetrics(t *testing.T, details trace.Details, interval time.Duration) ydb.Option {
+	return nil // nop
+}

--- a/tests/integration/table_test.go
+++ b/tests/integration/table_test.go
@@ -94,8 +94,6 @@ func (s *stats) addToOpen(t testing.TB, id string) {
 	}
 
 	s.openSessions[id] = struct{}{}
-
-	t.Logf("session '%s' added to open sessions", id)
 }
 
 func (s *stats) removeFromOpen(t testing.TB, id string) {
@@ -109,8 +107,6 @@ func (s *stats) removeFromOpen(t testing.TB, id string) {
 	}
 
 	delete(s.openSessions, id)
-
-	t.Logf("session '%s' removed from open sessions", id)
 }
 
 func (s *stats) addToPool(t testing.TB, id string) {
@@ -124,8 +120,6 @@ func (s *stats) addToPool(t testing.TB, id string) {
 	}
 
 	s.inPoolSessions[id] = struct{}{}
-
-	t.Logf("session '%s' added to pool", id)
 }
 
 func (s *stats) removeFromPool(t testing.TB, id string) {
@@ -139,8 +133,6 @@ func (s *stats) removeFromPool(t testing.TB, id string) {
 	}
 
 	delete(s.inPoolSessions, id)
-
-	t.Logf("session '%s' removed from pool", id)
 }
 
 func (s *stats) addToInFlight(t testing.TB, id string) {
@@ -154,8 +146,6 @@ func (s *stats) addToInFlight(t testing.TB, id string) {
 	}
 
 	s.inFlightSessions[id] = struct{}{}
-
-	t.Logf("session '%s' added to in-flight", id)
 }
 
 func (s *stats) removeFromInFlight(t testing.TB, id string) {
@@ -169,8 +159,6 @@ func (s *stats) removeFromInFlight(t testing.TB, id string) {
 	}
 
 	delete(s.inFlightSessions, id)
-
-	t.Logf("session '%s' removed from in-flight", id)
 }
 
 func TestTable(t *testing.T) { //nolint:gocyclo
@@ -265,6 +253,7 @@ func TestTable(t *testing.T) { //nolint:gocyclo
 		os.Getenv("YDB_CONNECTION_STRING"),
 		ydb.WithAccessTokenCredentials(os.Getenv("YDB_ACCESS_TOKEN_CREDENTIALS")),
 		ydb.WithUserAgent("table/e2e"),
+		withMetrics(t, trace.DetailsAll, time.Second),
 		ydb.With(
 			config.WithOperationTimeout(time.Second*5),
 			config.WithOperationCancelAfter(time.Second*5),
@@ -718,7 +707,7 @@ func (s *tableTestScope) streamReadTable(ctx context.Context, t testing.TB, c ta
 					if err != nil {
 						return err
 					}
-					t.Logf("  > %d %s %s\n", *id, *title, date.String())
+					// t.Logf("  > %d %s %s\n", *id, *title, date.String())
 				}
 			}
 			if err = res.Err(); err != nil {
@@ -801,7 +790,7 @@ func (s *tableTestScope) executeDataQuery(ctx context.Context, t testing.TB, c t
 			defer func() {
 				_ = res.Close()
 			}()
-			t.Logf("> select_simple_transaction:\n")
+			// t.Logf("> select_simple_transaction:\n")
 			for res.NextResultSet(ctx) {
 				for res.NextRow() {
 					err = res.ScanNamed(
@@ -812,10 +801,10 @@ func (s *tableTestScope) executeDataQuery(ctx context.Context, t testing.TB, c t
 					if err != nil {
 						return err
 					}
-					t.Logf(
-						"  > %d %s %s\n",
-						*id, *title, *date,
-					)
+					// t.Logf(
+					// 	"  > %d %s %s\n",
+					// 	*id, *title, *date,
+					// )
 				}
 			}
 			return res.Err()
@@ -869,14 +858,14 @@ func (s *tableTestScope) executeScanQuery(ctx context.Context, t testing.TB, c t
 			defer func() {
 				_ = res.Close()
 			}()
-			t.Logf("> scan_query_select:\n")
+			// t.Logf("> scan_query_select:\n")
 			for res.NextResultSet(ctx) {
 				for res.NextRow() {
 					err = res.ScanWithDefaults(&seriesID, &seasonID, &title, &date)
 					if err != nil {
 						return err
 					}
-					t.Logf("  > SeriesId: %d, SeasonId: %d, Title: %s, Air date: %s\n", seriesID, seasonID, title, date)
+					// t.Logf("  > SeriesId: %d, SeasonId: %d, Title: %s, Air date: %s\n", seriesID, seasonID, title, date)
 				}
 			}
 			return res.Err()

--- a/trace/table.go
+++ b/trace/table.go
@@ -99,6 +99,7 @@ type (
 	}
 	tableSessionInfo interface {
 		ID() string
+		NodeID() uint32
 		Status() string
 		LastUsage() time.Time
 	}


### PR DESCRIPTION
* Refactored default logger format
* Refactored `internal/conn.coonError` format
* Fixed data race on `internal/conn.conn.cc` access
* Added repeater event type to wake-up func context
* Fixed redundant trace call for finished `database/sql` transactions

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #477

## What is the new behavior?

```
[2023-10-03 18:00:58] final registry state:
- gauges:
  - ydb.driver.balancer.endpoints{az=VLA,local_dc=true} = 8.000000
  - ydb.table.pool.limit{} = 50.000000
  - ydb.table.pool.size{} = 0.000000
  - ydb.table.pool.wait{} = 0.000000
  - ydb.table.sessions{node_id=50005} = 0.000000
  - ydb.table.sessions{node_id=50008} = 0.000000
  - ydb.table.sessions{node_id=50006} = 0.000000
  - ydb.table.sessions{node_id=50003} = 0.000000
  - ydb.table.sessions{node_id=50001} = 0.000000
  - ydb.table.sessions{node_id=50007} = 0.000000
  - ydb.table.sessions{node_id=50004} = 0.000000
  - ydb.table.sessions{node_id=50002} = 0.000000
  - ydb.driver.conns{address=ydb-vla-dev03-004.search.yandex.net:31001,node_id=50005} = 0.000000
  - ydb.driver.conns{address=ydb-vla-dev03-007.search.yandex.net:31001,node_id=50008} = 0.000000
  - ydb.driver.conns{address=ydb-vla-dev03-005.search.yandex.net:31001,node_id=50006} = 0.000000
  - ydb.driver.conns{address=ydb-vla-dev03-002.search.yandex.net:31001,node_id=50003} = 0.000000
  - ydb.driver.conns{address=ydb-vla-dev03-006.search.yandex.net:31001,node_id=50007} = 0.000000
  - ydb.driver.conns{address=ydb-vla-dev03-000.search.yandex.net:31001,node_id=0} = 0.000000
  - ydb.driver.conns{address=ydb-vla-dev03-001.search.yandex.net:31001,node_id=50002} = 0.000000
  - ydb.driver.conns{address=ydb-vla-dev03-000.search.yandex.net:31001,node_id=50001} = 0.000000
  - ydb.driver.conns{address=ydb-vla-dev03-003.search.yandex.net:31001,node_id=50004} = 0.000000
  - ydb.driver.conn.banned{address=ydb-vla-dev03-003.search.yandex.net:31001,cause=transport/DeadlineExceeded,node_id=50004} = 5.000000
  - ydb.driver.conn.banned{address=ydb-vla-dev03-006.search.yandex.net:31001,cause=transport/DeadlineExceeded,node_id=50007} = 3.000000
  - ydb.driver.conn.banned{address=ydb-vla-dev03-007.search.yandex.net:31001,cause=transport/DeadlineExceeded,node_id=50008} = 4.000000
  - ydb.driver.conn.banned{address=ydb-vla-dev03-001.search.yandex.net:31001,cause=transport/DeadlineExceeded,node_id=50002} = 4.000000
  - ydb.driver.conn.banned{address=ydb-vla-dev03-002.search.yandex.net:31001,cause=transport/DeadlineExceeded,node_id=50003} = 5.000000
  - ydb.driver.conn.banned{address=ydb-vla-dev03-000.search.yandex.net:31001,cause=transport/DeadlineExceeded,node_id=50001} = 4.000000
  - ydb.driver.conn.banned{address=ydb-vla-dev03-004.search.yandex.net:31001,cause=transport/DeadlineExceeded,node_id=50005} = 3.000000
  - ydb.driver.conn.banned{address=ydb-vla-dev03-005.search.yandex.net:31001,cause=transport/DeadlineExceeded,node_id=50006} = 6.000000
  - ydb.table.pool.inflight{} = 0.000000
- counters:
  - ydb.driver.balancer.updates{force=false} = 1
  - ydb.driver.conn.requests{method=/Ydb.Table.V1.TableService/PrepareDataQuery,status=OK} = 1
  - ydb.driver.conn.requests{method=/Ydb.Table.V1.TableService/CommitTransaction,status=OK} = 1
  - ydb.driver.conn.requests{method=/Ydb.Table.V1.TableService/StreamReadTable,status=OK} = 41916
  - ydb.driver.conn.requests{method=/Ydb.Table.V1.TableService/StreamExecuteScanQuery,status=OK} = 35974
  - ydb.driver.conn.requests{method=/Ydb.Table.V1.TableService/StreamExecuteScanQuery,status=transport/DeadlineExceeded} = 8
  - ydb.driver.conn.requests{method=/Ydb.Table.V1.TableService/StreamReadTable,status=transport/DeadlineExceeded} = 20
  - ydb.driver.conn.requests{method=/Ydb.Scheme.V1.SchemeService/DescribePath,status=OK} = 2
  - ydb.driver.conn.requests{method=/Ydb.Table.V1.TableService/CreateTable,status=OK} = 3
  - ydb.driver.conn.requests{method=/Ydb.Table.V1.TableService/BeginTransaction,status=OK} = 1
  - ydb.driver.conn.requests{method=/Ydb.Scheme.V1.SchemeService/ListDirectory,status=OK} = 2
  - ydb.driver.conn.requests{method=/Ydb.Table.V1.TableService/ExecuteDataQuery,status=OK} = 48667
  - ydb.driver.conn.requests{method=/Ydb.Scheme.V1.SchemeService/MakeDirectory,status=OK} = 1
  - ydb.driver.conn.requests{method=/Ydb.Table.V1.TableService/DescribeTableOptions,status=OK} = 1
  - ydb.driver.conn.requests{method=/Ydb.Table.V1.TableService/DescribeTable,status=OK} = 3
  - ydb.driver.conn.requests{method=/Ydb.Table.V1.TableService/CreateSession,status=OK} = 51
  - ydb.driver.conn.requests{method=/Ydb.Scheme.V1.SchemeService/RemoveDirectory,status=OK} = 1
  - ydb.driver.conn.requests{method=/Ydb.Table.V1.TableService/DescribeTable,status=operation/SCHEME_ERROR} = 3
  - ydb.driver.conn.requests{method=/Ydb.Table.V1.TableService/DeleteSession,status=OK} = 1
  - ydb.driver.conn.requests{method=/Ydb.Table.V1.TableService/ExecuteDataQuery,status=transport/DeadlineExceeded} = 6
  - ydb.driver.conn.requests{method=/Ydb.Discovery.V1.DiscoveryService/ListEndpoints,status=OK} = 1
  - ydb.driver.conn.requests{method=/Ydb.Table.V1.TableService/DropTable,status=OK} = 3
  - ydb.table.do.intermediate.errors{status=context/DeadlineExceeded} = 134
  - ydb.table.do.intermediate.errors{status=transport/DeadlineExceeded} = 34
- timers:
  - ydb.table.pool.inflight.latency{} = 11.886865ms
  - ydb.table.pool.wait.latency{} = 33.317915ms
- histograms:
  - ydb.table.doTx.attempts{} = [[0..1]:1,[1..2]:0,[2..5]:0,[5..10]:0,[10...]:0]
  - ydb.table.do.attempts{} = [[0..1]:126613,[1..2]:0,[2..5]:0,[5..10]:0,[10...]:0]
```
## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
