### PR TITLE
fix context which is used for closing session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed connections pool leak on closing sessions
+
 ## v3.95.3
 * Supported of `database/sql/driver.Valuer` interfaces for params which passed to query using sql driver 
 * Exposed `credentials/credentials.OAuth2Config` OAuth2 config

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -302,7 +302,7 @@ func makeAsyncCloseItemFunc[PT ItemConstraint[T], T any](
 			defer closeItemCancel()
 
 			if d := p.config.closeTimeout; d > 0 {
-				closeItemCtx, closeItemCancel = xcontext.WithTimeout(ctx, d)
+				closeItemCtx, closeItemCancel = xcontext.WithTimeout(closeItemCtx, d)
 				defer closeItemCancel()
 			}
 


### PR DESCRIPTION
Fixed context which is used for closing session with timeout

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

pool spawns new goroutine for closing session, but for creating context with timeout it uses original, user context, which may be closed

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

it uses context whithout cancel, and should works propely

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
