### PR TITLE
Allow to unwrap joined errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-* Allow to Unwrap joined errors (internal/xerrors/join.go `joinError.Unwrap() []error`)
 * Added `internal/credentials.IsAccessError(err)` helper for check access errors
 * Changed period for re-fresh static credentials token from `1/2` to `1/10` to expiration time
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Allow to Unwrap joined errors (internal/xerrors/join.go `joinError.Unwrap() []error`)
 * Added `internal/credentials.IsAccessError(err)` helper for check access errors
 * Changed period for re-fresh static credentials token from `1/2` to `1/10` to expiration time
 

--- a/internal/xerrors/join.go
+++ b/internal/xerrors/join.go
@@ -43,3 +43,8 @@ func (errs joinError) Is(target error) bool {
 	}
 	return false
 }
+
+func (errs joinError) Unwrap() []error {
+	return errs
+}
+

--- a/internal/xerrors/join.go
+++ b/internal/xerrors/join.go
@@ -47,4 +47,3 @@ func (errs joinError) Is(target error) bool {
 func (errs joinError) Unwrap() []error {
 	return errs
 }
-

--- a/internal/xerrors/join_test.go
+++ b/internal/xerrors/join_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -37,4 +38,16 @@ func TestJoin(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUnwrapJoined(t *testing.T) {
+	err1 := context.Canceled
+	err2 := context.DeadlineExceeded
+
+	var joined error = Join(err1, err2)
+
+	unwrappable := joined.(interface{ Unwrap() []error })
+	inners := unwrappable.Unwrap()
+	assert.Contains(t, inners, err1)
+	assert.Contains(t, inners, err2)
 }


### PR DESCRIPTION
To support logic of processing inner errors

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

## Pull request type


Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

It is unable to enumerate inner errors without reflection.

Issue Number: N/A

## What is the new behavior?

You can cast `joinError` to standard `interface {Unwrap()[] error}` And work with inner errors.
