### PR TITLE
Fix topic writer infinite reconnections

### DIFF
--- a/internal/topic/retriable_error.go
+++ b/internal/topic/retriable_error.go
@@ -13,7 +13,8 @@ import (
 )
 
 const (
-	DefaultStartTimeout = time.Minute
+	DefaultStartTimeout          = time.Minute
+	connectionEstablishedTimeout = time.Minute
 )
 
 type RetrySettings struct {
@@ -46,7 +47,7 @@ var (
 func CheckResetReconnectionCounters(lastTry, now time.Time, connectionTimeout time.Duration) bool {
 	const resetAttemptEmpiricalCoefficient = 10
 	if connectionTimeout == value.InfiniteDuration {
-		return false
+		return now.Sub(lastTry) > connectionEstablishedTimeout
 	}
 	return now.Sub(lastTry) > connectionTimeout*resetAttemptEmpiricalCoefficient
 }

--- a/internal/topic/retriable_error.go
+++ b/internal/topic/retriable_error.go
@@ -93,9 +93,10 @@ func CheckRetryMode(err error, settings RetrySettings, retriesDuration time.Dura
 		return nil, false
 	}
 
-	if mode.BackoffType() == backoff.TypeFast {
+	switch mode.BackoffType() {
+	case backoff.TypeFast:
 		return backoff.Fast, true
+	default:
+		return backoff.Slow, true
 	}
-
-	return backoff.Slow, true
 }

--- a/internal/topic/retriable_error.go
+++ b/internal/topic/retriable_error.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/backoff"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/value"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
 	"github.com/ydb-platform/ydb-go-sdk/v3/retry"
 )
@@ -44,6 +45,9 @@ var (
 
 func CheckResetReconnectionCounters(lastTry, now time.Time, connectionTimeout time.Duration) bool {
 	const resetAttemptEmpiricalCoefficient = 10
+	if connectionTimeout == value.InfiniteDuration {
+		return false
+	}
 	return now.Sub(lastTry) > connectionTimeout*resetAttemptEmpiricalCoefficient
 }
 

--- a/internal/topic/retriable_error_test.go
+++ b/internal/topic/retriable_error_test.go
@@ -12,6 +12,7 @@ import (
 	grpcStatus "google.golang.org/grpc/status"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/backoff"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/value"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
 )
 
@@ -229,6 +230,43 @@ func TestCheckRetryMode(t *testing.T) {
 			resBackoff, retriable := CheckRetryMode(test.err, test.settings, test.duration)
 			require.Equal(t, test.resBackoff, resBackoff)
 			require.Equal(t, test.resRetriable, retriable)
+		})
+	}
+}
+
+func TestCheckResetReconnectionCounters(t *testing.T) {
+	now := time.Now()
+	fmt.Println(now.Sub(now.Add(-61 * time.Second)))
+	table := []struct {
+		name              string
+		lastTry           time.Time
+		connectionTimeout time.Duration
+		shouldReset       bool
+	}{
+		{
+			name:              "InfiniteConnectionTimeout",
+			lastTry:           time.Time{},
+			connectionTimeout: value.InfiniteDuration,
+			shouldReset:       false,
+		},
+		{
+			name:              "LastTryLessThanConnectionTimeout",
+			lastTry:           now.Add(-30 * time.Second),
+			connectionTimeout: time.Minute,
+			shouldReset:       false,
+		},
+		{
+			name:              "LastTryGreaterThanConnectionTimeout",
+			lastTry:           now.Add(-time.Hour),
+			connectionTimeout: time.Minute,
+			shouldReset:       true,
+		},
+	}
+
+	for _, test := range table {
+		t.Run(test.name, func(t *testing.T) {
+			shouldReset := CheckResetReconnectionCounters(test.lastTry, now, test.connectionTimeout)
+			require.Equal(t, test.shouldReset, shouldReset)
 		})
 	}
 }

