### PR TITLE
Writer flush messages before close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Added flush messages from buffer before close topic writer
 * Added Flush method for topic writer
 
 ## v3.66.0

--- a/internal/topic/topicwriterinternal/writer_reconnector.go
+++ b/internal/topic/topicwriterinternal/writer_reconnector.go
@@ -330,7 +330,17 @@ func (w *WriterReconnector) Flush(ctx context.Context) error {
 }
 
 func (w *WriterReconnector) Close(ctx context.Context) error {
-	return w.close(ctx, xerrors.WithStackTrace(errStopWriterReconnector))
+	reason := xerrors.WithStackTrace(errStopWriterReconnector)
+	w.queue.StopAddNewMessages(reason)
+
+	flushErr := w.Flush(ctx)
+	closeErr := w.close(ctx, reason)
+
+	if flushErr != nil {
+		return flushErr
+	}
+
+	return closeErr
 }
 
 func (w *WriterReconnector) close(ctx context.Context, reason error) (resErr error) {
@@ -338,10 +348,6 @@ func (w *WriterReconnector) close(ctx context.Context, reason error) (resErr err
 	defer func() {
 		onDone(resErr)
 	}()
-
-	w.queue.StopAddNewMessages(reason)
-
-	resErr = w.Flush(ctx)
 
 	closeErr := w.queue.Close(reason)
 	if resErr == nil && closeErr != nil {

--- a/internal/topic/topicwriterinternal/writer_reconnector.go
+++ b/internal/topic/topicwriterinternal/writer_reconnector.go
@@ -339,9 +339,17 @@ func (w *WriterReconnector) close(ctx context.Context, reason error) (resErr err
 		onDone(resErr)
 	}()
 
-	resErr = w.queue.Close(reason)
+	w.queue.StopAddNewMessages(reason)
+
+	resErr = w.Flush(ctx)
+
+	closeErr := w.queue.Close(reason)
+	if resErr == nil && closeErr != nil {
+		resErr = closeErr
+	}
+
 	bgErr := w.background.Close(ctx, reason)
-	if resErr == nil {
+	if resErr == nil && bgErr != nil {
 		resErr = bgErr
 	}
 

--- a/internal/topic/topicwriterinternal/writer_reconnector_test.go
+++ b/internal/topic/topicwriterinternal/writer_reconnector_test.go
@@ -196,7 +196,8 @@ func TestWriterImpl_WriteCodecs(t *testing.T) {
 			Data: bytes.NewReader(messContent),
 		}}))
 
-		require.Equal(t, rawtopiccommon.CodecRaw, <-messReceived)
+		mess := <-messReceived
+		require.Equal(t, rawtopiccommon.CodecRaw, mess)
 	})
 	t.Run("ForceGzip", func(t *testing.T) {
 		var err error

--- a/internal/topic/topicwriterinternal/writer_reconnector_test.go
+++ b/internal/topic/topicwriterinternal/writer_reconnector_test.go
@@ -531,67 +531,107 @@ func TestWriterImpl_Reconnect(t *testing.T) {
 }
 
 func TestWriterImpl_CloseWithFlush(t *testing.T) {
-	e := newTestEnv(t, nil)
+	type flushMethod func(ctx context.Context, writer *WriterReconnector) error
 
-	messageTime := time.Date(2023, 9, 7, 11, 34, 0, 0, time.UTC)
-	messageData := []byte("123")
+	f := func(t testing.TB, flush flushMethod) {
+		e := newTestEnv(t, nil)
 
-	const seqNo = 36
+		messageTime := time.Date(2023, 9, 7, 11, 34, 0, 0, time.UTC)
+		messageData := []byte("123")
 
-	writeCompleted := make(empty.Chan)
-	e.stream.EXPECT().Send(&rawtopicwriter.WriteRequest{
-		Messages: []rawtopicwriter.MessageData{
-			{
-				SeqNo:            seqNo,
-				CreatedAt:        messageTime,
-				UncompressedSize: int64(len(messageData)),
-				Partitioning:     rawtopicwriter.Partitioning{},
-				Data:             messageData,
-			},
-		},
-		Codec: rawtopiccommon.CodecRaw,
-	}).Return(nil)
+		const seqNo = 36
 
-	closeCompleted := make(empty.Chan)
-	go func() {
-		err := e.writer.Write(e.ctx, []PublicMessage{{
-			SeqNo:     seqNo,
-			CreatedAt: messageTime,
-			Data:      bytes.NewReader(messageData),
-		}})
-		close(writeCompleted)
-		require.NoError(t, err)
-	}()
-
-	<-writeCompleted
-
-	go func() {
-		require.NoError(t, e.writer.Flush(e.ctx))
-		require.NoError(t, e.writer.Close(e.ctx))
-		close(closeCompleted)
-	}()
-
-	select {
-	case <-closeCompleted:
-		t.Fatal("flush and close must complete only after message is acked")
-	case <-time.After(100 * time.Millisecond):
-		// pass
-	}
-
-	e.sendFromServer(&rawtopicwriter.WriteResult{
-		Acks: []rawtopicwriter.WriteAck{
-			{
-				SeqNo: seqNo,
-				MessageWriteStatus: rawtopicwriter.MessageWriteStatus{
-					Type:          rawtopicwriter.WriteStatusTypeWritten,
-					WrittenOffset: 4,
+		writeCompleted := make(empty.Chan)
+		e.stream.EXPECT().Send(&rawtopicwriter.WriteRequest{
+			Messages: []rawtopicwriter.MessageData{
+				{
+					SeqNo:            seqNo,
+					CreatedAt:        messageTime,
+					UncompressedSize: int64(len(messageData)),
+					Partitioning:     rawtopicwriter.Partitioning{},
+					Data:             messageData,
 				},
 			},
-		},
-		PartitionID: e.partitionID,
-	})
+			Codec: rawtopiccommon.CodecRaw,
+		}).Return(nil)
 
-	xtest.WaitChannelClosed(t, closeCompleted)
+		flushCompleted := make(empty.Chan)
+		go func() {
+			err := e.writer.Write(e.ctx, []PublicMessage{{
+				SeqNo:     seqNo,
+				CreatedAt: messageTime,
+				Data:      bytes.NewReader(messageData),
+			}})
+			close(writeCompleted)
+			require.NoError(t, err)
+		}()
+
+		<-writeCompleted
+
+		go func() {
+			require.NoError(t, flush(e.ctx, e.writer))
+			close(flushCompleted)
+		}()
+
+		select {
+		case <-flushCompleted:
+			t.Fatal("flush and close must complete only after message is acked")
+		case <-time.After(10 * time.Millisecond):
+			// pass
+		}
+
+		e.sendFromServer(&rawtopicwriter.WriteResult{
+			Acks: []rawtopicwriter.WriteAck{
+				{
+					SeqNo: seqNo,
+					MessageWriteStatus: rawtopicwriter.MessageWriteStatus{
+						Type:          rawtopicwriter.WriteStatusTypeWritten,
+						WrittenOffset: 4,
+					},
+				},
+			},
+			PartitionID: e.partitionID,
+		})
+
+		xtest.WaitChannelClosed(t, flushCompleted)
+	}
+
+	tests := []struct {
+		name  string
+		flush flushMethod
+	}{
+		{
+			name: "close",
+			flush: func(ctx context.Context, writer *WriterReconnector) error {
+				return writer.Close(ctx)
+			},
+		},
+		{
+			name: "flush",
+			flush: func(ctx context.Context, writer *WriterReconnector) error {
+				return writer.Close(ctx)
+			},
+		},
+		{
+			name: "flush and close",
+			flush: func(ctx context.Context, writer *WriterReconnector) error {
+				err := writer.Flush(ctx)
+				if err != nil {
+					return err
+				}
+
+				return writer.Close(ctx)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			xtest.TestManyTimes(t, func(t testing.TB) {
+				f(t, test.flush)
+			})
+		})
+	}
 }
 
 func TestAllMessagesHasSameBufCodec(t *testing.T) {

--- a/tests/integration/helpers_test.go
+++ b/tests/integration/helpers_test.go
@@ -103,7 +103,9 @@ func (scope *scopeT) Driver(opts ...ydb.Option) *ydb.Driver {
 			)...,
 		)
 		clean := func() {
-			scope.Require.NoError(driver.Close(scope.Ctx))
+			if driver != nil {
+				scope.Require.NoError(driver.Close(scope.Ctx))
+			}
 		}
 
 		return fixenv.NewGenericResultWithCleanup(driver, clean), err

--- a/topic/topicwriter/topicwriter.go
+++ b/topic/topicwriter/topicwriter.go
@@ -66,6 +66,8 @@ func (w *Writer) WaitInitInfo(ctx context.Context) (info PublicInitialInfo, err 
 	return publicInfo, nil
 }
 
+// Close will flush rested messages from buffer and close the writer.
+// You can't write new messages after call Close
 func (w *Writer) Close(ctx context.Context) error {
 	return w.inner.Close(ctx)
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Close writer right after call Close(...) and lost messages from a buffer

## What is the new behavior?
Flush messages before close