### PR TITLE
use buffered channel to manage items in query pool

### DIFF
--- a/internal/pool/defaults.go
+++ b/internal/pool/defaults.go
@@ -1,6 +1,22 @@
 package pool
 
-const DefaultLimit = 50
+import "time"
+
+const (
+	DefaultLimit = 50
+
+	// defaultCreateRetryDelay specifies amount of time that spawner will wait
+	// before retrying unsuccessful item create.
+	defaultCreateRetryDelay = 500 * time.Millisecond
+
+	// defaultSpawnGoroutinesNumber specifies amount of spawnItems goroutines.
+	// Having more than one spawner can potentially decrease warm-up time
+	// and connections re-establishment time after connectivity failure.
+	// Too high value will result in frequent connection establishment
+	// attempts (see defaultCreateRetryDelay) during connectivity
+	// issues which in some cases might not be desirable.
+	defaultSpawnGoroutinesNumber = 2
+)
 
 var defaultTrace = &Trace{
 	OnNew: func(info *NewStartInfo) func(info *NewDoneInfo) {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Current approach has couple shortcomings:
- items can be created above configured limit
- item will not be closed during shutdown if it was only in idle slice and not added to index map.
- pool has no warm-up, new items are created upon request 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

I propose to use buffered channel to manage query pool items as oppose to index map and idle slice. This approach makes item creation process continuous and asynchronous, which allows seamlessly warm-up pool or re-establish all connections after connectivity failure.

Internally I introduced: 
- item queue (buffered channel) - main item queue
- item tokens (buffered channel) - item creation requests
- item spawner goroutine - runs asynchronously and fills queue with new items

getItem() and putItem() are working with item queue - receiving or sending back items. New thing about getItem() is that it ensures that retrieved item is ok to use (as far IsAlive() can tell). To achieve this it spins in endless loop until in can receive item from queue. This means in case of connectivity failure or pool starvation it will block causing back pressure to caller (who should use context with deadline if it wishes to not block as well but detect this situation).

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
