### PR TITLE
Fix pool item close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed connections pool leak on closing
+
 ## v3.92.2
 * Added `table/options.WithShardNodesInfo()` experimental option to get shard nodeId for describe table call
 

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -296,15 +296,15 @@ func makeAsyncCloseItemFunc[PT ItemConstraint[T], T any](
 	p *Pool[PT, T],
 ) func(ctx context.Context, item PT) {
 	return func(ctx context.Context, item PT) {
-		closeItemCtx, closeItemCancel := xcontext.WithDone(xcontext.ValueOnly(ctx), p.done)
-		defer closeItemCancel()
-
-		if d := p.config.closeTimeout; d > 0 {
-			closeItemCtx, closeItemCancel = xcontext.WithTimeout(ctx, d)
-			defer closeItemCancel()
-		}
-
 		go func() {
+			closeItemCtx, closeItemCancel := xcontext.WithDone(xcontext.ValueOnly(ctx), p.done)
+			defer closeItemCancel()
+
+			if d := p.config.closeTimeout; d > 0 {
+				closeItemCtx, closeItemCancel = xcontext.WithTimeout(ctx, d)
+				defer closeItemCancel()
+			}
+
 			_ = item.Close(closeItemCtx)
 		}()
 	}


### PR DESCRIPTION
Because of goroutine used context, which was closed in defer, item.Close wasn't closing session in table client, but delete it from pool. It causes session leak. This pr fixed this.