### PR TITLE
Fix nil pointer dereference when closing result set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed nil pointer dereference when closing result set
+
 ## v3.74.4
 * Fixed bug with fail cast of grpc response to `operation.{Response,Status}`
 

--- a/internal/query/client.go
+++ b/internal/query/client.go
@@ -231,15 +231,15 @@ func clientExecute(ctx context.Context,
 	q string, opts ...options.ExecuteOption,
 ) (r query.Result, err error) {
 	err = do(ctx, pool, func(ctx context.Context, s query.Session) (err error) {
-		_, r, err = s.Execute(ctx, q, opts...)
+		_, streamResult, err := s.Execute(ctx, q, opts...)
 		if err != nil {
 			return xerrors.WithStackTrace(err)
 		}
 		defer func() {
-			_ = r.Close(ctx)
+			_ = streamResult.Close(ctx)
 		}()
 
-		r, err = resultToMaterializedResult(ctx, r)
+		r, err = resultToMaterializedResult(ctx, streamResult)
 		if err != nil {
 			return xerrors.WithStackTrace(err)
 		}


### PR DESCRIPTION
fixed nil pointer dereference when `resultToMaterializedResult` returned error

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

````
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0xab2966]
```

Issue Number: N/A

## What is the new behavior?

returned error from `resultToMaterializedResult`

## Other information
