### PR TITLE
Allow to set preferred node id to execute query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Allow to set preferred node id to execute query
+
 ## v3.90.1
 * Small broken change: added method `ID()` into `spans.Span` interface (need to implement in adapter) 
 * Fixed traceparent header for tracing grpc requests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-* Allow to set preferred node id to execute query
+* Added option to set preferred node id to execute query
 
 ## v3.90.1
 * Small broken change: added method `ID()` into `spans.Span` interface (need to implement in adapter) 

--- a/context.go
+++ b/context.go
@@ -19,3 +19,8 @@ func WithOperationTimeout(ctx context.Context, operationTimeout time.Duration) c
 func WithOperationCancelAfter(ctx context.Context, operationCancelAfter time.Duration) context.Context {
 	return operation.WithCancelAfter(ctx, operationCancelAfter)
 }
+
+// WithPreferredNodeID allows to set preferred node to get session from
+func WithPreferredNodeID(ctx context.Context, nodeID uint32) context.Context {
+	return operation.WithPreferredNodeID(ctx, nodeID)
+}

--- a/internal/operation/context.go
+++ b/internal/operation/context.go
@@ -8,6 +8,7 @@ import (
 type (
 	ctxOperationTimeoutKey     struct{}
 	ctxOperationCancelAfterKey struct{}
+	ctxWithPreferredNodeIDKey  struct{}
 )
 
 // WithTimeout returns a copy of parent context in which YDB operation timeout
@@ -33,6 +34,10 @@ func WithCancelAfter(ctx context.Context, operationCancelAfter time.Duration) co
 	return context.WithValue(ctx, ctxOperationCancelAfterKey{}, operationCancelAfter)
 }
 