--- a/internal/topic/retriable_error_test.go
+++ b/internal/topic/retriable_error_test.go
@@ -243,10 +243,16 @@ func TestCheckResetReconnectionCounters(t *testing.T) {
 		shouldReset       bool
 	}{
 		{
-			name:              "InfiniteConnectionTimeout",
-			lastTry:           time.Time{},
+			name:              "RecentLastTryWithInfiniteConnectionTimeout",
+			lastTry:           now.Add(-30 * time.Second),
 			connectionTimeout: value.InfiniteDuration,
 			shouldReset:       false,
+		},
+		{
+			name:              "OldLastTryWithInfiniteConnectionTimeout",
+			lastTry:           now.Add(-30 * time.Minute),
+			connectionTimeout: value.InfiniteDuration,
+			shouldReset:       true,
 		},
 		{
 			name:              "LastTryLessThanConnectionTimeout",

--- a/internal/topic/retriable_error_test.go
+++ b/internal/topic/retriable_error_test.go
@@ -236,7 +236,6 @@ func TestCheckRetryMode(t *testing.T) {
 
 func TestCheckResetReconnectionCounters(t *testing.T) {
 	now := time.Now()
-	fmt.Println(now.Sub(now.Add(-61 * time.Second)))
 	table := []struct {
 		name              string
 		lastTry           time.Time

--- a/internal/topic/topicwriterinternal/writer_reconnector.go
+++ b/internal/topic/topicwriterinternal/writer_reconnector.go
@@ -369,7 +369,7 @@ func (w *WriterReconnector) connectionLoop(ctx context.Context) {
 		streamCtx, streamCtxCancel = createStreamContext()
 
 		now := time.Now()
-		if topic.CheckResetReconnectionCounters(prevAttemptTime, now, w.cfg.connectTimeout) {
+		if startOfRetries.IsZero() || topic.CheckResetReconnectionCounters(prevAttemptTime, now, w.cfg.connectTimeout) {
 			attempt = 0
 			startOfRetries = w.clock.Now()
 		} else {

--- a/internal/topic/topicwriterinternal/writer_reconnector_test.go
+++ b/internal/topic/topicwriterinternal/writer_reconnector_test.go
@@ -516,7 +516,7 @@ func TestWriterImpl_Reconnect(t *testing.T) {
 		err := w.Write(ctx, newTestMessages(1))
 		require.NoError(t, err)
 
-		xtest.WaitChannelClosed(t, connectionLoopStopped)
+		xtest.WaitChannelClosedWithTimeout(t, connectionLoopStopped, 4*time.Second)
 	})
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->
Hello! 

I've created topic writer with `StartTimeout` 30 seconds and Default or Retry `RetryPolicy`.
Then with ip6tables I've blocked the YDB port to get transport error.
The retries are expected to stop after 30 seconds, but this does not happened. 

The reason why this is happened is `connectionTimeout*resetAttemptEmpiricalCoefficient` overflow. 
If `connectionTimeout` is `time.Duration(math.MaxInt64)` (that is always true, since we do not have options to set `connectionTimeout`), then its multiplication to empirical coefficient (=10) gives negative value (see playground https://goplay.space/#qlIeS6o3PCz). 
As a result, function `CheckResetReconnectionCounters` always returns true. Since `CheckResetReconnectionCounters` gives true, `startOfRetries` in `connectionLoop` loop method always sets to `w.clock.Now()`. Thus, in `CheckRetryMode` there are no chance to get `retriesDuration > settings.StartTimeout` to stop reconnections. As a result, we always get infinite reconnections in `Retry` and `Default` modes.

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Topic writer with `StartTimeout` set to X and Default or Retry `RetryPolicy`.
Topic writer gets any error in Retry mode or retryable error in Default mode. 
After X time topic writer **continue** reconnections. 

Issue Number: N/A

## What is the new behavior?
Topic writer with `StartTimeout` set to X and Default or Retry `RetryPolicy`.
Topic writer gets any error in Retry mode or retryable error in Default mode. 
After X time topic writer **stop** reconnections. 

<!-- Please describe the behavior or changes that are being added by this PR. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Condition `startOfRetries.IsZero()` is needed to set `startOfRetries` for the first time.
Since with infinite connection duration `CheckResetReconnectionCounters` will return false.