### PR TITLE
revert linter settings from https://github.com/ydb-platform/ydb-go-sd…

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -225,27 +225,66 @@ linters-settings:
         # Default: false
         checkExported: true
 linters:
-  enable-all: true
-  disable:
-    - godot
-    - varnamelen
-    - wrapcheck
-    - nosnakecase
-    - deadcode
-    - golint
-    - interfacer
-    - maligned
-    - ifshort
-    - structcheck
-    - exhaustivestruct
-    - scopelint
-    - varcheck
-    - ireturn
+  disable-all: true
+  enable:
+#    - cyclop
     - depguard
-    - wsl
-    - exhaustruct
-    - gci
-    - paralleltest #need be enabled
+    - dogsled
+#    - dupl
+    - errcheck
+    - errorlint
+#    - exhaustive
+#    - exhaustivestruct
+#    - forbidigo
+#    - funlen
+#    - gci
+#    - gocognit
+    - goconst
+    - gocritic
+    - gocyclo
+#    - godot
+    - godox
+    - gofmt # On why gofmt when goimports is enabled - https://github.com/golang/go/issues/21476
+    - gofumpt
+    - goheader
+    - goimports
+#    - gomnd
+#    - gomoddirectives
+#    - gomodguard
+    - gosec
+    - gosimple
+    - govet
+    - depguard
+#    - ifshort
+#    - ireturn
+    - lll
+    - makezero
+    - misspell
+    - ineffassign
+    - misspell
+    - nakedret
+    - nestif
+#    - nilnil
+#    - nlreturn
+    - nolintlint
+    - prealloc
+    - predeclared
+    - rowserrcheck
+    - revive
+    - staticcheck
+    - stylecheck
+#    - tagliatelle
+#    - testpackage
+#    - thelper
+#    - tenv
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+#    - varnamelen
+    - whitespace
+#    - wrapcheck
+#    - wsl
 
 issues:
   # List of regexps of issue texts to exclude, empty list by default.


### PR DESCRIPTION
…k/pull/903

because linters are broken

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
revert linters settings from https://github.com/ydb-platform/ydb-go-sdk/pull/903