### PR TITLE
restored WithSessionPoolKeepAliveMinSize & WithSessionPoolKeepAliveTimeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 * Added `Struct` support for `Variant` in `ydb.ParamsBuilder()`
+* Restored `WithSessionPoolKeepAliveMinSize` and `WithSessionPoolKeepAliveTimeout` for backward compatibility.
 
 ## v3.61.2
 * Changed default transaction control to `NoTx` for execute query through query service client 

--- a/options.go
+++ b/options.go
@@ -432,6 +432,20 @@ func WithSessionPoolDeleteTimeout(deleteTimeout time.Duration) Option {
 	}
 }
 
+// WithSessionPoolKeepAliveMinSize set minimum sessions should be keeped alive in table.Client
+//
+// Deprecated: table client do not support background session keep-aliving now
+func WithSessionPoolKeepAliveMinSize(keepAliveMinSize int) Option {
+	return func(ctx context.Context, c *Driver) error { return nil }
+}
+
+// WithSessionPoolKeepAliveTimeout set timeout of keep alive requests for session in table.Client
+//
+// Deprecated: table client do not support background session keep-aliving now
+func WithSessionPoolKeepAliveTimeout(keepAliveTimeout time.Duration) Option {
+	return func(ctx context.Context, c *Driver) error { return nil }
+}
+
 // WithIgnoreTruncated disables errors on truncated flag
 func WithIgnoreTruncated() Option {
 	return func(ctx context.Context, c *Driver) error {


### PR DESCRIPTION
for backward compatibility.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1173 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
