### PR TITLE
separate lifetime for option context from connection context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Context for call options now have same lifetime as driver (previous - same lifetime as context for call Open function).
+
 ## v3.54.2
 * Added context to some internal methods for better tracing
 * Added `trace.FunctionID` helper and `FunctionID` field to trace start info's 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
context for option has same lifetime as connection token

## What is the new behavior?

context for options has same lifetime as driver

Close: #898