### PR TITLE
fix broken metric `ydb_go_sdk_ydb_database_sql_conns`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed broken metric `ydb_go_sdk_ydb_database_sql_conns`
+
 ## v3.96.1
 * Fixed drop session from pool unnecessary in query service 
 
@@ -6,7 +8,6 @@
 
 ## v3.95.6
 * Fixed panic on span reporting in `xsql/Tx`
-* Fixed broken metric `ydb_go_sdk_ydb_database_sql_conns`
 
 ## v3.95.5
 * Fixed goroutine leak on failed execute call in query client

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## v3.95.6
 * Fixed panic on span reporting in `xsql/Tx`
+* Fixed broken metric `ydb_go_sdk_ydb_database_sql_conns`
 
 ## v3.95.5
 * Fixed goroutine leak on failed execute call in query client

--- a/internal/xslices/keys.go
+++ b/internal/xslices/keys.go
@@ -1,0 +1,18 @@
+package xslices
+
+import (
+	"cmp"
+	"slices"
+)
+
+func Keys[Key cmp.Ordered, T any](m map[Key]T) []Key {
+	keys := make([]Key, 0, len(m))
+
+	for key := range m {
+		keys = append(keys, key)
+	}
+
+	slices.Sort(keys)
+
+	return keys
+}

--- a/internal/xslices/keys_test.go
+++ b/internal/xslices/keys_test.go
@@ -1,0 +1,18 @@
+package xslices
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKeys(t *testing.T) {
+	require.Equal(t, []string{"1", "2"}, Keys(map[string]any{
+		"1": nil,
+		"2": nil,
+	}))
+	require.Equal(t, []int{1, 2}, Keys(map[int]any{
+		1: nil,
+		2: nil,
+	}))
+}

