### PR TITLE
Handle EOF error when reading stream.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-* Fixed unhandled EOF in topic service
+* Stopped wrapping err error as transport error at topic streams (internals)
 
 ## v3.56.1
 * Fixed fixenv usage (related to tests only)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed unhandled EOF in topic service
+
 ## v3.56.1
 * Fixed fixenv usage (related to tests only)
 

--- a/internal/grpcwrapper/rawtopic/rawtopicreader/rawtopicreader.go
+++ b/internal/grpcwrapper/rawtopic/rawtopicreader/rawtopicreader.go
@@ -3,6 +3,7 @@ package rawtopicreader
 import (
 	"errors"
 	"fmt"
+	"io"
 	"reflect"
 
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Topic"
@@ -30,6 +31,9 @@ func (s StreamReader) CloseSend() error {
 
 func (s StreamReader) Recv() (ServerMessage, error) {
 	grpcMess, err := s.Stream.Recv()
+	if xerrors.Is(err, io.EOF) {
+		return nil, err
+	}
 	if err != nil {
 		if !xerrors.IsErrorFromServer(err) {
 			err = xerrors.Transport(err)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Unhadnled EOF error converted to transport error with gRPC code `Unknown`.

Issue Number: SLYDB-894

## What is the new behavior?
EOF handled correctly.
