### PR TITLE
Default timeout for topic writer connection is infinite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Changed default StartTime (time of retries for connect to server) for topic writer from 1 minute to infinite (can be overrided by WithWriterStartTimeout topic option)
 * Added `Struct` support for `Variant` in `ydb.ParamsBuilder()`
 
 ## v3.61.2

--- a/internal/topic/retriable_error.go
+++ b/internal/topic/retriable_error.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	DefaultStartTimeout          = time.Minute
+	DefaultStartTimeout          = value.InfiniteDuration
 	connectionEstablishedTimeout = time.Minute
 )
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe):

## What is the current behavior?

Change default timeout for topic writer connection to a server.