--- a/internal/xsql/conn.go
+++ b/internal/xsql/conn.go
@@ -48,7 +48,7 @@ func (c *Conn) CheckNamedValue(value *driver.NamedValue) (finalErr error) {
 }
 
 func (c *Conn) BeginTx(ctx context.Context, opts driver.TxOptions) (_ driver.Tx, finalErr error) {
-	onDone := trace.DatabaseSQLOnConnBeginTx(c.connector.trace, &ctx,
+	onDone := trace.DatabaseSQLOnConnBegin(c.connector.trace, &ctx,
 		stack.FunctionID("", stack.Package("database/sql")),
 	)
 	defer func() {

--- a/internal/xsql/conn.go
+++ b/internal/xsql/conn.go
@@ -48,7 +48,7 @@ func (c *Conn) CheckNamedValue(value *driver.NamedValue) (finalErr error) {
 }
 
 func (c *Conn) BeginTx(ctx context.Context, opts driver.TxOptions) (_ driver.Tx, finalErr error) {
-	onDone := trace.DatabaseSQLOnConnBegin(c.connector.trace, &ctx,
+	onDone := trace.DatabaseSQLOnConnBeginTx(c.connector.trace, &ctx,
 		stack.FunctionID("", stack.Package("database/sql")),
 	)
 	defer func() {

--- a/internal/xsql/options.go
+++ b/internal/xsql/options.go
@@ -200,7 +200,7 @@ func WithQueryOptions(opts ...propose.Option) Option {
 
 func WithQueryService(b bool) Option {
 	if b {
-		return queryProcessorOption(QUERY_SERVICE)
+		return queryProcessorOption(PROPOSE)
 	}
 
 	return queryProcessorOption(LEGACY)

--- a/metrics/sql.go
+++ b/metrics/sql.go
@@ -1,16 +1,16 @@
 package metrics
 
 import (
-	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xsync"
 	"time"
 
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xsync"
 	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
 )
 
-// databaseSQL makes trace.DatabaseSQL with measuring `database/sql` events
+// DatabaseSQL makes trace.DatabaseSQL with measuring `database/sql` events
 //
 //nolint:funlen
-func databaseSQL(config Config) trace.DatabaseSQL {
+func DatabaseSQL(config Config) trace.DatabaseSQL {
 	config = config.WithSystem("database").WithSystem("sql")
 
 	conns := config.GaugeVec("conns")

--- a/metrics/sql.go
+++ b/metrics/sql.go
@@ -64,6 +64,19 @@ func databaseSQL(config Config) (t trace.DatabaseSQL) {
 
 		return nil
 	}
+	t.OnConnBeginTx = func(info trace.DatabaseSQLConnBeginTxStartInfo) func(trace.DatabaseSQLConnBeginTxDoneInfo) {
+		start := time.Now()
+		if config.Details()&trace.DatabaseSQLTxEvents != 0 {
+			return func(info trace.DatabaseSQLConnBeginTxDoneInfo) {
+				txBegin.With(map[string]string{
+					"status": errorBrief(info.Error),
+				}).Inc()
+				txBeginLatency.With(nil).Record(time.Since(start))
+			}
+		}
+
+		return nil
+	}
 	t.OnTxCommit = func(info trace.DatabaseSQLTxCommitStartInfo) func(trace.DatabaseSQLTxCommitDoneInfo) {
 		start := time.Now()
 

--- a/metrics/sql.go
+++ b/metrics/sql.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xsync"
 	"time"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
@@ -9,174 +10,136 @@ import (
 // databaseSQL makes trace.DatabaseSQL with measuring `database/sql` events
 //
 //nolint:funlen
-func databaseSQL(config Config) (t trace.DatabaseSQL) {
+func databaseSQL(config Config) trace.DatabaseSQL {
 	config = config.WithSystem("database").WithSystem("sql")
+
 	conns := config.GaugeVec("conns")
-	inflight := config.WithSystem("conns").GaugeVec("inflight")
+
 	query := config.CounterVec("query", "status", "query_mode")
 	queryLatency := config.WithSystem("query").TimerVec("latency", "query_mode")
+
 	exec := config.CounterVec("exec", "status", "query_mode")
 	execLatency := config.WithSystem("exec").TimerVec("latency", "query_mode")
 
-	config = config.WithSystem("tx")
-	txBegin := config.CounterVec("begin", "status")
-	txBeginLatency := config.WithSystem("begin").TimerVec("latency")
-	txExec := config.CounterVec("exec", "status")
-	txExecLatency := config.WithSystem("exec").TimerVec("latency")
-	txQuery := config.CounterVec("query", "status")
-	txQueryLatency := config.WithSystem("query").TimerVec("latency")
-	txCommit := config.CounterVec("commit", "status")
-	txCommitLatency := config.WithSystem("commit").TimerVec("latency")
-	txRollback := config.CounterVec("rollback", "status")
-	txRollbackLatency := config.WithSystem("rollback").TimerVec("latency")
-	t.OnConnectorConnect = func(info trace.DatabaseSQLConnectorConnectStartInfo) func(
-		trace.DatabaseSQLConnectorConnectDoneInfo,
-	) {
-		if config.Details()&trace.DatabaseSQLConnectorEvents != 0 {
-			return func(info trace.DatabaseSQLConnectorConnectDoneInfo) {
-				if info.Error == nil {
-					conns.With(nil).Add(1)
+	txs := config.GaugeVec("tx")
+	txLatency := config.WithSystem("tx").TimerVec("latency")
+	txStart := xsync.Map[string, time.Time]{}
+
+	return trace.DatabaseSQL{
+		OnConnectorConnect: func(info trace.DatabaseSQLConnectorConnectStartInfo) func(
+			trace.DatabaseSQLConnectorConnectDoneInfo,
+		) {
+			if config.Details()&trace.DatabaseSQLConnectorEvents != 0 {
+				return func(info trace.DatabaseSQLConnectorConnectDoneInfo) {
+					if info.Error == nil {
+						conns.With(nil).Add(1)
+					}
 				}
 			}
-		}
 
-		return nil
-	}
-	t.OnConnClose = func(info trace.DatabaseSQLConnCloseStartInfo) func(trace.DatabaseSQLConnCloseDoneInfo) {
-		if config.Details()&trace.DatabaseSQLConnectorEvents != 0 {
-			return func(info trace.DatabaseSQLConnCloseDoneInfo) {
-				conns.With(nil).Add(-1)
+			return nil
+		},
+		OnConnClose: func(info trace.DatabaseSQLConnCloseStartInfo) func(trace.DatabaseSQLConnCloseDoneInfo) {
+			if config.Details()&trace.DatabaseSQLConnectorEvents != 0 {
+				return func(info trace.DatabaseSQLConnCloseDoneInfo) {
+					conns.With(nil).Add(-1)
+				}
 			}
-		}
 
-		return nil
-	}
-	t.OnConnBegin = func(info trace.DatabaseSQLConnBeginStartInfo) func(trace.DatabaseSQLConnBeginDoneInfo) {
-		start := time.Now()
-		if config.Details()&trace.DatabaseSQLTxEvents != 0 {
-			return func(info trace.DatabaseSQLConnBeginDoneInfo) {
-				txBegin.With(map[string]string{
-					"status": errorBrief(info.Error),
-				}).Inc()
-				txBeginLatency.With(nil).Record(time.Since(start))
-			}
-		}
-
-		return nil
-	}
-	t.OnConnBeginTx = func(info trace.DatabaseSQLConnBeginTxStartInfo) func(trace.DatabaseSQLConnBeginTxDoneInfo) {
-		start := time.Now()
-		if config.Details()&trace.DatabaseSQLTxEvents != 0 {
-			return func(info trace.DatabaseSQLConnBeginTxDoneInfo) {
-				txBegin.With(map[string]string{
-					"status": errorBrief(info.Error),
-				}).Inc()
-				txBeginLatency.With(nil).Record(time.Since(start))
-			}
-		}
-
-		return nil
-	}
-	t.OnTxCommit = func(info trace.DatabaseSQLTxCommitStartInfo) func(trace.DatabaseSQLTxCommitDoneInfo) {
-		start := time.Now()
-
-		return func(info trace.DatabaseSQLTxCommitDoneInfo) {
+			return nil
+		},
+		OnConnBegin: func(info trace.DatabaseSQLConnBeginStartInfo) func(trace.DatabaseSQLConnBeginDoneInfo) {
 			if config.Details()&trace.DatabaseSQLTxEvents != 0 {
-				txCommit.With(map[string]string{
-					"status": errorBrief(info.Error),
-				}).Inc()
-				txCommitLatency.With(nil).Record(time.Since(start))
+				return func(info trace.DatabaseSQLConnBeginDoneInfo) {
+					if info.Error == nil {
+						txs.With(nil).Add(1)
+						txStart.Set(info.Tx.ID(), time.Now())
+					}
+				}
 			}
-		}
-	}
-	t.OnTxExec = func(info trace.DatabaseSQLTxExecStartInfo) func(trace.DatabaseSQLTxExecDoneInfo) {
-		start := time.Now()
 
-		return func(info trace.DatabaseSQLTxExecDoneInfo) {
+			return nil
+		},
+		OnConnBeginTx: func(info trace.DatabaseSQLConnBeginTxStartInfo) func(trace.DatabaseSQLConnBeginTxDoneInfo) {
 			if config.Details()&trace.DatabaseSQLTxEvents != 0 {
-				status := errorBrief(info.Error)
-				txExec.With(map[string]string{
-					"status": status,
-				}).Inc()
-				txExecLatency.With(nil).Record(time.Since(start))
+				return func(info trace.DatabaseSQLConnBeginTxDoneInfo) {
+					if info.Error == nil {
+						txs.With(nil).Add(1)
+						txStart.Set(info.Tx.ID(), time.Now())
+					}
+				}
 			}
-		}
-	}
-	t.OnTxQuery = func(info trace.DatabaseSQLTxQueryStartInfo) func(trace.DatabaseSQLTxQueryDoneInfo) {
-		start := time.Now()
 
-		return func(info trace.DatabaseSQLTxQueryDoneInfo) {
-			if config.Details()&trace.DatabaseSQLTxEvents != 0 {
-				status := errorBrief(info.Error)
-				txQuery.With(map[string]string{
-					"status": status,
-				}).Inc()
-				txQueryLatency.With(nil).Record(time.Since(start))
-			}
-		}
-	}
-	t.OnTxRollback = func(info trace.DatabaseSQLTxRollbackStartInfo) func(trace.DatabaseSQLTxRollbackDoneInfo) {
-		start := time.Now()
+			return nil
+		},
+		OnTxCommit: func(info trace.DatabaseSQLTxCommitStartInfo) func(trace.DatabaseSQLTxCommitDoneInfo) {
+			txs.With(nil).Add(-1)
 
-		return func(info trace.DatabaseSQLTxRollbackDoneInfo) {
-			if config.Details()&trace.DatabaseSQLTxEvents != 0 {
-				txRollback.With(map[string]string{
-					"status": errorBrief(info.Error),
-				}).Inc()
-				txRollbackLatency.With(nil).Record(time.Since(start))
+			if start, has := txStart.Extract(info.Tx.ID()); has {
+				txLatency.With(nil).Record(time.Since(start))
 			}
-		}
-	}
-	t.OnConnExec = func(info trace.DatabaseSQLConnExecStartInfo) func(trace.DatabaseSQLConnExecDoneInfo) {
-		if config.Details()&trace.DatabaseSQLEvents != 0 {
-			inflight.With(nil).Add(1)
-		}
-		var (
-			mode  = info.Mode
-			start = time.Now()
-		)
 
-		return func(info trace.DatabaseSQLConnExecDoneInfo) {
-			if config.Details()&trace.DatabaseSQLEvents != 0 {
-				inflight.With(nil).Add(-1)
-			}
-			if config.Details()&trace.DatabaseSQLConnEvents != 0 {
-				status := errorBrief(info.Error)
-				exec.With(map[string]string{
-					"status":     status,
-					"query_mode": mode,
-				}).Inc()
-				execLatency.With(map[string]string{
-					"query_mode": mode,
-				}).Record(time.Since(start))
-			}
-		}
-	}
-	t.OnConnQuery = func(info trace.DatabaseSQLConnQueryStartInfo) func(trace.DatabaseSQLConnQueryDoneInfo) {
-		if config.Details()&trace.DatabaseSQLEvents != 0 {
-			inflight.With(nil).Add(1)
-		}
-		var (
-			mode  = info.Mode
-			start = time.Now()
-		)
+			return nil
+		},
+		OnTxRollback: func(info trace.DatabaseSQLTxRollbackStartInfo) func(trace.DatabaseSQLTxRollbackDoneInfo) {
+			txs.With(nil).Add(-1)
 
-		return func(info trace.DatabaseSQLConnQueryDoneInfo) {
-			if config.Details()&trace.DatabaseSQLEvents != 0 {
-				inflight.With(nil).Add(-1)
+			if start, has := txStart.Extract(info.Tx.ID()); has {
+				txLatency.With(nil).Record(time.Since(start))
 			}
-			if config.Details()&trace.DatabaseSQLConnEvents != 0 {
-				status := errorBrief(info.Error)
-				query.With(map[string]string{
-					"status":     status,
-					"query_mode": mode,
-				}).Inc()
-				queryLatency.With(map[string]string{
-					"query_mode": mode,
-				}).Record(time.Since(start))
-			}
-		}
-	}
 
-	return t
+			return nil
+		},
+		OnConnExec: func(info trace.DatabaseSQLConnExecStartInfo) func(trace.DatabaseSQLConnExecDoneInfo) {
+			var (
+				mode  = info.Mode
+				start = time.Now()
+			)
+
+			return func(info trace.DatabaseSQLConnExecDoneInfo) {
+				if config.Details()&trace.DatabaseSQLConnEvents != 0 {
+					status := errorBrief(info.Error)
+					exec.With(map[string]string{
+						"status":     status,
+						"query_mode": mode,
+					}).Inc()
+					execLatency.With(map[string]string{
+						"query_mode": mode,
+					}).Record(time.Since(start))
+				}
+			}
+		},
+		OnConnQuery: func(info trace.DatabaseSQLConnQueryStartInfo) func(trace.DatabaseSQLConnQueryDoneInfo) {
+			var (
+				mode  = info.Mode
+				start = time.Now()
+			)
+
+			return func(info trace.DatabaseSQLConnQueryDoneInfo) {
+				if config.Details()&trace.DatabaseSQLConnEvents != 0 {
+					status := errorBrief(info.Error)
+					query.With(map[string]string{
+						"status":     status,
+						"query_mode": mode,
+					}).Inc()
+					queryLatency.With(map[string]string{
+						"query_mode": mode,
+					}).Record(time.Since(start))
+				}
+			}
+		},
+		OnConnPing:            nil,
+		OnConnPrepare:         nil,
+		OnConnCheckNamedValue: nil,
+		OnConnIsTableExists:   nil,
+		OnConnIsColumnExists:  nil,
+		OnConnGetIndexColumns: nil,
+		OnTxExec:              nil,
+		OnTxQuery:             nil,
+		OnTxPrepare:           nil,
+		OnStmtQuery:           nil,
+		OnStmtExec:            nil,
+		OnStmtClose:           nil,
+		OnDoTx:                nil,
+	}
 }

--- a/metrics/traces.go
+++ b/metrics/traces.go
@@ -19,7 +19,7 @@ func WithTraces(config Config) ydb.Option {
 		ydb.WithTraceCoordination(coordination(config)),
 		ydb.WithTraceRatelimiter(ratelimiter(config)),
 		ydb.WithTraceDiscovery(discovery(config)),
-		ydb.WithTraceDatabaseSQL(databaseSQL(config)),
+		ydb.WithTraceDatabaseSQL(DatabaseSQL(config)),
 		ydb.WithTraceRetry(retry(config)),
 	)
 }

--- a/tests/integration/database_sql_metrics_test.go
+++ b/tests/integration/database_sql_metrics_test.go
@@ -1,0 +1,78 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xslices"
+	"github.com/ydb-platform/ydb-go-sdk/v3/metrics"
+	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
+)
+
+func TestDatabaseSqlMetrics(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var (
+		scope    = newScope(t)
+		registry = &registryConfig{
+			details:    trace.DatabaseSQLEvents,
+			gauges:     newVec[gaugeVec](),
+			counters:   newVec[counterVec](),
+			timers:     newVec[timerVec](),
+			histograms: newVec[histogramVec](),
+		}
+		db = scope.SQLDriver(ydb.WithDatabaseSQLTrace(metrics.DatabaseSQL(registry)))
+	)
+
+	require.Equal(t,
+		[]string{"database.sql.conns{}", "database.sql.tx{}"},
+		xslices.Keys(registry.gauges.data),
+	)
+	require.EqualValues(t, 1, registry.gauges.data["database.sql.conns{}"].gauges["database.sql.conns{}"].value)
+
+	cc1, err := db.Conn(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, cc1)
+	require.EqualValues(t, 1, registry.gauges.data["database.sql.conns{}"].gauges["database.sql.conns{}"].value)
+	require.Empty(t, registry.gauges.data["database.sql.tx{}"].gauges)
+
+	cc2, err := db.Conn(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, cc2)
+	require.EqualValues(t, 2, registry.gauges.data["database.sql.conns{}"].gauges["database.sql.conns{}"].value)
+	require.Empty(t, registry.gauges.data["database.sql.tx{}"].gauges)
+
+	tx1, err := cc1.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	require.NotNil(t, tx1)
+	require.NotEmpty(t, registry.gauges.data["database.sql.tx{}"].gauges)
+	require.EqualValues(t, 1, registry.gauges.data["database.sql.tx{}"].gauges["database.sql.tx{}"].value)
+
+	require.NoError(t, tx1.Commit())
+	require.EqualValues(t, 0, registry.gauges.data["database.sql.tx{}"].gauges["database.sql.tx{}"].value)
+
+	require.NoError(t, cc1.Close())
+	require.EqualValues(t, 2, registry.gauges.data["database.sql.conns{}"].gauges["database.sql.conns{}"].value)
+
+	tx2, err := cc2.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	require.NotNil(t, tx2)
+	require.NotEmpty(t, registry.gauges.data["database.sql.tx{}"].gauges)
+	require.EqualValues(t, 1, registry.gauges.data["database.sql.tx{}"].gauges["database.sql.tx{}"].value)
+
+	require.NoError(t, tx2.Rollback())
+	require.EqualValues(t, 0, registry.gauges.data["database.sql.tx{}"].gauges["database.sql.tx{}"].value)
+
+	require.NoError(t, cc2.Close())
+	require.EqualValues(t, 2, registry.gauges.data["database.sql.conns{}"].gauges["database.sql.conns{}"].value)
+
+	require.NoError(t, db.Close())
+	require.EqualValues(t, 0, registry.gauges.data["database.sql.conns{}"].gauges["database.sql.conns{}"].value)
+}

--- a/tests/integration/database_sql_regression_test.go
+++ b/tests/integration/database_sql_regression_test.go
@@ -239,7 +239,7 @@ func TestUUIDSerializationDatabaseSQLIssue1501(t *testing.T) {
 		switch driverEngine(db) {
 		case xsql.LEGACY:
 			require.Error(t, err)
-		case xsql.QUERY_SERVICE:
+		case xsql.PROPOSE:
 			require.NoError(t, err)
 		}
 	})
@@ -268,7 +268,7 @@ func TestUUIDSerializationDatabaseSQLIssue1501(t *testing.T) {
 			require.NoError(t, err)
 			resUUID := uuid.UUID(res.AsBytesArray())
 			require.Equal(t, expectedResultWithBug, resUUID.String())
-		case xsql.QUERY_SERVICE:
+		case xsql.PROPOSE:
 			require.Error(t, err)
 		}
 	})
@@ -357,7 +357,7 @@ func TestUUIDSerializationDatabaseSQLIssue1501(t *testing.T) {
 			require.NoError(t, err)
 			resUUID := uuid.UUID(resBytes.AsBytesArray())
 			require.Equal(t, id, resUUID)
-		case xsql.QUERY_SERVICE:
+		case xsql.PROPOSE:
 			require.Error(t, err)
 		}
 	})
@@ -425,7 +425,7 @@ func TestUUIDSerializationDatabaseSQLIssue1501(t *testing.T) {
 			resUUID := resFromDB.PublicRevertReorderForIssue1501()
 			resString := strings.ToUpper(resUUID.String())
 			require.Equal(t, idString, resString)
-		case xsql.QUERY_SERVICE:
+		case xsql.PROPOSE:
 			require.Error(t, err)
 		}
 	})

--- a/tests/integration/table_truncated_err_test.go
+++ b/tests/integration/table_truncated_err_test.go
@@ -137,7 +137,7 @@ func TestIssue798TruncatedError(t *testing.T) {
 		switch driverEngine(db) {
 		case xsql.LEGACY:
 			scope.Require.ErrorIs(err, result.ErrTruncated)
-		case xsql.QUERY_SERVICE:
+		case xsql.PROPOSE:
 			scope.Require.NoError(err)
 		}
 	}

--- a/trace/sql.go
+++ b/trace/sql.go
@@ -77,8 +77,8 @@ type (
 	}
 	// Internals: https://github.com/ydb-platform/ydb-go-sdk/blob/master/VERSIONING.md#internals
 	DatabaseSQLConnectorConnectDoneInfo struct {
-		Error   error
 		Session sessionInfo
+		Error   error
 	}
 	// Internals: https://github.com/ydb-platform/ydb-go-sdk/blob/master/VERSIONING.md#internals
 	DatabaseSQLConnPingStartInfo struct {

--- a/trace/sql_gtrace.go
+++ b/trace/sql_gtrace.go
@@ -1119,15 +1119,15 @@ func (t *DatabaseSQL) onDoTx(d DatabaseSQLDoTxStartInfo) func(DatabaseSQLDoTxInt
 	}
 }
 // Internals: https://github.com/ydb-platform/ydb-go-sdk/blob/master/VERSIONING.md#internals
-func DatabaseSQLOnConnectorConnect(t *DatabaseSQL, c *context.Context, call call) func(_ error, session sessionInfo) {
+func DatabaseSQLOnConnectorConnect(t *DatabaseSQL, c *context.Context, call call) func(session sessionInfo, _ error) {
 	var p DatabaseSQLConnectorConnectStartInfo
 	p.Context = c
 	p.Call = call
 	res := t.onConnectorConnect(p)
-	return func(e error, session sessionInfo) {
+	return func(session sessionInfo, e error) {
 		var p DatabaseSQLConnectorConnectDoneInfo
-		p.Error = e
 		p.Session = session
+		p.Error = e
 		res(p)
 	}
 }


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Counter `ydb_go_sdk_ydb_database_sql_conns` goes in negative values when `database/sql` driver is used. The reason is [after this commit](https://github.com/ydb-platform/ydb-go-sdk/commit/fd4142df6e70e949cc2b141bdc358d27473f69f9#diff-bc3f866611d992e908970b6cc021a96cb80ac60cbe0afd9372284c9713add5c3R51), `OnConnBeginTx` is called on begin, `OnConnClose` called on close, gauge is only decremented, and `database/sql` driver in sdk does not have its own `OnConnBeginTx` implementation, so it does nothing
Issue Number: N/A

## What is the new behavior?

Restores the behaviour before the mentioned commit