### PR TITLE
add Topic.DescribeTopicConsumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Added `db.Topic().DescribeTopicConsumer()` method for displaying consumer information
+
 ## v3.84.1
 * Added session info into `trace.TableSessionBulkUpsertStartInfo`
 

--- a/internal/grpcwrapper/rawoptional/rawoptional.go
+++ b/internal/grpcwrapper/rawoptional/rawoptional.go
@@ -35,6 +35,26 @@ func (v *Duration) ToProto() *durationpb.Duration {
 	return nil
 }
 
+func (v *Duration) MustFromProto(proto *durationpb.Duration) {
+	if proto == nil {
+		v.Value = time.Duration(0)
+		v.HasValue = false
+
+		return
+	}
+
+	v.HasValue = true
+	v.Value = proto.AsDuration()
+}
+
+func (v *Duration) ToDuration() *time.Duration {
+	if v.HasValue {
+		return nil
+	}
+
+	return &v.Value
+}
+
 type Int64 struct {
 	Value    int64
 	HasValue bool
@@ -73,4 +93,12 @@ func (v *Time) MustFromProto(proto *timestamppb.Timestamp) {
 
 	v.HasValue = true
 	v.Value = proto.AsTime()
+}
+
+func (v *Time) ToTime() *time.Time {
+	if v.HasValue {
+		return nil
+	}
+
+	return &v.Value
 }

--- a/internal/grpcwrapper/rawtopic/client.go
+++ b/internal/grpcwrapper/rawtopic/client.go
@@ -46,9 +46,27 @@ func (c *Client) CreateTopic(
 func (c *Client) DescribeTopic(ctx context.Context, req DescribeTopicRequest) (res DescribeTopicResult, err error) {
 	resp, err := c.service.DescribeTopic(ctx, req.ToProto())
 	if err != nil {
-		return DescribeTopicResult{}, xerrors.WithStackTrace(xerrors.Wrap(
-			fmt.Errorf("ydb: describe topic grpc failed: %w", err),
-		))
+		return DescribeTopicResult{}, xerrors.WithStackTrace(
+			xerrors.Wrap(
+				fmt.Errorf("ydb: describe topic grpc failed: %w", err),
+			),
+		)
+	}
+	err = res.FromProto(resp)
+
+	return res, err
+}
+
+func (c *Client) DescribeConsumer(ctx context.Context, req DescribeConsumerRequest) (
+	res DescribeConsumerResult, err error,
+) {
+	resp, err := c.service.DescribeConsumer(ctx, req.ToProto())
+	if err != nil {
+		return DescribeConsumerResult{}, xerrors.WithStackTrace(
+			xerrors.Wrap(
+				fmt.Errorf("ydb: describe topic consumer grpc failed: %w", err),
+			),
+		)
 	}
 	err = res.FromProto(resp)
 

--- a/internal/grpcwrapper/rawtopic/describe_consumer.go
+++ b/internal/grpcwrapper/rawtopic/describe_consumer.go
@@ -1,0 +1,151 @@
+package rawtopic
+
+import (
+	"fmt"
+
+	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Topic"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/clone"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawoptional"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawscheme"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawtopic/rawtopiccommon"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawydb"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/operation"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
+)
+
+type DescribeConsumerRequest struct {
+	OperationParams rawydb.OperationParams
+	Path            string
+	Consumer        string
+	IncludeStats    bool
+}
+
+func (req *DescribeConsumerRequest) ToProto() *Ydb_Topic.DescribeConsumerRequest {
+	return &Ydb_Topic.DescribeConsumerRequest{
+		OperationParams: req.OperationParams.ToProto(),
+		Path:            req.Path,
+		Consumer:        req.Consumer,
+		IncludeStats:    req.IncludeStats,
+	}
+}
+
+type DescribeConsumerResult struct {
+	Operation  rawydb.Operation
+	Self       rawscheme.Entry
+	Consumer   Consumer
+	Partitions []DescribeConsumerResultPartitionInfo
+}
+
+func (res *DescribeConsumerResult) FromProto(response operation.Response) error {
+	if err := res.Operation.FromProtoWithStatusCheck(response.GetOperation()); err != nil {
+		return err
+	}
+	protoResult := &Ydb_Topic.DescribeConsumerResult{}
+	if err := response.GetOperation().GetResult().UnmarshalTo(protoResult); err != nil {
+		return xerrors.WithStackTrace(
+			fmt.Errorf(
+				"ydb: describe consumer result failed on unmarshal grpc result: %w", err,
+			),
+		)
+	}
+
+	if err := res.Self.FromProto(protoResult.GetSelf()); err != nil {
+		return err
+	}
+
+	res.Consumer.MustFromProto(protoResult.GetConsumer())
+
+	protoPartitions := protoResult.GetPartitions()
+	res.Partitions = make([]DescribeConsumerResultPartitionInfo, len(protoPartitions))
+	for i, protoPartition := range protoPartitions {
+		if err := res.Partitions[i].FromProto(protoPartition); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type MultipleWindowsStat struct {
+	PerMinute int64
+	PerHour   int64
+	PerDay    int64
+}
+
+func (stat *MultipleWindowsStat) MustFromProto(proto *Ydb_Topic.MultipleWindowsStat) {
+	stat.PerMinute = proto.GetPerMinute()
+	stat.PerHour = proto.GetPerHour()
+	stat.PerDay = proto.GetPerDay()
+}
+
+type PartitionStats struct {
+	PartitionsOffset rawtopiccommon.OffsetRange
+	StoreSizeBytes   int64
+	LastWriteTime    rawoptional.Time
+	MaxWriteTimeLag  rawoptional.Duration
+	BytesWritten     MultipleWindowsStat
+}
+
+func (ps *PartitionStats) FromProto(proto *Ydb_Topic.PartitionStats) error {
+	if proto == nil {
+		return nil
+	}
+	if err := ps.PartitionsOffset.FromProto(proto.GetPartitionOffsets()); err != nil {
+		return err
+	}
+	ps.StoreSizeBytes = proto.GetStoreSizeBytes()
+	ps.LastWriteTime.MustFromProto(proto.GetLastWriteTime())
+	ps.MaxWriteTimeLag.ToProto()
+	ps.BytesWritten.MustFromProto(proto.GetBytesWritten())
+
+	return nil
+}
+
+type PartitionConsumerStats struct {
+	LastReadOffset                 int64
+	CommittedOffset                int64
+	ReadSessionID                  string
+	PartitionReadSessionCreateTime rawoptional.Time
+	LastReadTime                   rawoptional.Time
+	MaxReadTimeLag                 rawoptional.Duration
+	MaxWriteTimeLag                rawoptional.Duration
+	BytesRead                      MultipleWindowsStat
+	ReaderName                     string
+}
+
+func (stats *PartitionConsumerStats) FromProto(proto *Ydb_Topic.DescribeConsumerResult_PartitionConsumerStats) error {
+	if proto == nil {
+		return nil
+	}
+	stats.LastReadOffset = proto.GetLastReadOffset()
+	stats.CommittedOffset = proto.GetCommittedOffset()
+	stats.ReadSessionID = proto.GetReadSessionId()
+	stats.PartitionReadSessionCreateTime.MustFromProto(proto.GetPartitionReadSessionCreateTime())
+	stats.LastReadTime.MustFromProto(proto.GetLastReadTime())
+	stats.MaxReadTimeLag.MustFromProto(proto.GetMaxReadTimeLag())
+	stats.MaxWriteTimeLag.MustFromProto(proto.GetMaxWriteTimeLag())
+	stats.BytesRead.MustFromProto(proto.GetBytesRead())
+	stats.ReaderName = proto.GetReaderName()
+
+	return nil
+}
+
+type DescribeConsumerResultPartitionInfo struct {
+	PartitionID            int64
+	Active                 bool
+	ChildPartitionIDs      []int64
+	ParentPartitionIDs     []int64
+	PartitionStats         PartitionStats
+	PartitionConsumerStats PartitionConsumerStats
+}
+
+func (pi *DescribeConsumerResultPartitionInfo) FromProto(proto *Ydb_Topic.DescribeConsumerResult_PartitionInfo) error {
+	pi.PartitionID = proto.GetPartitionId()
+	pi.Active = proto.GetActive()
+
+	pi.ChildPartitionIDs = clone.Int64Slice(proto.GetChildPartitionIds())
+	pi.ParentPartitionIDs = clone.Int64Slice(proto.GetParentPartitionIds())
+
+	return pi.PartitionStats.FromProto(proto.GetPartitionStats())
+}

--- a/topic/client.go
+++ b/topic/client.go
@@ -23,6 +23,11 @@ type Client interface {
 	// Describe topic
 	Describe(ctx context.Context, path string, opts ...topicoptions.DescribeOption) (topictypes.TopicDescription, error)
 
+	// Describe topic consumer
+	DescribeTopicConsumer(
+		ctx context.Context, path string, consumer string, opts ...topicoptions.DescribeConsumerOption,
+	) (topictypes.TopicConsumerDescription, error)
+
 	// Drop topic
 	Drop(ctx context.Context, path string, opts ...topicoptions.DropOption) error
 

--- a/topic/example_test.go
+++ b/topic/example_test.go
@@ -84,11 +84,36 @@ func Example_describeTopic() {
 
 	descResult, err := db.Topic().Describe(ctx, "topic-path")
 	if err != nil {
-		log.Printf("failed drop topic: %v", err)
+		log.Printf("failed describe topic: %v", err)
 
 		return
 	}
 	fmt.Printf("describe: %#v\n", descResult)
+}
+
+func Example_desrcibeTopicConsumer() {
+	ctx := context.TODO()
+	connectionString := os.Getenv("YDB_CONNECTION_STRING")
+	if connectionString == "" {
+		connectionString = "grpc://localhost:2136/local"
+	}
+	db, err := ydb.Open(
+		ctx, connectionString,
+	)
+	if err != nil {
+		log.Printf("failed connect: %v", err)
+
+		return
+	}
+	defer db.Close(ctx) // cleanup resources
+
+	descResult, err := db.Topic().DescribeTopicConsumer(ctx, "topic-path", "new-consumer")
+	if err != nil {
+		log.Printf("failed describe topic consumer: %v", err)
+
+		return
+	}
+	fmt.Printf("describe consumer: %#v\n", descResult)
 }
 
 func Example_dropTopic() {

--- a/topic/topicoptions/topicoptions_describe.go
+++ b/topic/topicoptions/topicoptions_describe.go
@@ -4,3 +4,12 @@ import "github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawtopic"
 
 // DescribeOption type for options of describe method. Not used now.
 type DescribeOption func(req *rawtopic.DescribeTopicRequest)
+
+// DescribeConsumerOption type for options of describe consumer method.
+type DescribeConsumerOption func(req *rawtopic.DescribeConsumerRequest)
+
+func IncludeConsumerStats() DescribeConsumerOption {
+	return func(req *rawtopic.DescribeConsumerRequest) {
+		req.IncludeStats = true
+	}
+}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

It is impossible to get detailed topic consumer information. in YDB CLI, there is `topic consumer describe` method that allows user to get read/write lag timings, amount of read bytes per customer ets.

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

`Topic` client got `DescribeTopicConsumer` method that performs corresponding GRPC call to YDB and returns the data with minimal modification.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
