### PR TITLE
add: unwrap method for issues errors

### DIFF
--- a/internal/xerrors/issues.go
+++ b/internal/xerrors/issues.go
@@ -115,6 +115,10 @@ func (e *withIssuesError) Is(target error) bool {
 	return false
 }
 
+func (e *withIssuesError) Unwrap() []error {
+	return e.issues
+}
+
 // Issue struct
 type Issue struct {
 	Message  string


### PR DESCRIPTION
Add Unwrap method for issues errors

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

We couldn't check issues inners errors. Add Unwrap method for issues errors

## What is the new behavior?

We could unwrap inner error for withIssuesError type. When i catch issues errors with DoTxWithResult call's, I want to sort errors by type so that they can be handled correctly. Add Unwrap method

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
