### PR TITLE
fix: re-send cancel message on coordination session re-attach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed the hanging semaphore issue on coordination session reconnect
+
 ## v3.65.3
 * Fixed data race in `internal/conn.grpcClientStream` 
 

--- a/internal/coordination/conversation/conversation.go
+++ b/internal/coordination/conversation/conversation.go
@@ -424,7 +424,12 @@ func (c *Controller) OnAttach() {
 				delete(c.conflicts, req.conflictKey)
 			}
 
-			req.requestSent = nil
+			// If the request has been canceled, re-send the cancellation message, otherwise re-send the original one.
+			if req.canceled {
+				req.cancelRequestSent = nil
+			} else {
+				req.requestSent = nil
+			}
 			notify = true
 		}
 	}


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The current version may re-send original requests for already canceled conversations which may lead to inconsistency between the client and server state.

## What is the new behavior?

If a coordination service session re-attaches, idempotent conversations requests are being re-sent. However, if a conversation has been canceled, only its cancelation request must be re-send.
