### PR TITLE
refactoring: move internal/xerrors.operationStatus to internal/operation/status.Status

### DIFF
--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -70,9 +70,7 @@ func (c *Client) Discover(ctx context.Context) (endpoints []endpoint.Endpoint, e
 
 	if response.GetOperation().GetStatus() != Ydb.StatusIds_SUCCESS {
 		return nil, xerrors.WithStackTrace(
-			xerrors.Operation(
-				xerrors.FromOperation(response.GetOperation()),
-			),
+			xerrors.FromOperation(response.GetOperation()),
 		)
 	}
 
@@ -126,10 +124,8 @@ func (c *Client) WhoAmI(ctx context.Context) (whoAmI *discovery.WhoAmI, err erro
 
 	if response.GetOperation().GetStatus() != Ydb.StatusIds_SUCCESS {
 		return nil, xerrors.WithStackTrace(
-			xerrors.Operation(
-				xerrors.FromOperation(
-					response.GetOperation(),
-				),
+			xerrors.FromOperation(
+				response.GetOperation(),
 			),
 		)
 	}

--- a/internal/operation/status.go
+++ b/internal/operation/status.go
@@ -1,0 +1,11 @@
+package operation
+
+import (
+	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb"
+	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Issue"
+)
+
+type Status interface {
+	GetStatus() Ydb.StatusIds_StatusCode
+	GetIssues() []*Ydb_Issue.IssueMessage
+}

--- a/internal/table/session.go
+++ b/internal/table/session.go
@@ -1083,9 +1083,7 @@ func (s *session) ReadRows(
 
 	if response.GetStatus() != Ydb.StatusIds_SUCCESS {
 		return nil, xerrors.WithStackTrace(
-			xerrors.Operation(
-				xerrors.FromOperation(response),
-			),
+			xerrors.FromOperation(response),
 		)
 	}
 

--- a/internal/xerrors/operation.go
+++ b/internal/xerrors/operation.go
@@ -8,10 +8,11 @@ import (
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Issue"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/backoff"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/operation"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xstring"
 )
 
-// operationError reports about operationStatus fail.
+// operationError reports about operation fail.
 type operationError struct {
 	code    Ydb.StatusIds_StatusCode
 	issues  issues
@@ -29,18 +30,13 @@ func (e *operationError) Name() string {
 	return "operation/" + e.code.String()
 }
 
-type operationStatus interface {
-	GetStatus() Ydb.StatusIds_StatusCode
-	GetIssues() []*Ydb_Issue.IssueMessage
-}
-
 type issuesOption []*Ydb_Issue.IssueMessage
 
 func (issues issuesOption) applyToOperationError(oe *operationError) {
 	oe.issues = []*Ydb_Issue.IssueMessage(issues)
 }
 
-// WithIssues is an option for construct operationStatus error with issues list
+// WithIssues is an option for construct operation error with issues list
 // WithIssues must use as `Operation(WithIssues(issues))`
 func WithIssues(issues []*Ydb_Issue.IssueMessage) issuesOption {
 	return issues
@@ -52,7 +48,7 @@ func (code statusCodeOption) applyToOperationError(oe *operationError) {
 	oe.code = Ydb.StatusIds_StatusCode(code)
 }
 
-// WithStatusCode is an option for construct operationStatus error with reason code
+// WithStatusCode is an option for construct operation error with reason code
 // WithStatusCode must use as `Operation(WithStatusCode(reason))`
 func WithStatusCode(code Ydb.StatusIds_StatusCode) statusCodeOption {
 	return statusCodeOption(code)
@@ -72,24 +68,25 @@ func (traceID traceIDOption) applyToOperationError(oe *operationError) {
 	oe.traceID = string(traceID)
 }
 
-// WithTraceID is an option for construct operationStatus error with traceID
+// WithTraceID is an option for construct operation error with traceID
 func WithTraceID(traceID string) traceIDOption {
 	return traceIDOption(traceID)
 }
 
-type operationOption struct {
-	operationStatus
+type operationOption = operationError
+
+func (e *operationOption) applyToOperationError(oe *operationError) {
+	oe.code = e.code
+	oe.issues = e.issues
 }
 
-func (operation operationOption) applyToOperationError(oe *operationError) {
-	oe.code = operation.GetStatus()
-	oe.issues = operation.GetIssues()
-}
-
-// FromOperation is an option for construct operationStatus error from operationStatus
-// FromOperation must use as `Operation(FromOperation(operationStatus))`
-func FromOperation(operation operationStatus) operationOption {
-	return operationOption{operation}
+// FromOperation is an option for construct operation error from operation.Status
+// FromOperation must use as `Operation(FromOperation(operation.Status))`
+func FromOperation(operation operation.Status) *operationOption {
+	return &operationOption{
+		code:   operation.GetStatus(),
+		issues: operation.GetIssues(),
+	}
 }
 
 type oeOpt interface {


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
