### PR TITLE
Avoid retrying requests finished with 'UNAUTHORIZED' errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-## v3.92.5
 * Avoid retrying requests finished with 'UNAUTHORIZED' errors
 
 ## v3.92.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
+## v3.92.5
+* Avoid retrying requests finished with 'UNAUTHORIZED' errors
+
 ## v3.92.4
 * Fixed connections pool leak on closing
 
 ## v3.92.3
 * Fixed error with incompleted data returen from transaction.ReadQueryResult method
 * Added option `query/WithResponsePartLimitSizeBytes(...)` for queries with query service
-
 
 ## v3.92.2
 * Added `table/options.WithShardNodesInfo()` experimental option to get shard nodeId for describe table call

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/jonboulle/clockwork"
 
+	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/endpoint"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/stack"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xcontext"
@@ -339,7 +340,14 @@ func (p *Pool[PT, T]) try(ctx context.Context, f func(ctx context.Context, item 
 	item, err := p.getItem(ctx)
 	if err != nil {
 		if xerrors.IsYdb(err) {
-			return xerrors.WithStackTrace(xerrors.Retryable(err))
+			switch {
+			case xerrors.IsOperationError(err, Ydb.StatusIds_UNAUTHORIZED):
+				// https://github.com/ydb-platform/ydb-go-sdk/issues/1550
+				// Avoid retrying UNAUTHORIZED errors.
+				return xerrors.WithStackTrace(xerrors.Unretryable(err))
+			default:
+				return xerrors.WithStackTrace(xerrors.Retryable(err))
+			}
 		}
 
 		return xerrors.WithStackTrace(err)

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/jonboulle/clockwork"
-
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb"
+
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/endpoint"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/stack"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xcontext"


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

All YDB errors are retryable now with no exceptions. This causes hanging of `driver.Table().Do()` calls in case if invalid credentials were provided.

Issue Number: #1550.

## What is the new behavior?

Errors with code `UNAUTHORIZED` are returned immediately to the caller.

## Other information

Fixes #1550 and YQ-3843.
