### PR TITLE
Fixed empty database in DSN while using config.WithDatabase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-* Fixed config.WithDatabase behaviour with empty database in DSN string
+* Fixed `config.WithDatabase` behaviour with empty database in DSN string
 * Added experimental method `query/Client.Execute` for execute query and read materialized result
 
 ## v3.69.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Fixed config.WithDatabase behaviour with empty database in DSN string
 * Added experimental method `query/Client.Execute` for execute query and read materialized result
 
 ## v3.69.0

--- a/internal/dsn/dsn.go
+++ b/internal/dsn/dsn.go
@@ -35,8 +35,10 @@ func Parse(dsn string) (info parsedInfo, err error) {
 	info.Options = append(info.Options,
 		config.WithSecure(uri.Scheme != insecureSchema),
 		config.WithEndpoint(uri.Host),
-		config.WithDatabase(uri.Path),
 	)
+	if uri.Path != "" {
+		info.Options = append(info.Options, config.WithDatabase(uri.Path))
+	}
 	if uri.User != nil {
 		password, _ := uri.User.Password()
 		info.UserInfo = &UserInfo{

--- a/internal/dsn/dsn_test.go
+++ b/internal/dsn/dsn_test.go
@@ -124,3 +124,15 @@ func TestParseConnectionString(t *testing.T) {
 		})
 	}
 }
+
+func TestParseConnectionStringEmptyDatabase(t *testing.T) {
+	info, err := Parse("grpc://ydb-ru.yandex.net:2135")
+	if err != nil {
+		t.Fatalf("Received unexpected error:\n%+v", err)
+	}
+	c := config.New(config.WithDatabase("mydb"))
+	c = c.With(info.Options...)
+	require.Equal(t, false, c.Secure())
+	require.Equal(t, "ydb-ru.yandex.net:2135", c.Endpoint())
+	require.Equal(t, "mydb", c.Database())
+}

--- a/internal/dsn/dsn_test.go
+++ b/internal/dsn/dsn_test.go
@@ -132,7 +132,7 @@ func TestParseConnectionStringEmptyDatabase(t *testing.T) {
 	}
 	c := config.New(config.WithDatabase("mydb"))
 	c = c.With(info.Options...)
-	require.Equal(t, false, c.Secure())
+	require.False(t, c.Secure())
 	require.Equal(t, "ydb-ru.yandex.net:2135", c.Endpoint())
 	require.Equal(t, "mydb", c.Database())
 }


### PR DESCRIPTION
## Pull request type

- [X] Bugfix

## What is the current behavior?

Using empty database in ydb.Open with config.WithDatabase gives `configuration: empty database at github.com/ydb-platform/ydb-go-sdk/v3.(*Driver).connect(driver.go:389) at github.com/ydb-platform/ydb-go-sdk/v3.Open(driver.go:266)` error:

```go
ydbOpts := []ydb.Option{
	ydb.WithDatabase("/local"),
}

_, err := ydb.Open(
	ctx,
	"grpc://localhost:2136",
	ydbOpts...,
)
if err != nil {
	panic(err.Error())
}
```

Issue Number: N/A

## What is the new behavior?

Like in older versions of SDK (3.65.3 for sure), the code above connects to /local database.