### PR TITLE
update session status only after logging it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed an error in logging session deletion events
+
 ## v3.95.3
 * Supported of `database/sql/driver.Valuer` interfaces for params which passed to query using sql driver 
 * Exposed `credentials/credentials.OAuth2Config` OAuth2 config

--- a/internal/table/session.go
+++ b/internal/table/session.go
@@ -193,8 +193,8 @@ func (s *session) Close(ctx context.Context) (err error) {
 			s,
 		)
 		defer func() {
-			s.SetStatus(table.SessionClosed)
 			onDone(err)
+			s.SetStatus(table.SessionClosed)
 		}()
 
 		if time.Since(s.LastUsage()) < s.config.IdleThreshold() {


### PR DESCRIPTION
So we know real status when delete fails

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Right now, when ydb.table.session.delete fails, session status is always "closed", because it sets right before logging, so we do not know if we are closing a session twice, or there is some kind of different error.

## What is the new behavior?

Status is changed to closed only after logging it.