+func WithPreferredNodeID(ctx context.Context, nodeID uint32) context.Context {
+	return context.WithValue(ctx, ctxWithPreferredNodeIDKey{}, nodeID)
+}
+
 // ctxTimeout returns the timeout within given context after which
 // YDB should try to cancel operation and return result regardless of the cancelation.
 func ctxTimeout(ctx context.Context) (d time.Duration, ok bool) {
@@ -56,4 +61,17 @@ func ctxUntilDeadline(ctx context.Context) (time.Duration, bool) {
 	}
 
 	return 0, false
+}
+
+func CtxPreferredNodeID(ctx context.Context) uint32 {
+	x := ctx.Value(ctxWithPreferredNodeIDKey{})
+	if x == nil {
+		return 0
+	}
+	val, ok := x.(uint32)
+	if !ok {
+		return 0
+	}
+
+	return val
 }

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -20,6 +20,7 @@ import (
 	grpcStatus "google.golang.org/grpc/status"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/closer"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/operation"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/stack"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xcontext"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
@@ -38,6 +39,7 @@ type (
 
 		onClose   func() error
 		onIsAlive func() bool
+		onNodeID  func() uint32
 	}
 	testWaitChPool struct {
 		xsync.Pool[chan *testItem]
@@ -113,6 +115,14 @@ func (t *testItem) ID() string {
 	return ""
 }
 
+func (t *testItem) NodeID() uint32 {
+	if t.onNodeID != nil {
+		return t.onNodeID()
+	}
+
+	return 0
+}
+
 func (t *testItem) Close(context.Context) error {
 	if t.closed.Len() > 0 {
 		debug.PrintStack()
@@ -135,8 +145,8 @@ func caller() string {
 	return fmt.Sprintf("%s:%d", path.Base(file), line)
 }
 
-func mustGetItem[PT ItemConstraint[T], T any](t testing.TB, p *Pool[PT, T]) PT {
-	s, err := p.getItem(context.Background())
+func mustGetItem[PT ItemConstraint[T], T any](t testing.TB, p *Pool[PT, T], nodeID uint32) PT {
+	s, err := p.getItem(operation.WithPreferredNodeID(context.Background(), nodeID))
 	if err != nil {
 		t.Helper()
 		t.Fatalf("%s: %v", caller(), err)
@@ -167,9 +177,112 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 				WithTrace[*testItem, testItem](defaultTrace),
 			)
 			err := p.With(rootCtx, func(ctx context.Context, testItem *testItem) error {
+				require.EqualValues(t, 0, testItem.NodeID())
+
 				return nil
 			})
 			require.NoError(t, err)
+		})
+		t.Run("RequireNodeIdFromPool", func(t *testing.T) {
+			var nextNodeID uint32
+			nextNodeID = 0
+			var newSessionCalled uint32
+			p := New[*testItem, testItem](rootCtx,
+				WithTrace[*testItem, testItem](defaultTrace),
+				WithCreateItemFunc(func(context.Context, uint32) (*testItem, error) {
+					newSessionCalled++
+					var (
+						nodeID = nextNodeID
+						v      = testItem{
+							v: 0,
+							onNodeID: func() uint32 {
+								return nodeID
+							},
+						}
+					)
+
+					return &v, nil
+				}),
+			)
+
+			item := mustGetItem(t, p, 0)
+			require.EqualValues(t, 0, item.NodeID())
+			require.EqualValues(t, true, item.IsAlive())
+			mustPutItem(t, p, item)
+
+			nextNodeID = 32
+
+			item = mustGetItem(t, p, 32)
+			require.EqualValues(t, 32, item.NodeID())
+			mustPutItem(t, p, item)
+
+			nextNodeID = 33
+
+			item = mustGetItem(t, p, 33)
+			require.EqualValues(t, 33, item.NodeID())
+			mustPutItem(t, p, item)
+
+			item = mustGetItem(t, p, 32)
+			require.EqualValues(t, 32, item.NodeID())
+			mustPutItem(t, p, item)
+
+			item = mustGetItem(t, p, 33)
+			require.EqualValues(t, 33, item.NodeID())
+			mustPutItem(t, p, item)
+
+			item = mustGetItem(t, p, 32)
+			item2 := mustGetItem(t, p, 33)
+			require.EqualValues(t, 32, item.NodeID())
+			require.EqualValues(t, 33, item2.NodeID())
+			mustPutItem(t, p, item2)
+			mustPutItem(t, p, item)
+
+			item = mustGetItem(t, p, 32)
+			item2 = mustGetItem(t, p, 33)
+			require.EqualValues(t, 32, item.NodeID())
+			require.EqualValues(t, 33, item2.NodeID())
+			mustPutItem(t, p, item)
+			mustPutItem(t, p, item2)
+
+			item = mustGetItem(t, p, 32)
+			item2 = mustGetItem(t, p, 33)
+			item3 := mustGetItem(t, p, 0)
+			require.EqualValues(t, 32, item.NodeID())
+			require.EqualValues(t, 33, item2.NodeID())
+			require.EqualValues(t, 0, item3.NodeID())
+			mustPutItem(t, p, item)
+			mustPutItem(t, p, item2)
+			mustPutItem(t, p, item3)
+
+			require.EqualValues(t, 3, newSessionCalled)
+		})
+		t.Run("CreateSessionOnGivenNode", func(t *testing.T) {
+			var newSessionCalled uint32
+			p := New[*testItem, testItem](rootCtx,
+				WithTrace[*testItem, testItem](defaultTrace),
+				WithCreateItemFunc(func(_ context.Context, nodeID uint32) (*testItem, error) {
+					newSessionCalled++
+					v := testItem{
+						v: 0,
+						onNodeID: func() uint32 {
+							return nodeID
+						},
+					}
+
+					return &v, nil
+				}),
+			)
+
+			item := mustGetItem(t, p, 32)
+			require.EqualValues(t, 32, item.NodeID())
+			require.EqualValues(t, true, item.IsAlive())
+			mustPutItem(t, p, item)
+
+			item = mustGetItem(t, p, 32)
+			require.EqualValues(t, 32, item.NodeID())
+			mustPutItem(t, p, item)
+
+			require.EqualValues(t, 1, newSessionCalled)
 		})
 		t.Run("WithLimit", func(t *testing.T) {
 			p := New[*testItem, testItem](rootCtx, WithLimit[*testItem, testItem](1),
@@ -184,7 +297,7 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 				WithItemUsageLimit[*testItem, testItem](5),
 				WithCreateItemTimeout[*testItem, testItem](50*time.Millisecond),
 				WithCloseItemTimeout[*testItem, testItem](50*time.Millisecond),
-				WithCreateItemFunc(func(context.Context) (*testItem, error) {
+				WithCreateItemFunc(func(context.Context, uint32) (*testItem, error) {
 					atomic.AddInt64(&newCounter, 1)
 
 					var v testItem
@@ -208,7 +321,7 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 			var newCounter int64
 			p := New(rootCtx,
 				WithLimit[*testItem, testItem](1),
-				WithCreateItemFunc(func(context.Context) (*testItem, error) {
+				WithCreateItemFunc(func(context.Context, uint32) (*testItem, error) {
 					atomic.AddInt64(&newCounter, 1)
 					var v testItem
 
@@ -242,7 +355,7 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 				WithLimit[*testItem, testItem](3),
 				WithCreateItemTimeout[*testItem, testItem](50*time.Millisecond),
 				WithCloseItemTimeout[*testItem, testItem](50*time.Millisecond),
-				WithCreateItemFunc(func(context.Context) (*testItem, error) {
+				WithCreateItemFunc(func(context.Context, uint32) (*testItem, error) {
 					var (
 						idx = created.Add(1) - 1
 						v   = testItem{
@@ -270,9 +383,9 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 			require.Zero(t, p.idle.Len())
 
 			var (
-				s1 = mustGetItem(t, p)
-				s2 = mustGetItem(t, p)
-				s3 = mustGetItem(t, p)
+				s1 = mustGetItem(t, p, 0)
+				s2 = mustGetItem(t, p, 0)
+				s3 = mustGetItem(t, p, 0)
 			)
 
 			require.Len(t, p.index, 3)
@@ -347,7 +460,7 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 					// second call getItem from pool with limit === 1 will skip
 					// create item step (because pool have not enough space for
 					// creating new items) and will freeze until wait free item from pool
-					mustGetItem(t, p)
+					mustGetItem(t, p, 0)
 
 					go func() {
 						p.config.trace.OnGet = func(ctx *context.Context, call stack.Caller) func(item any, attempts int, err error) {
@@ -405,7 +518,7 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 				p := New[*testItem, testItem](rootCtx,
 					WithLimit[*testItem, testItem](2),
 					WithCreateItemTimeout[*testItem, testItem](0),
-					WithCreateItemFunc[*testItem, testItem](func(ctx context.Context) (*testItem, error) {
+					WithCreateItemFunc[*testItem, testItem](func(ctx context.Context, _ uint32) (*testItem, error) {
 						v := testItem{
 							v: 0,
 							onClose: func() error {
@@ -425,8 +538,8 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 					WithTrace[*testItem, testItem](defaultTrace),
 				)
 
-				s1 := mustGetItem(t, p)
-				s2 := mustGetItem(t, p)
+				s1 := mustGetItem(t, p, 0)
+				s2 := mustGetItem(t, p, 0)
 
 				// Put both items at the absolutely same time.
 				// That is, both items must be updated their lastUsage timestamp.
@@ -442,7 +555,7 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 				// on get item from idle list the pool must check the item idle timestamp
 				// both existing items must be closed
 				// getItem must create a new item and return it from getItem
-				s3 := mustGetItem(t, p)
+				s3 := mustGetItem(t, p, 0)
 
 				require.Len(t, p.index, 1)
 
@@ -464,7 +577,7 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 				require.Len(t, p.index, 1)
 				require.Equal(t, 1, p.idle.Len())
 
-				s4 := mustGetItem(t, p)
+				s4 := mustGetItem(t, p, 0)
 				require.Equal(t, s3, s4)
 				require.Len(t, p.index, 1)
 				require.Equal(t, 0, p.idle.Len())
@@ -485,7 +598,7 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 					p := New(rootCtx,
 						WithCreateItemTimeout[*testItem, testItem](50*time.Millisecond),
 						WithCloseItemTimeout[*testItem, testItem](50*time.Millisecond),
-						WithCreateItemFunc(func(context.Context) (*testItem, error) {
+						WithCreateItemFunc(func(context.Context, uint32) (*testItem, error) {
 							atomic.AddInt64(&counter, 1)
 
 							if atomic.LoadInt64(&counter) < 10 {
@@ -508,7 +621,7 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 					p := New(rootCtx,
 						WithCreateItemTimeout[*testItem, testItem](50*time.Millisecond),
 						WithCloseItemTimeout[*testItem, testItem](50*time.Millisecond),
-						WithCreateItemFunc(func(context.Context) (*testItem, error) {
+						WithCreateItemFunc(func(context.Context, uint32) (*testItem, error) {
 							atomic.AddInt64(&counter, 1)
 
 							if atomic.LoadInt64(&counter) < 10 {
@@ -532,7 +645,7 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 				p := New(rootCtx,
 					WithCreateItemTimeout[*testItem, testItem](50*time.Millisecond),
 					WithCloseItemTimeout[*testItem, testItem](50*time.Millisecond),
-					WithCreateItemFunc(func(context.Context) (*testItem, error) {
+					WithCreateItemFunc(func(context.Context, uint32) (*testItem, error) {
 						atomic.AddInt64(&counter, 1)
 
 						if atomic.LoadInt64(&counter) < 10 {
@@ -555,7 +668,7 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 				p := New(rootCtx,
 					WithCreateItemTimeout[*testItem, testItem](50*time.Millisecond),
 					WithCloseItemTimeout[*testItem, testItem](50*time.Millisecond),
-					WithCreateItemFunc(func(context.Context) (*testItem, error) {
+					WithCreateItemFunc(func(context.Context, uint32) (*testItem, error) {
 						atomic.AddInt64(&counter, 1)
 
 						if atomic.LoadInt64(&counter) < 10 {
@@ -597,7 +710,7 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 							time.Duration(r.Int64(int64(time.Second))),
 						)
 						defer childCancel()
-						s, err := p.createItem(childCtx)
+						s, err := p.createItem(childCtx, 0)
 						if s == nil && err == nil {
 							errCh <- fmt.Errorf("unexpected result: <%v, %w>", s, err)
 						}
@@ -703,7 +816,7 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 				)
 				p := New(rootCtx,
 					WithLimit[*testItem, testItem](1),
-					WithCreateItemFunc(func(context.Context) (*testItem, error) {
+					WithCreateItemFunc(func(context.Context, uint32) (*testItem, error) {
 						atomic.AddInt64(&createCounter, 1)
 
 						v := &testItem{
@@ -740,7 +853,7 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 					WithLimit[*testItem, testItem](1),
 					WithCreateItemTimeout[*testItem, testItem](50*time.Millisecond),
 					WithCloseItemTimeout[*testItem, testItem](50*time.Millisecond),
-					WithCreateItemFunc(func(context.Context) (*testItem, error) {
+					WithCreateItemFunc(func(context.Context, uint32) (*testItem, error) {
 						newItems.Add(1)
 
 						v := &testItem{
@@ -801,7 +914,7 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 				WithLimit[*testItem, testItem](1),
 				WithCreateItemTimeout[*testItem, testItem](50*time.Millisecond),
 				WithCloseItemTimeout[*testItem, testItem](50*time.Millisecond),
-				WithCreateItemFunc(func(context.Context) (*testItem, error) {
+				WithCreateItemFunc(func(context.Context, uint32) (*testItem, error) {
 					created.Add(1)
 					v := testItem{
 						v: 0,
@@ -821,20 +934,20 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 				_ = p.Close(context.Background())
 			}()
 
-			s := mustGetItem(t, p)
+			s := mustGetItem(t, p, 0)
 			assertCreated(1)
 
 			mustPutItem(t, p, s)
 			assertClosed(0)
 
-			mustGetItem(t, p)
+			mustGetItem(t, p, 0)
 			assertCreated(1)
 
 			p.closeItem(context.Background(), s)
 			delete(p.index, s)
 			assertClosed(1)
 
-			mustGetItem(t, p)
+			mustGetItem(t, p, 0)
 			assertCreated(2)
 		})
 		t.Run("Racy", func(t *testing.T) {
@@ -917,7 +1030,7 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 				// replace default async closer for sync testing
 				WithSyncCloseItem[*testItem, testItem](),
 			)
-			item := mustGetItem(t, p)
+			item := mustGetItem(t, p, 0)
 			if err := p.putItem(context.Background(), item); err != nil {
 				t.Fatalf("unexpected error on put session into non-full client: %v, wand: %v", err, nil)
 			}
@@ -934,7 +1047,7 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 				// replace default async closer for sync testing
 				WithSyncCloseItem[*testItem, testItem](),
 			)
-			item := mustGetItem(t, p)
+			item := mustGetItem(t, p, 0)
 			mustPutItem(t, p, item)
 
 			require.Panics(t, func() {

--- a/internal/query/client.go
+++ b/internal/query/client.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/allocator"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/closer"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/conn"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/operation"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/pool"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/query/config"
@@ -39,7 +40,7 @@ type (
 		closer.Closer
 
 		Stats() pool.Stats
-		With(ctx context.Context, f func(ctx context.Context, s *Session) error, opts ...retry.Option) error
+		With(ctx context.Context, f func(context.Context, *Session) error, opts ...retry.Option) error
 	}
 	Client struct {
 		config *config.Config
@@ -562,7 +563,7 @@ func New(ctx context.Context, cc grpc.ClientConnInterface, cfg *config.Config) *
 			pool.WithCreateItemTimeout[*Session, Session](cfg.SessionCreateTimeout()),
 			pool.WithCloseItemTimeout[*Session, Session](cfg.SessionDeleteTimeout()),
 			pool.WithIdleTimeToLive[*Session, Session](cfg.SessionIdleTimeToLive()),
-			pool.WithCreateItemFunc(func(ctx context.Context) (_ *Session, err error) {
+			pool.WithCreateItemFunc(func(ctx context.Context, nodeID uint32) (_ *Session, err error) {
 				var (
 					createCtx    context.Context
 					cancelCreate context.CancelFunc
@@ -575,7 +576,7 @@ func New(ctx context.Context, cc grpc.ClientConnInterface, cfg *config.Config) *
 				defer cancelCreate()
 
 				s, err := createSession(createCtx, client,
-					session.WithConn(cc),
+					session.WithConn(conn.ModifyConn(cc, nodeID)),
 					session.WithDeleteTimeout(cfg.SessionDeleteTimeout()),
 					session.WithTrace(cfg.Trace()),
 				)

--- a/internal/query/client_test.go
+++ b/internal/query/client_test.go
@@ -1590,7 +1590,9 @@ func testPool(
 ) *pool.Pool[*Session, Session] {
 	return pool.New[*Session, Session](ctx,
 		pool.WithLimit[*Session, Session](1),
-		pool.WithCreateItemFunc(createSession),
+		pool.WithCreateItemFunc(func(ctx context.Context, _ uint32) (*Session, error) {
+			return createSession(ctx)
+		}),
 		pool.WithSyncCloseItem[*Session, Session](),
 	)
 }

--- a/internal/table/client.go
+++ b/internal/table/client.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/allocator"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/conn"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/pool"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/stack"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/table/config"
@@ -40,8 +41,8 @@ func New(ctx context.Context, cc grpc.ClientConnInterface, config *config.Config
 			pool.WithCreateItemTimeout[*session, session](config.CreateSessionTimeout()),
 			pool.WithCloseItemTimeout[*session, session](config.DeleteTimeout()),
 			pool.WithClock[*session, session](config.Clock()),
-			pool.WithCreateItemFunc[*session, session](func(ctx context.Context) (*session, error) {
-				return newSession(ctx, cc, config)
+			pool.WithCreateItemFunc[*session, session](func(ctx context.Context, nodeId uint32) (*session, error) {
+				return newSession(ctx, conn.ModifyConn(cc, nodeId), config)
 			}),
 			pool.WithTrace[*session, session](&pool.Trace{
 				OnNew: func(ctx *context.Context, call stack.Caller) func(limit int) {

--- a/internal/table/retry_test.go
+++ b/internal/table/retry_test.go
@@ -86,7 +86,7 @@ func TestDoBadSession(t *testing.T) {
 	xtest.TestManyTimes(t, func(t testing.TB) {
 		closed := make(map[table.Session]bool)
 		p := pool.New[*session, session](ctx,
-			pool.WithCreateItemFunc[*session, session](func(ctx context.Context) (*session, error) {
+			pool.WithCreateItemFunc[*session, session](func(ctx context.Context, _ uint32) (*session, error) {
 				s := simpleSession(t)
 				s.onClose = append(s.onClose, func(s *session) {
 					closed[s] = true
@@ -137,7 +137,7 @@ func TestDoCreateSessionError(t *testing.T) {
 		ctx, cancel := xcontext.WithTimeout(rootCtx, 30*time.Millisecond)
 		defer cancel()
 		p := pool.New[*session, session](ctx,
-			pool.WithCreateItemFunc[*session, session](func(ctx context.Context) (*session, error) {
+			pool.WithCreateItemFunc[*session, session](func(ctx context.Context, _ uint32) (*session, error) {
 				return nil, xerrors.Operation(xerrors.WithStatusCode(Ydb.StatusIds_UNAVAILABLE))
 			}),
 			pool.WithSyncCloseItem[*session, session](),
@@ -306,7 +306,7 @@ func TestDoContextDeadline(t *testing.T) {
 	}
 	ctx := xtest.Context(t)
 	p := pool.New[*session, session](ctx,
-		pool.WithCreateItemFunc[*session, session](func(ctx context.Context) (*session, error) {
+		pool.WithCreateItemFunc[*session, session](func(ctx context.Context, _ uint32) (*session, error) {
 			return newSession(ctx, client.cc, config.New())
 		}),
 		pool.WithSyncCloseItem[*session, session](),
@@ -355,7 +355,7 @@ func TestDoWithCustomErrors(t *testing.T) {
 		limit = 10
 		ctx   = context.Background()
 		p     = pool.New[*session, session](ctx,
-			pool.WithCreateItemFunc[*session, session](func(ctx context.Context) (*session, error) {
+			pool.WithCreateItemFunc[*session, session](func(ctx context.Context, _ uint32) (*session, error) {
 				return simpleSession(t), nil
 			}),
 			pool.WithLimit[*session, session](limit),


### PR DESCRIPTION
Server has ability to return node id during table describe
https://github.com/ydb-platform/ydb/pull/10935
It allows to reduce number of network transfers.

This is initial implementation of client support for this feature.