### PR TITLE
Do not check ResultSetIndex when ResuilSet is nil.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Fixed bug with reading empty result set parts.
 * Fixed nil pointer dereference when closing result set
 
 ## v3.74.4

--- a/internal/query/result_set.go
+++ b/internal/query/result_set.go
@@ -143,7 +143,7 @@ func (rs *resultSet) nextRow(ctx context.Context) (*row, error) {
 					return nil, xerrors.WithStackTrace(io.EOF)
 				}
 			}
-			if rs.index != rs.currentPart.GetResultSetIndex() {
+			if rs.currentPart.GetResultSet() != nil && rs.index != rs.currentPart.GetResultSetIndex() {
 				close(rs.done)
 
 				return nil, xerrors.WithStackTrace(fmt.Errorf(

--- a/tests/integration/query_multi_result_sets_test.go
+++ b/tests/integration/query_multi_result_sets_test.go
@@ -1,0 +1,77 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/version"
+	"github.com/ydb-platform/ydb-go-sdk/v3/query"
+)
+
+func TestQueryMultiResultSets(t *testing.T) {
+	if version.Lt(os.Getenv("YDB_VERSION"), "24.1") {
+		t.Skip("query service not allowed in YDB version '" + os.Getenv("YDB_VERSION") + "'")
+	}
+
+	scope := newScope(t)
+	var i, j, k int
+	db := scope.Driver()
+	err := db.Query().Do(scope.Ctx, func(ctx context.Context, s query.Session) (err error) {
+		_, res, err := s.Execute(ctx, `SELECT 42; SELECT 43, 44;`)
+		if err != nil {
+			return fmt.Errorf("can't get result: %w", err)
+		}
+		set, err := res.NextResultSet(ctx)
+		if err != nil {
+			return fmt.Errorf("set 0: get next result set: %w", err)
+		}
+
+		for row, err := set.NextRow(ctx); !errors.Is(err, io.EOF); row, err = set.NextRow(ctx) {
+			if err != nil {
+				return fmt.Errorf("set 0: get next row: %w", err)
+			}
+			if err := row.Scan(&i); err != nil {
+				return fmt.Errorf("set 0: scan row: %w", err)
+			}
+			fmt.Println(i)
+		}
+
+		set, err = res.NextResultSet(ctx)
+		if err != nil {
+			return err
+		}
+
+		for row, err := set.NextRow(ctx); !errors.Is(err, io.EOF); row, err = set.NextRow(ctx) {
+			if err != nil {
+				return fmt.Errorf("set 1: get next row: %w", err)
+			}
+
+			if err := row.Scan(&j, &k); err != nil {
+				return fmt.Errorf("set 1: scan row: %w", err)
+			}
+			fmt.Println(j, k)
+		}
+		_, err = res.NextResultSet(ctx)
+		if !errors.Is(err, io.EOF) {
+			return fmt.Errorf("get next result set: %w", err)
+		}
+
+		if res.Err() != nil {
+			return fmt.Errorf("res.Err() = %w", res.Err())
+		}
+		return nil
+	}, query.WithIdempotent())
+
+	scope.Require.NoError(err)
+
+	scope.Require.Equal(42, i)
+	scope.Require.Equal(43, j)
+	scope.Require.Equal(44, k)
+}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

```
query: non-retryable error occurred on attempt No.1 (idempotent=true): set 1: get next row: received part with result set index = 1, current result set index = 0: critical violation of the logic - wrong result set index at `github.com/ydb-platform/ydb-go-sdk/v3/internal/query.(*resultSet).nextRow(result_set.go:149)` at `github.com/ydb-platform/ydb-go-sdk/v3/internal/query.do.func1(client.go:126)` at `github.com/ydb-platform/ydb-go-sdk/v3/internal/query.(*poolStub).With.func2(client.go:83)` at `github.com/ydb-platform/ydb-go-sdk/v3/retry.Retry.func1(retry.go:264)` at `github.com/ydb-platform/ydb-go-sdk/v3/retry.opWithRecover(retry.go:411)` at `github.com/ydb-platform/ydb-go-sdk/v3/retry.RetryWithResult(retry.go:356)` at `github.com/ydb-platform/ydb-go-sdk/v3/retry.Retry(retry.go:270)` at `github.com/ydb-platform/ydb-go-sdk/v3/internal/query.(*poolStub).With(client.go:89)` at `github.com/ydb-platform/ydb-go-sdk/v3/internal/query.do(client.go:134)`
```

Issue Number: #1310

## What is the new behavior?

EOF returned when next part is empty