### PR TITLE
return concrete type instead of interface for topic client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Changed return type for Driver.Topic() - now return pointer to struct (*topic.ClientType) instead of topic.Topic interface 
+
 ## v3.53.0
 * Removed `internal/backoff.Backoff.Wait` interface method for exclude resource leak with bug-provoked usage of `time.After` method
 * Marked as deprecated `retry.WithDoRetryOptions` and `retry.WithDoTxRetryOptions`

--- a/connection.go
+++ b/connection.go
@@ -78,7 +78,7 @@ type Connection interface {
 	Scripting() scripting.Client
 
 	// Topic returns topic client
-	Topic() topic.Client
+	Topic() *topic.ClientType
 }
 
 var _ Connection = (*Driver)(nil)
@@ -121,7 +121,7 @@ type Driver struct { //nolint:maligned
 	ratelimiterOptions []ratelimiterConfig.Option
 
 	topicOnce    initOnce
-	topic        *topicclientinternal.Client
+	topic        *topicclientinternal.PublicTopicClient
 	topicOptions []topicoptions.TopicOption
 
 	databaseSQLOptions []xsql.ConnectorOption
@@ -330,7 +330,7 @@ func (c *Driver) Scripting() scripting.Client {
 }
 
 // Topic returns topic client
-func (c *Driver) Topic() topic.Client {
+func (c *Driver) Topic() *topic.ClientType {
 	c.topicOnce.Init(func() closeFunc {
 		c.topic = topicclientinternal.New(c.balancer, c.config.Credentials(),
 			append(

--- a/sugar/path.go
+++ b/sugar/path.go
@@ -29,7 +29,7 @@ type dbTable interface {
 }
 
 type dbTopic interface {
-	Topic() topic.Client
+	Topic() *topic.ClientType
 }
 
 type dbForMakeRecursive interface {

--- a/topic/client.go
+++ b/topic/client.go
@@ -3,14 +3,17 @@ package topic
 import (
 	"context"
 
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/topic/topicclientinternal"
 	"github.com/ydb-platform/ydb-go-sdk/v3/topic/topicoptions"
 	"github.com/ydb-platform/ydb-go-sdk/v3/topic/topicreader"
 	"github.com/ydb-platform/ydb-go-sdk/v3/topic/topictypes"
 	"github.com/ydb-platform/ydb-go-sdk/v3/topic/topicwriter"
 )
 
+type ClientType = topicclientinternal.PublicTopicClient
+
 // Client is interface for topic client
-// Attention: the interface may be extended in the future.
+// Deprecated: now returned concrete type
 type Client interface {
 	// Alter change topic options
 	Alter(ctx context.Context, path string, opts ...topicoptions.AlterOption) error


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Driver was return interface type for topic client.
It will problem in future, when we need to extend the client.

# New behaviour
Driver return pointer to struct instead of interface.
