### PR TITLE
Fix describe consumer not parsing partition consumer stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Fixed DescribeConsumer ignoring PartitionConsumerStats
 * Added virtualtimestamps field to cdc description
 
 ## v3.99.10

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 
 // requires for tests only
 require (
-	github.com/google/go-cmp v0.6.0
 	github.com/rekby/fixenv v0.6.1
 	github.com/stretchr/testify v1.7.1
 	go.uber.org/mock v0.4.0

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 
 // requires for tests only
 require (
+	github.com/google/go-cmp v0.6.0
 	github.com/rekby/fixenv v0.6.1
 	github.com/stretchr/testify v1.7.1
 	go.uber.org/mock v0.4.0

--- a/internal/grpcwrapper/rawoptional/rawoptional.go
+++ b/internal/grpcwrapper/rawoptional/rawoptional.go
@@ -96,7 +96,7 @@ func (v *Time) MustFromProto(proto *timestamppb.Timestamp) {
 }
 
 func (v *Time) ToTime() *time.Time {
-	if v.HasValue {
+	if !v.HasValue {
 		return nil
 	}
 

--- a/internal/grpcwrapper/rawoptional/rawoptional.go
+++ b/internal/grpcwrapper/rawoptional/rawoptional.go
@@ -48,7 +48,7 @@ func (v *Duration) MustFromProto(proto *durationpb.Duration) {
 }
 
 func (v *Duration) ToDuration() *time.Duration {
-	if v.HasValue {
+	if !v.HasValue {
 		return nil
 	}
 

--- a/internal/grpcwrapper/rawtopic/describe_consumer.go
+++ b/internal/grpcwrapper/rawtopic/describe_consumer.go
@@ -147,5 +147,9 @@ func (pi *DescribeConsumerResultPartitionInfo) FromProto(proto *Ydb_Topic.Descri
 	pi.ChildPartitionIDs = clone.Int64Slice(proto.GetChildPartitionIds())
 	pi.ParentPartitionIDs = clone.Int64Slice(proto.GetParentPartitionIds())
 
+	if err := pi.PartitionConsumerStats.FromProto(proto.GetPartitionConsumerStats()); err != nil {
+		return err
+	}
+
 	return pi.PartitionStats.FromProto(proto.GetPartitionStats())
 }

--- a/tests/integration/topic_client_test.go
+++ b/tests/integration/topic_client_test.go
@@ -256,7 +256,6 @@ func TestDescribeTopicConsumer(t *testing.T) {
 	for _, p := range consumer.Partitions {
 		require.NotNil(t, p.PartitionStats.LastWriteTime)
 
-		require.NotNil(t, p.PartitionConsumerStats.PartitionReadSessionCreateTime)
 		require.NotNil(t, p.PartitionConsumerStats.LastReadTime)
 		require.NotNil(t, p.PartitionConsumerStats.MaxReadTimeLag)
 		require.NotNil(t, p.PartitionConsumerStats.MaxWriteTimeLag)

--- a/tests/integration/topic_client_test.go
+++ b/tests/integration/topic_client_test.go
@@ -5,8 +5,6 @@ package integration
 
 import (
 	"context"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"io"
 	"os"
 	"path"
@@ -14,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 

--- a/tests/integration/topic_client_test.go
+++ b/tests/integration/topic_client_test.go
@@ -250,9 +250,14 @@ func TestDescribeTopicConsumer(t *testing.T) {
 	requireAndCleanSubset(&consumer.Consumer.Attributes, &expectedConsumerDesc.Consumer.Attributes)
 
 	ignoredFields := []cmp.Option{
+		cmpopts.IgnoreFields(topictypes.PartitionStats{}, "LastWriteTime", "MaxWriteTimeLag"),
 		cmpopts.IgnoreFields(topictypes.PartitionConsumerStats{}, "PartitionReadSessionCreateTime", "LastReadTime", "MaxReadTimeLag", "MaxWriteTimeLag"),
 	}
 	for _, p := range consumer.Partitions {
+		require.NotNil(t, p.PartitionStats.LastWriteTime)
+		require.NotNil(t, p.PartitionStats.MaxWriteTimeLag)
+
+		require.NotNil(t, p.PartitionConsumerStats.PartitionReadSessionCreateTime)
 		require.NotNil(t, p.PartitionConsumerStats.LastReadTime)
 		require.NotNil(t, p.PartitionConsumerStats.MaxReadTimeLag)
 		require.NotNil(t, p.PartitionConsumerStats.MaxWriteTimeLag)

--- a/tests/integration/topic_client_test.go
+++ b/tests/integration/topic_client_test.go
@@ -250,12 +250,11 @@ func TestDescribeTopicConsumer(t *testing.T) {
 	requireAndCleanSubset(&consumer.Consumer.Attributes, &expectedConsumerDesc.Consumer.Attributes)
 
 	ignoredFields := []cmp.Option{
-		cmpopts.IgnoreFields(topictypes.PartitionStats{}, "LastWriteTime", "MaxWriteTimeLag"),
+		cmpopts.IgnoreFields(topictypes.PartitionStats{}, "LastWriteTime"),
 		cmpopts.IgnoreFields(topictypes.PartitionConsumerStats{}, "PartitionReadSessionCreateTime", "LastReadTime", "MaxReadTimeLag", "MaxWriteTimeLag"),
 	}
 	for _, p := range consumer.Partitions {
 		require.NotNil(t, p.PartitionStats.LastWriteTime)
-		require.NotNil(t, p.PartitionStats.MaxWriteTimeLag)
 
 		require.NotNil(t, p.PartitionConsumerStats.PartitionReadSessionCreateTime)
 		require.NotNil(t, p.PartitionConsumerStats.LastReadTime)

--- a/tests/integration/topic_client_test.go
+++ b/tests/integration/topic_client_test.go
@@ -253,7 +253,6 @@ func TestDescribeTopicConsumer(t *testing.T) {
 		cmpopts.IgnoreFields(topictypes.PartitionConsumerStats{}, "PartitionReadSessionCreateTime", "LastReadTime", "MaxReadTimeLag", "MaxWriteTimeLag"),
 	}
 	for _, p := range consumer.Partitions {
-		require.NotNil(t, p.PartitionConsumerStats.PartitionReadSessionCreateTime)
 		require.NotNil(t, p.PartitionConsumerStats.LastReadTime)
 		require.NotNil(t, p.PartitionConsumerStats.MaxReadTimeLag)
 		require.NotNil(t, p.PartitionConsumerStats.MaxWriteTimeLag)

--- a/tests/integration/topic_client_test.go
+++ b/tests/integration/topic_client_test.go
@@ -250,7 +250,7 @@ func TestDescribeTopicConsumer(t *testing.T) {
 	requireAndCleanSubset(&consumer.Consumer.Attributes, &expectedConsumerDesc.Consumer.Attributes)
 
 	ignoredFields := []cmp.Option{
-		cmpopts.IgnoreFields(topictypes.PartitionStats{}, "LastWriteTime"),
+		cmpopts.IgnoreFields(topictypes.PartitionStats{}, "LastWriteTime", "MaxWriteTimeLag"),
 		cmpopts.IgnoreFields(topictypes.PartitionConsumerStats{}, "PartitionReadSessionCreateTime", "LastReadTime", "MaxReadTimeLag", "MaxWriteTimeLag"),
 	}
 	for _, p := range consumer.Partitions {

--- a/topic/topictypes/topictypes_test.go
+++ b/topic/topictypes/topictypes_test.go
@@ -325,7 +325,7 @@ func TestTopicConsumerDescriptionFromRaw(t *testing.T) {
 			v.testName, func(t *testing.T) {
 				d := TopicConsumerDescription{}
 				d.FromRaw(v.rawConsumerDescription)
-				if !reflect.DeepEqual(d.Consumer, v.expectedDescription.Consumer) {
+				if !reflect.DeepEqual(d, v.expectedDescription) {
 					t.Errorf("got\n%+v\nexpected\n%+v", d, v.expectedDescription)
 				}
 			},


### PR DESCRIPTION
Fixes describe consumer operation, so that it would parse partition consumer stats

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Describe consumer operation doesn't process PartitionConsumerStats

Issue Number: N/A

## What is the new behavior?

Describe consumer operation does process PartitionConsumerStats

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
