### PR TITLE
fix panic in span reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v3.95.6
+* Fixed panic on span reporting in `xsql/Tx`
+
 ## v3.95.5
 * Fixed goroutine leak on failed execute call in query client
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-## v3.95.6
 * Fixed panic on span reporting in `xsql/Tx`
 
 ## v3.95.5

--- a/internal/xsql/legacy/tx.go
+++ b/internal/xsql/legacy/tx.go
@@ -20,6 +20,10 @@ type transaction struct {
 }
 
 func (tx *transaction) ID() string {
+	if tx.tx == nil {
+		return ""
+	}
+
 	return tx.tx.ID()
 }
 

--- a/internal/xsql/tx.go
+++ b/internal/xsql/tx.go
@@ -18,6 +18,10 @@ type Tx struct {
 }
 
 func (tx *Tx) ID() string {
+	if tx.tx == nil {
+		return ""
+	}
+
 	return tx.tx.ID()
 }
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

SDK panics when it tries to log a span on non-existing xsql.tx. Backtraces are like this:

```
goroutine 171969 [running]:
runtime/debug.Stack()
	GOROOT/src/runtime/debug/stack.go:26 +0x5e
nebius.ai/nebo/msp/internal/grpc.NewServer.recoveryLogger.func4({0x4685130, 0xc0041e74d0}, {0x36275e0, 0x74ed7f0})
	msp/internal/grpc/server.go:51 +0x14e
github.com/grpc-ecosystem/go-grpc-middleware/recovery.recoverFrom({0x4685130?, 0xc0041e74d0?}, {0x36275e0?, 0x74ed7f0?}, 0xc003c51810?)
	external/gazelle~~go_deps~com_github_grpc_ecosystem_go_grpc_middleware/recovery/interceptors.go:61 +0x30
github.com/grpc-ecosystem/go-grpc-middleware/recovery.UnaryServerInterceptor.func1.1()
	external/gazelle~~go_deps~com_github_grpc_ecosystem_go_grpc_middleware/recovery/interceptors.go:29 +0x75
panic({0x36275e0?, 0x74ed7f0?})
	GOROOT/src/runtime/panic.go:785 +0x132
github.com/ydb-platform/ydb-go-sdk/v3/internal/xsql.(*Tx).ID(0xc0029f87b0?)
	external/gazelle~~go_deps~com_github_ydb_platform_ydb_go_sdk_v3/internal/xsql/tx.go:21 +0xe
github.com/ydb-platform/ydb-go-sdk/v3/spans.safeID(...)
	external/gazelle~~go_deps~com_github_ydb_platform_ydb_go_sdk_v3/spans/safe.go:29
github.com/ydb-platform/ydb-go-sdk/v3/spans.databaseSQL.func9.1({{0x462ba00?, 0x0?}, {0x4629480?, 0xc003d68240?}})
	external/gazelle~~go_deps~com_github_ydb_platform_ydb_go_sdk_v3/spans/sql.go:183 +0x94
github.com/ydb-platform/ydb-go-sdk/v3/trace.(*DatabaseSQL).Compose.func6.2({{0x462ba00?, 0x0?}, {0x4629480?, 0xc003d68240?}})
	external/gazelle~~go_deps~com_github_ydb_platform_ydb_go_sdk_v3/trace/sql_gtrace.go:246 +0xcf
github.com/ydb-platform/ydb-go-sdk/v3/trace.(*DatabaseSQL).Compose.func6.2({{0x462ba00?, 0x0?}, {0x4629480?, 0xc003d68240?}})
	external/gazelle~~go_deps~com_github_ydb_platform_ydb_go_sdk_v3/trace/sql_gtrace.go:243 +0x9d
github.com/ydb-platform/ydb-go-sdk/v3/trace.(*DatabaseSQL).Compose.func6.2({{0x462ba00?, 0x0?}, {0x4629480?, 0xc003d68240?}})
	external/gazelle~~go_deps~com_github_ydb_platform_ydb_go_sdk_v3/trace/sql_gtrace.go:243 +0x9d
github.com/ydb-platform/ydb-go-sdk/v3/trace.DatabaseSQLOnConnBeginTx.func1({0x462ba00?, 0x0?}, {0x4629480?, 0xc003d68240?})
	external/gazelle~~go_deps~com_github_ydb_platform_ydb_go_sdk_v3/trace/sql_gtrace.go:1194 +0x2b
github.com/ydb-platform/ydb-go-sdk/v3/internal/xsql.(*Conn).BeginTx.func1()
	external/gazelle~~go_deps~com_github_ydb_platform_ydb_go_sdk_v3/internal/xsql/conn.go:55 +0x32
github.com/ydb-platform/ydb-go-sdk/v3/internal/xsql.(*Conn).BeginTx(0xc004bc1040, {0x4685130, 0xc0041e7680}, {0x74ede60?, 0x80?})
	external/gazelle~~go_deps~com_github_ydb_platform_ydb_go_sdk_v3/internal/xsql/conn.go:64 +0x3a8
database/sql.ctxDriverBegin({0x4685130, 0xc0041e7680}, 0x10?, {0x46730d0, 0xc004bc1040})
	GOROOT/src/database/sql/ctxutil.go:104 +0x77
database/sql.(*DB).beginDC.func1()
	GOROOT/src/database/sql/sql.go:1898 +0xae
database/sql.withLock({0x4663338, 0xc004bcd000}, 0xc003255e00)
	GOROOT/src/database/sql/sql.go:3566 +0x71
database/sql.(*DB).beginDC(0xc000a2d5f0, {0x4685130, 0xc0041e7680}, 0xc004bcd000, 0xc007a04350, 0x0?)
	GOROOT/src/database/sql/sql.go:1894 +0xab
database/sql.(*DB).begin(0xc000a2d5f0, {0x4685130, 0xc0041e7680}, 0x0, 0x30?)
	GOROOT/src/database/sql/sql.go:1887 +0x8d
database/sql.(*DB).BeginTx.func1(0x30?)
	GOROOT/src/database/sql/sql.go:1866 +0x3e
database/sql.(*DB).retry(0x41da309?, 0xc003c51f48)
	GOROOT/src/database/sql/sql.go:1568 +0x42
database/sql.(*DB).BeginTx(0x988845?, {0x4685130?, 0xc0041e7680?}, 0x4685130?)
	GOROOT/src/database/sql/sql.go:1865 +0x6c
github.com/jmoiron/sqlx.(*DB).BeginTxx(0xc000d43110, {0x4685130?, 0xc0041e7680?}, 0xf?)
```


Issue Number: N/A

## What is the new behavior?

Go SDK should not panic on a nil dereference with this patch

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
