### PR TITLE
Removed `backoff.Backoff.Wait` interface method for exclude resource leak with bug-provoked usage of `time.After`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Removed `internal/backoff.Backoff.Wait` interface method for exclude resource leak with bug-provoked usage of `time.After` method
 * Marked as deprecated `retry.WithDoRetryOptions` and `retry.WithDoTxRetryOptions`
 * Added receiving first result set on construct `internal/table/scanner.NewStream()`
 * Added experimental package `metrics` with SDK metrics

--- a/internal/wait/wait.go
+++ b/internal/wait/wait.go
@@ -2,6 +2,7 @@ package wait
 
 import (
 	"context"
+	"time"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/backoff"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
@@ -11,8 +12,11 @@ import (
 // expiration.
 // It returns non-nil error if and only if deadline expiration branch wins.
 func waitBackoff(ctx context.Context, b backoff.Backoff, i int) error {
+	t := time.NewTimer(b.Delay(i))
+	defer t.Stop()
+
 	select {
-	case <-b.Wait(i):
+	case <-t.C:
 		return nil
 	case <-ctx.Done():
 		if err := ctx.Err(); err != nil {

--- a/internal/xsql/errors.go
+++ b/internal/xsql/errors.go
@@ -20,7 +20,7 @@ type ErrConnAlreadyHaveTx struct {
 }
 
 func (err *ErrConnAlreadyHaveTx) Error() string {
-	return "conn already have an opened currentTx: " + err.currentTx
+	return "conn already have an open currentTx: " + err.currentTx
 }
 
 func (err *ErrConnAlreadyHaveTx) As(target interface{}) bool {


### PR DESCRIPTION
…th `time.After` usage

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
