### PR TITLE
Metrics over table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Added metrics over `table.Do()` and `table.DoTx()`
 * Added method `ydb.ParamsBuilder().Param(name).Any(value)` to add custom `types.Value`
 * Upgraded dependencies:
   * `google.golang.org/grpc` - from `v1.57.1` to `v1.62.1`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-* Added metrics over `table.Do()` and `table.DoTx()`
+* Added metrics over `db.Table().Do()` and `db.Table().DoTx()`
 * Added method `ydb.ParamsBuilder().Param(name).Any(value)` to add custom `types.Value`
 * Upgraded dependencies:
   * `google.golang.org/grpc` - from `v1.57.1` to `v1.62.1`

--- a/metrics/table.go
+++ b/metrics/table.go
@@ -84,37 +84,37 @@ func table(config Config) (t trace.Table) {
 		return nil
 	}
 	{
-		queryLatency := session.WithSystem("query").TimerVec("latency")
-		queryError := session.WithSystem("query").CounterVec("errs", "status")
-		queryAttempts := session.WithSystem("query").HistogramVec("attempts", []float64{0, 1, 2, 3, 4, 5, 7, 10})
+		latency := session.WithSystem("query").TimerVec("latency")
+		errs := session.WithSystem("query").CounterVec("errs", "status")
+		attempts := session.WithSystem("query").HistogramVec("attempts", []float64{0, 1, 2, 3, 4, 5, 7, 10})
 		t.OnDo = func(info trace.TableDoStartInfo) func(trace.TableDoDoneInfo) {
 			start := time.Now()
 
 			return func(doneInfo trace.TableDoDoneInfo) {
 				if config.Details()&trace.TableSessionQueryEvents != 0 {
-					queryLatency.With(nil).Record(time.Since(start))
-					queryError.With(map[string]string{
+					latency.With(nil).Record(time.Since(start))
+					errs.With(map[string]string{
 						"status": errorBrief(doneInfo.Error),
 					})
-					queryAttempts.With(nil).Record(float64(doneInfo.Attempts))
+					attempts.With(nil).Record(float64(doneInfo.Attempts))
 				}
 			}
 		}
 	}
 	{
-		queryLatency := session.WithSystem("tx").TimerVec("latency")
-		queryError := session.WithSystem("tx").CounterVec("errs", "status")
-		queryAttempts := session.WithSystem("tx").HistogramVec("attempts", []float64{0, 1, 2, 3, 4, 5, 7, 10})
+		latency := session.WithSystem("tx").TimerVec("latency")
+		errs := session.WithSystem("tx").CounterVec("errs", "status")
+		attempts := session.WithSystem("tx").HistogramVec("attempts", []float64{0, 1, 2, 3, 4, 5, 7, 10})
 		t.OnDoTx = func(info trace.TableDoTxStartInfo) func(trace.TableDoTxDoneInfo) {
 			start := time.Now()
 
 			return func(doneInfo trace.TableDoTxDoneInfo) {
 				if config.Details()&trace.TableSessionQueryEvents != 0 {
-					queryLatency.With(nil).Record(time.Since(start))
-					queryError.With(map[string]string{
+					latency.With(nil).Record(time.Since(start))
+					errs.With(map[string]string{
 						"status": errorBrief(doneInfo.Error),
 					})
-					queryAttempts.With(nil).Record(float64(doneInfo.Attempts))
+					attempts.With(nil).Record(float64(doneInfo.Attempts))
 				}
 			}
 		}


### PR DESCRIPTION
Add metrics:
```
table.session.query.latency
table.session.query.errs
table.session.query.attempts
table.session.tx.latency
table.session.tx.errs
table.session.tx.attempts
```
## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Issue Number: 1318

## What is the new behavior?

Add metrics over table.Do and tabel.DoTx similar to query.Do and query.DoTx
