### PR TITLE
add: skip rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-* Doesn't rollback a the transaction on the operation error
+* Doesn't rollback a the transaction on the operation error in table service
 * Renamed method at experimental API reader.PopBatchTx to reader.PopMessagesBatchTx
 
 ## v3.80.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Doesn't rollback a the transaction on the operation error
 * Renamed method at experimental API reader.PopBatchTx to reader.PopMessagesBatchTx
 
 ## v3.80.5

--- a/internal/table/client.go
+++ b/internal/table/client.go
@@ -238,7 +238,7 @@ func (c *Client) DoTx(ctx context.Context, op table.TxOperation, opts ...table.O
 		}
 
 		defer func() {
-			if err != nil {
+			if err != nil && !xerrors.IsOperationError(err) {
 				_ = tx.Rollback(ctx)
 			}
 		}()


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

We skip rollback operation from ydb golang sdk because all DB server operation errors rollback from server. If we log error from underscore we could see new error as similar: `Transaction $transactionNumber not found`

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Currently, we catch extra error for rollbacked transacrion

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- skip rollback
![transaction_not_found](https://github.com/user-attachments/assets/1e7b00c4-89db-449a-a134-16678796be3d)


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
