### PR TITLE
Push to main branch before create tag.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,7 +70,7 @@ jobs:
             TAG="v$MAJOR.$MINOR.$PATCH";
           fi;
           git tag $TAG
-          git push --tags && git push
+          git push && git push --tags
           CHANGELOG="$CHANGELOG
           
           Full Changelog: [$LAST_TAG...$TAG](https://github.com/ydb-platform/ydb-go-sdk/compare/$LAST_TAG...$TAG)"


### PR DESCRIPTION
For prevent situation when tag point to commit, which doesn't exist in main branch.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
push tags, then push branch

## What is the new behavior?
push branch then push tags

It prevent situation, when exists tag for commit without branch (if push to branch fail)