### PR TITLE
Hide EOF error in recvMsg logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* EOF error in RecvMsg is no longer logged
+
 ## v3.78.0
 * Changed result type of method `query.Executor.QueryResultSet` from `query.ResultSet` to `query.ClosableResultSet`
 * Added `table/types.DecimalValueFromString` decimal type constructor

--- a/log/driver.go
+++ b/log/driver.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/secret"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
 	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
 )
 
@@ -302,7 +303,7 @@ func internalDriver(l Logger, d trace.Detailer) trace.Driver {
 			start := time.Now()
 
 			return func(info trace.DriverConnStreamRecvMsgDoneInfo) {
-				if info.Error == nil {
+				if xerrors.HideEOF(info.Error) == nil {
 					l.Log(ctx, "done",
 						latencyField(start),
 					)


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
```
2024-09-04 21:53:18.534 WARN 'ydb.driver.conn.stream.RecvMsg' => failed {"error":"EOF","latency":"1.173618216s","version":"3.77.0"}
```
Issue Number: N/A

## What is the new behavior?

this error is not logged
