### PR TITLE
[OAuth 2 token exchange] Don't take lock when performing http request. Add retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Added `query.ResultSet.Index()` method
 * Support loading OAuth 2.0 token exchange credentials provider from config file
 * Added options for JWT tokens for loading EC private keys and HMAC secrets
+* Add retries to OAuth 2.0 token exchange credentials
 
 ## v3.74.5
 * Fixed bug with reading empty result set parts.
@@ -14,11 +15,11 @@
 * Fixed bug with fail cast of grpc response to `operation.{Response,Status}`
 
 ## v3.74.3
-* Removed check the node is available for query and table service sessions 
+* Removed check the node is available for query and table service sessions
 * Refactored the `balancers.PreferLocations()` function - it is a clean/pure function
 * Added experimental `balancers.WithNodeID()` context modifier for define per request the YDB endpoint by NodeID
 * Reverted the allowing the casts from signed YDB types to unsigned destination types if source value is not negative
-* Replaced internal query session pool by default to stub for exclude impact from internal/pool 
+* Replaced internal query session pool by default to stub for exclude impact from internal/pool
 
 ## v3.74.2
 * Added description to scan errors with use query service client scanner
@@ -67,7 +68,7 @@
 ## v3.68.0
 * Added experimental `ydb.{Register,Unregister}DsnParser` global funcs for register/unregister external custom DSN parser for `ydb.Open` and `sql.Open` driver constructor
 * Simple implement option WithReaderWithoutConsumer
-* Fixed bug: topic didn't send specified partition number to a server 
+* Fixed bug: topic didn't send specified partition number to a server
 
 ## v3.67.2
 * Fixed incorrect formatting of decimal. Implementation of decimal has been reverted to latest working version
@@ -92,12 +93,12 @@
 * Added Flush method for topic writer
 
 ## v3.66.0
-* Added experimental package `retry/budget` for limit second and subsequent retry attempts 
+* Added experimental package `retry/budget` for limit second and subsequent retry attempts
 * Refactored internals for enabling `containedctx` linter
 * Fixed the hanging semaphore issue on coordination session reconnect
 
 ## v3.65.3
-* Fixed data race in `internal/conn.grpcClientStream` 
+* Fixed data race in `internal/conn.grpcClientStream`
 
 ## v3.65.2
 * Fixed data race using `log.WithNames`

--- a/credentials/options.go
+++ b/credentials/options.go
@@ -55,6 +55,11 @@ func WithRequestTimeout(timeout time.Duration) Oauth2TokenExchangeCredentialsOpt
 	return credentials.WithRequestTimeout(timeout)
 }
 
+// SyncExchangeTimeout
+func WithSyncExchangeTimeout(timeout time.Duration) Oauth2TokenExchangeCredentialsOption {
+	return credentials.WithSyncExchangeTimeout(timeout)
+}
+
 // SubjectTokenSource
 func WithSubjectToken(subjectToken credentials.TokenSource) Oauth2TokenExchangeCredentialsOption {
 	return credentials.WithSubjectToken(subjectToken)


### PR DESCRIPTION
OAuth 2.0 token exchange credentials provider fixes and improvements

* Don't take lock when performing http request
* Add retries

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
