### PR TITLE
* Moved `internal/allocator.Buffers` to package `internal/xstring`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Moved `internal/allocator.Buffers` to package `internal/xstring`
 * Bumped `golang.org/x/sync` to `v0.3.0`
 * Bumped `google.golang.org/protobuf` to `v1.31.0`
 * Bumped `google.golang.org/grpc` to `v1.57.1`

--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -4,9 +4,6 @@
 package allocator
 
 import (
-	"bytes"
-	"sync"
-
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb"
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Table"
 )
@@ -191,23 +188,4 @@ func (a *Allocator) TableQueryID(id string) (v *Ydb_Table.Query_Id) {
 	return &Ydb_Table.Query_Id{
 		Id: id,
 	}
-}
-
-var Buffers = &buffersPoolType{}
-
-type buffersPoolType struct {
-	sync.Pool
-}
-
-func (p *buffersPoolType) Get() *bytes.Buffer {
-	v := p.Pool.Get()
-	if v == nil {
-		v = new(bytes.Buffer)
-	}
-	return v.(*bytes.Buffer)
-}
-
-func (p *buffersPoolType) Put(b *bytes.Buffer) {
-	b.Reset()
-	p.Pool.Put(b)
 }

--- a/internal/allocator/allocator_go1.18.go
+++ b/internal/allocator/allocator_go1.18.go
@@ -4,7 +4,6 @@
 package allocator
 
 import (
-	"bytes"
 	"sync"
 
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb"
@@ -880,17 +879,7 @@ func (p *Pool[T]) Put(t *T) {
 	(*sync.Pool)(p).Put(t)
 }
 
-type buffersPoolType struct {
-	Pool[bytes.Buffer]
-}
-
-func (p *buffersPoolType) Put(b *bytes.Buffer) {
-	b.Reset()
-	p.Pool.Put(b)
-}
-
 var (
-	Buffers                          = &buffersPoolType{}
 	allocatorPool                    Pool[Allocator]
 	valuePool                        Pool[Ydb.Value]
 	typePool                         Pool[Ydb.Type]

--- a/internal/bind/auto_declare.go
+++ b/internal/bind/auto_declare.go
@@ -3,8 +3,8 @@ package bind
 import (
 	"sort"
 
-	"github.com/ydb-platform/ydb-go-sdk/v3/internal/allocator"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xstring"
 )
 
 type AutoDeclare struct{}
@@ -27,9 +27,9 @@ func (m AutoDeclare) RewriteQuery(query string, args ...interface{}) (
 
 	var (
 		declares = make([]string, 0, len(params))
-		buffer   = allocator.Buffers.Get()
+		buffer   = xstring.Buffer()
 	)
-	defer allocator.Buffers.Put(buffer)
+	defer buffer.Free()
 
 	buffer.WriteString("-- bind declares\n")
 

--- a/internal/bind/bind.go
+++ b/internal/bind/bind.go
@@ -3,8 +3,8 @@ package bind
 import (
 	"sort"
 
-	"github.com/ydb-platform/ydb-go-sdk/v3/internal/allocator"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xstring"
 	"github.com/ydb-platform/ydb-go-sdk/v3/table"
 )
 
@@ -38,8 +38,8 @@ func (bindings Bindings) RewriteQuery(query string, args ...interface{}) (
 		return query, table.NewQueryParameters(params...), nil
 	}
 
-	buffer := allocator.Buffers.Get()
-	defer allocator.Buffers.Put(buffer)
+	buffer := xstring.Buffer()
+	defer buffer.Free()
 
 	for i := range bindings {
 		query, args, err = bindings[len(bindings)-1-i].RewriteQuery(query, args...)

--- a/internal/bind/numeric_args.go
+++ b/internal/bind/numeric_args.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 	"unicode/utf8"
 
-	"github.com/ydb-platform/ydb-go-sdk/v3/internal/allocator"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xstring"
 	"github.com/ydb-platform/ydb-go-sdk/v3/table"
 )
 
@@ -30,10 +30,10 @@ func (m NumericArgs) RewriteQuery(sql string, args ...interface{}) (
 	}
 
 	var (
-		buffer = allocator.Buffers.Get()
+		buffer = xstring.Buffer()
 		param  table.ParameterOption
 	)
-	defer allocator.Buffers.Put(buffer)
+	defer buffer.Free()
 
 	if len(args) > 0 {
 		newArgs = make([]interface{}, len(args))

--- a/internal/bind/positional_args.go
+++ b/internal/bind/positional_args.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 	"unicode/utf8"
 
-	"github.com/ydb-platform/ydb-go-sdk/v3/internal/allocator"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xstring"
 	"github.com/ydb-platform/ydb-go-sdk/v3/table"
 )
 
@@ -30,11 +30,11 @@ func (m PositionalArgs) RewriteQuery(sql string, args ...interface{}) (
 	}
 
 	var (
-		buffer   = allocator.Buffers.Get()
+		buffer   = xstring.Buffer()
 		position = 0
 		param    table.ParameterOption
 	)
-	defer allocator.Buffers.Put(buffer)
+	defer buffer.Free()
 
 	for _, p := range l.parts {
 		switch p := p.(type) {

--- a/internal/bind/table_path_prefix.go
+++ b/internal/bind/table_path_prefix.go
@@ -4,7 +4,7 @@ import (
 	"path"
 	"strings"
 
-	"github.com/ydb-platform/ydb-go-sdk/v3/internal/allocator"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xstring"
 )
 
 type TablePathPrefix string
@@ -27,8 +27,8 @@ func (tablePathPrefix TablePathPrefix) NormalizePath(folderOrTable string) strin
 func (tablePathPrefix TablePathPrefix) RewriteQuery(query string, args ...interface{}) (
 	yql string, newArgs []interface{}, err error,
 ) {
-	buffer := allocator.Buffers.Get()
-	defer allocator.Buffers.Put(buffer)
+	buffer := xstring.Buffer()
+	defer buffer.Free()
 
 	buffer.WriteString("-- bind TablePathPrefix\n")
 	buffer.WriteString("PRAGMA TablePathPrefix(\"")

--- a/internal/credentials/access_token.go
+++ b/internal/credentials/access_token.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ydb-platform/ydb-go-sdk/v3/internal/allocator"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/secret"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/stack"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xstring"
 )
 
 var (
@@ -44,8 +44,8 @@ func (c AccessToken) Token(_ context.Context) (string, error) {
 
 // Token implements Credentials.
 func (c AccessToken) String() string {
-	buffer := allocator.Buffers.Get()
-	defer allocator.Buffers.Put(buffer)
+	buffer := xstring.Buffer()
+	defer buffer.Free()
 	buffer.WriteString("AccessToken(token:")
 	fmt.Fprintf(buffer, "%q", secret.Token(c.token))
 	if c.sourceInfo != "" {

--- a/internal/credentials/anonymous.go
+++ b/internal/credentials/anonymous.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/ydb-platform/ydb-go-sdk/v3/internal/allocator"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/stack"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xstring"
 )
 
 var (
@@ -40,8 +40,8 @@ func (c Anonymous) Token(_ context.Context) (string, error) {
 
 // Token implements Credentials.
 func (c Anonymous) String() string {
-	buffer := allocator.Buffers.Get()
-	defer allocator.Buffers.Put(buffer)
+	buffer := xstring.Buffer()
+	defer buffer.Free()
 	buffer.WriteString("Anonymous(")
 	if c.sourceInfo != "" {
 		buffer.WriteString("from:")

--- a/internal/credentials/static.go
+++ b/internal/credentials/static.go
@@ -13,10 +13,10 @@ import (
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Operations"
 	"google.golang.org/grpc"
 
-	"github.com/ydb-platform/ydb-go-sdk/v3/internal/allocator"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/secret"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/stack"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xstring"
 )
 
 var (
@@ -145,8 +145,8 @@ func parseExpiresAt(raw string) (expiresAt time.Time, err error) {
 }
 
 func (c *Static) String() string {
-	buffer := allocator.Buffers.Get()
-	defer allocator.Buffers.Put(buffer)
+	buffer := xstring.Buffer()
+	defer buffer.Free()
 	buffer.WriteString("Static(user:")
 	fmt.Fprintf(buffer, "%q", c.user)
 	buffer.WriteString(",password:")

--- a/internal/stack/record.go
+++ b/internal/stack/record.go
@@ -5,7 +5,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/ydb-platform/ydb-go-sdk/v3/internal/allocator"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xstring"
 )
 
 type recordOptions struct {
@@ -109,8 +109,8 @@ func Record(depth int, opts ...recordOption) string {
 		structName = split[1]
 	}
 
-	buffer := allocator.Buffers.Get()
-	defer allocator.Buffers.Put(buffer)
+	buffer := xstring.Buffer()
+	defer buffer.Free()
 	if optionsHolder.packagePath {
 		buffer.WriteString(pkgPath)
 	}

--- a/internal/table/scanner/scanner.go
+++ b/internal/table/scanner/scanner.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb"
 
-	"github.com/ydb-platform/ydb-go-sdk/v3/internal/allocator"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/value"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xstring"
@@ -251,8 +250,8 @@ func (s *scanner) reset(set *Ydb.ResultSet, columnNames ...string) {
 }
 
 func (s *scanner) path() string {
-	buf := allocator.Buffers.Get()
-	defer allocator.Buffers.Put(buf)
+	buf := xstring.Buffer()
+	defer buf.Free()
 	_, _ = s.writePathTo(buf)
 	return buf.String()
 }

--- a/internal/value/type.go
+++ b/internal/value/type.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/allocator"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xstring"
 )
 
 type Type interface {
@@ -195,8 +196,8 @@ func (v *dictType) String() string {
 }
 
 func (v *dictType) Yql() string {
-	buffer := allocator.Buffers.Get()
-	defer allocator.Buffers.Put(buffer)
+	buffer := xstring.Buffer()
+	defer buffer.Free()
 	buffer.WriteString("Dict<")
 	buffer.WriteString(v.keyType.Yql())
 	buffer.WriteByte(',')
@@ -550,8 +551,8 @@ func (v *StructType) String() string {
 }
 
 func (v *StructType) Yql() string {
-	buffer := allocator.Buffers.Get()
-	defer allocator.Buffers.Put(buffer)
+	buffer := xstring.Buffer()
+	defer buffer.Free()
 	buffer.WriteString("Struct<")
 	for i := range v.fields {
 		if i > 0 {
@@ -632,8 +633,8 @@ func (v *TupleType) String() string {
 }
 
 func (v *TupleType) Yql() string {
-	buffer := allocator.Buffers.Get()
-	defer allocator.Buffers.Put(buffer)
+	buffer := xstring.Buffer()
+	defer buffer.Free()
 	buffer.WriteString("Tuple<")
 	for i, t := range v.items {
 		if i > 0 {
@@ -692,8 +693,8 @@ type variantStructType struct {
 }
 
 func (v *variantStructType) Yql() string {
-	buffer := allocator.Buffers.Get()
-	defer allocator.Buffers.Put(buffer)
+	buffer := xstring.Buffer()
+	defer buffer.Free()
 	buffer.WriteString("Variant<")
 	for i := range v.fields {
 		if i > 0 {
@@ -746,8 +747,8 @@ type variantTupleType struct {
 }
 
 func (v *variantTupleType) Yql() string {
-	buffer := allocator.Buffers.Get()
-	defer allocator.Buffers.Put(buffer)
+	buffer := xstring.Buffer()
+	defer buffer.Free()
 	buffer.WriteString("Variant<")
 	for i, t := range v.items {
 		if i > 0 {

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -441,8 +441,8 @@ func (v *decimalValue) castTo(dst interface{}) error {
 }
 
 func (v *decimalValue) Yql() string {
-	buffer := allocator.Buffers.Get()
-	defer allocator.Buffers.Put(buffer)
+	buffer := xstring.Buffer()
+	defer buffer.Free()
 	buffer.WriteString(v.innerType.Name())
 	buffer.WriteByte('(')
 	buffer.WriteByte('"')
@@ -515,8 +515,8 @@ func (v *dictValue) castTo(dst interface{}) error {
 }
 
 func (v *dictValue) Yql() string {
-	buffer := allocator.Buffers.Get()
-	defer allocator.Buffers.Put(buffer)
+	buffer := xstring.Buffer()
+	defer buffer.Free()
 	buffer.WriteByte('{')
 	for i := range v.values {
 		if i != 0 {
@@ -916,8 +916,8 @@ func (v intervalValue) castTo(dst interface{}) error {
 }
 
 func (v intervalValue) Yql() string {
-	buffer := allocator.Buffers.Get()
-	defer allocator.Buffers.Put(buffer)
+	buffer := xstring.Buffer()
+	defer buffer.Free()
 	buffer.WriteString(v.Type().Yql())
 	buffer.WriteByte('(')
 	buffer.WriteByte('"')
@@ -1066,8 +1066,8 @@ func (v *listValue) castTo(dst interface{}) error {
 }
 
 func (v *listValue) Yql() string {
-	buffer := allocator.Buffers.Get()
-	defer allocator.Buffers.Put(buffer)
+	buffer := xstring.Buffer()
+	defer buffer.Free()
 	buffer.WriteByte('[')
 	for i, item := range v.items {
 		if i != 0 {
@@ -1121,8 +1121,8 @@ func (v *setValue) castTo(dst interface{}) error {
 }
 
 func (v *setValue) Yql() string {
-	buffer := allocator.Buffers.Get()
-	defer allocator.Buffers.Put(buffer)
+	buffer := xstring.Buffer()
+	defer buffer.Free()
 	buffer.WriteByte('{')
 	for i, item := range v.items {
 		if i != 0 {
@@ -1251,8 +1251,8 @@ func (v *structValue) castTo(dst interface{}) error {
 }
 
 func (v *structValue) Yql() string {
-	buffer := allocator.Buffers.Get()
-	defer allocator.Buffers.Put(buffer)
+	buffer := xstring.Buffer()
+	defer buffer.Free()
 	buffer.WriteString("<|")
 	for i := range v.fields {
 		if i != 0 {
@@ -1352,8 +1352,8 @@ func (v *tupleValue) castTo(dst interface{}) error {
 }
 
 func (v *tupleValue) Yql() string {
-	buffer := allocator.Buffers.Get()
-	defer allocator.Buffers.Put(buffer)
+	buffer := xstring.Buffer()
+	defer buffer.Free()
 	buffer.WriteByte('(')
 	for i, item := range v.items {
 		if i != 0 {
@@ -1786,8 +1786,8 @@ func (v *uuidValue) castTo(dst interface{}) error {
 }
 
 func (v *uuidValue) Yql() string {
-	buffer := allocator.Buffers.Get()
-	defer allocator.Buffers.Put(buffer)
+	buffer := xstring.Buffer()
+	defer buffer.Free()
 	buffer.WriteString(v.Type().Yql())
 	buffer.WriteByte('(')
 	buffer.WriteByte('"')
@@ -1844,8 +1844,8 @@ func (v *variantValue) castTo(dst interface{}) error {
 }
 
 func (v *variantValue) Yql() string {
-	buffer := allocator.Buffers.Get()
-	defer allocator.Buffers.Put(buffer)
+	buffer := xstring.Buffer()
+	defer buffer.Free()
 	buffer.WriteString("Variant(")
 	buffer.WriteString(v.value.Yql())
 	buffer.WriteByte(',')

--- a/internal/xerrors/issues.go
+++ b/internal/xerrors/issues.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb"
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Issue"
 
-	"github.com/ydb-platform/ydb-go-sdk/v3/internal/allocator"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xstring"
 )
 
 type issues []*Ydb_Issue.IssueMessage
@@ -18,8 +18,8 @@ func (ii issues) String() string {
 	if len(ii) == 0 {
 		return ""
 	}
-	b := allocator.Buffers.Get()
-	defer allocator.Buffers.Put(b)
+	b := xstring.Buffer()
+	defer b.Free()
 	b.WriteByte('[')
 	for i, m := range ii {
 		if i != 0 {

--- a/internal/xerrors/join.go
+++ b/internal/xerrors/join.go
@@ -3,7 +3,7 @@ package xerrors
 import (
 	"fmt"
 
-	"github.com/ydb-platform/ydb-go-sdk/v3/internal/allocator"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xstring"
 )
 
 func Join(errs ...error) joinError {
@@ -13,8 +13,8 @@ func Join(errs ...error) joinError {
 type joinError []error
 
 func (errs joinError) Error() string {
-	b := allocator.Buffers.Get()
-	defer allocator.Buffers.Put(b)
+	b := xstring.Buffer()
+	defer b.Free()
 	b.WriteByte('[')
 	for i, err := range errs {
 		if i > 0 {

--- a/internal/xerrors/operation.go
+++ b/internal/xerrors/operation.go
@@ -7,8 +7,8 @@ import (
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb"
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Issue"
 
-	"github.com/ydb-platform/ydb-go-sdk/v3/internal/allocator"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/backoff"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xstring"
 )
 
 // operationError reports about operationStatus fail.
@@ -113,8 +113,8 @@ func (e *operationError) Issues() []*Ydb_Issue.IssueMessage {
 }
 
 func (e *operationError) Error() string {
-	b := allocator.Buffers.Get()
-	defer allocator.Buffers.Put(b)
+	b := xstring.Buffer()
+	defer b.Free()
 	b.WriteString(e.Name())
 	fmt.Fprintf(b, " (code = %d", e.code)
 	if len(e.address) > 0 {

--- a/internal/xstring/buffer.go
+++ b/internal/xstring/buffer.go
@@ -1,0 +1,23 @@
+package xstring
+
+import (
+	"bytes"
+	"sync"
+)
+
+type buffer struct {
+	bytes.Buffer
+}
+
+var buffersPool = sync.Pool{New: func() interface{} {
+	return &buffer{}
+}}
+
+func (b *buffer) Free() {
+	b.Reset()
+	buffersPool.Put(b)
+}
+
+func Buffer() *buffer {
+	return buffersPool.Get().(*buffer)
+}

--- a/internal/xstring/buffer_test.go
+++ b/internal/xstring/buffer_test.go
@@ -1,0 +1,27 @@
+package xstring
+
+import (
+	"bytes"
+	"testing"
+)
+
+func BenchmarkBufferWithPool(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		func() {
+			buffer := Buffer()
+			buffer.WriteString(b.Name())
+			defer buffer.Free()
+		}()
+	}
+}
+
+func BenchmarkBufferWithoutPool(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		func() {
+			buffer := bytes.Buffer{}
+			buffer.WriteString(b.Name())
+		}()
+	}
+}

--- a/log/field.go
+++ b/log/field.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/ydb-platform/ydb-go-sdk/v3/internal/allocator"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/version"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xstring"
 	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
@@ -344,8 +343,8 @@ func versionField() Field {
 type endpoints []trace.EndpointInfo
 
 func (ee endpoints) String() string {
-	b := allocator.Buffers.Get()
-	defer allocator.Buffers.Put(b)
+	b := xstring.Buffer()
+	defer b.Free()
 	b.WriteByte('[')
 	for i, e := range ee {
 		if i != 0 {

--- a/log/logger.go
+++ b/log/logger.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/jonboulle/clockwork"
 
-	"github.com/ydb-platform/ydb-go-sdk/v3/internal/allocator"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xstring"
 )
 
 const (
@@ -48,8 +48,8 @@ type defaultLogger struct {
 }
 
 func (l *defaultLogger) format(namespace []string, msg string, logLevel Level) string {
-	b := allocator.Buffers.Get()
-	defer allocator.Buffers.Put(b)
+	b := xstring.Buffer()
+	defer b.Free()
 	if l.coloring {
 		b.WriteString(logLevel.Color())
 	}
@@ -114,8 +114,8 @@ func (l *defaultLogger) appendFields(msg string, fields ...Field) string {
 	if len(fields) == 0 {
 		return msg
 	}
-	b := allocator.Buffers.Get()
-	defer allocator.Buffers.Put(b)
+	b := xstring.Buffer()
+	defer b.Free()
 	b.WriteString(msg)
 	b.WriteString(" {")
 	for i := range fields {

--- a/metrics/error_brief.go
+++ b/metrics/error_brief.go
@@ -5,8 +5,8 @@ import (
 	"io"
 	"net"
 
-	"github.com/ydb-platform/ydb-go-sdk/v3/internal/allocator"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xstring"
 )
 
 func errorBrief(err error) string {
@@ -17,8 +17,8 @@ func errorBrief(err error) string {
 		return "io/EOF"
 	}
 	if netErr := (*net.OpError)(nil); xerrors.As(err, &netErr) {
-		buffer := allocator.Buffers.Get()
-		defer allocator.Buffers.Put(buffer)
+		buffer := xstring.Buffer()
+		defer buffer.Free()
 		buffer.WriteString("network")
 		if netErr.Op != "" {
 			buffer.WriteByte('/')

--- a/table/table.go
+++ b/table/table.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/allocator"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/closer"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/value"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xstring"
 	"github.com/ydb-platform/ydb-go-sdk/v3/retry"
 	"github.com/ydb-platform/ydb-go-sdk/v3/table/options"
 	"github.com/ydb-platform/ydb-go-sdk/v3/table/result"
@@ -512,8 +513,8 @@ func (q *QueryParameters) names() []string {
 }
 
 func (q *QueryParameters) String() string {
-	buffer := allocator.Buffers.Get()
-	defer allocator.Buffers.Put(buffer)
+	buffer := xstring.Buffer()
+	defer buffer.Free()
 
 	buffer.WriteByte('{')
 	for i, name := range q.names() {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

```
BenchmarkBufferWithPool-8      	51107196	        22.97 ns/op	       0 B/op	       0 allocs/op
BenchmarkBufferWithoutPool-8   	27986596	        46.01 ns/op	      64 B/op	       1 allocs/op
```
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
