### PR TITLE
* Added binding `ydb.WithWideTimeTypes()` which interprets `time.Time` and `time.Duration` as `Timestamp64` and `Interval64` YDB types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Added binding `ydb.WithWideTypes()` which interprets `time.Time` and `time.Duration` as `Timestamp64` and `Interval64` YDB types
+
 ## v3.103.0
 * Supported wide `Interval64` type
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-* Added binding `ydb.WithWideTypes()` which interprets `time.Time` and `time.Duration` as `Timestamp64` and `Interval64` YDB types
+* Added binding `ydb.WithWideTimeTypes()` which interprets `time.Time` and `time.Duration` as `Timestamp64` and `Interval64` YDB types
 
 ## v3.103.0
 * Supported wide `Interval64` type

--- a/dsn.go
+++ b/dsn.go
@@ -114,6 +114,8 @@ func parseConnectionString(dataSourceName string) (opts []Option, _ error) {
 				binders = append(binders, xsql.WithQueryBind(bind.PositionalArgs{}))
 			case "numeric":
 				binders = append(binders, xsql.WithQueryBind(bind.NumericArgs{}))
+			case "wide_time_types":
+				binders = append(binders, xsql.WithQueryBind(bind.WideTimeTypes{}))
 			default:
 				if strings.HasPrefix(transformer, tablePathPrefixTransformer) {
 					prefix, err := extractTablePathPrefixFromBinderName(transformer)

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -171,6 +171,21 @@ func TestParse(t *testing.T) {
 			},
 			err: nil,
 		},
+		{
+			dsn: "grpc://localhost:2135/local?query_mode=scripting&go_query_bind=positional,declare,wide_time_types", //nolint:lll
+			opts: []config.Option{
+				config.WithSecure(false),
+				config.WithEndpoint("localhost:2135"),
+				config.WithDatabase("/local"),
+			},
+			connectorOpts: []xsql.Option{
+				xsql.WithDefaultQueryMode(xtable.ScriptingQueryMode),
+				xsql.WithQueryBind(bind.PositionalArgs{}),
+				xsql.WithQueryBind(bind.AutoDeclare{}),
+				xsql.WithQueryBind(bind.WideTimeTypes{}),
+			},
+			err: nil,
+		},
 	} {
 		t.Run("", func(t *testing.T) {
 			opts, err := parseConnectionString(tt.dsn)

--- a/internal/bind/auto_declare.go
+++ b/internal/bind/auto_declare.go
@@ -13,8 +13,8 @@ func (m AutoDeclare) blockID() blockID {
 	return blockDeclare
 }
 
-func (m AutoDeclare) ToYdb(sql string, args ...interface{}) (
-	yql string, newArgs []interface{}, err error,
+func (m AutoDeclare) ToYdb(sql string, args ...any) (
+	yql string, newArgs []any, err error,
 ) {
 	params, err := Params(args...)
 	if err != nil {

--- a/internal/bind/bind.go
+++ b/internal/bind/bind.go
@@ -11,14 +11,16 @@ import (
 type blockID int
 
 const (
-	blockPragma = blockID(iota)
+	blockDefault = blockID(iota)
+	blockPragma
 	blockDeclare
 	blockYQL
+	blockCastArgs
 )
 
 type Bind interface {
-	ToYdb(sql string, args ...interface{}) (
-		yql string, newArgs []interface{}, _ error,
+	ToYdb(sql string, args ...any) (
+		yql string, newArgs []any, _ error,
 	)
 
 	blockID() blockID
@@ -26,7 +28,7 @@ type Bind interface {
 
 type Bindings []Bind
 
-func (bindings Bindings) ToYdb(sql string, args ...interface{}) (
+func (bindings Bindings) ToYdb(sql string, args ...any) (
 	yql string, params params.Params, err error,
 ) {
 	if len(bindings) == 0 {

--- a/internal/bind/noop.go
+++ b/internal/bind/noop.go
@@ -1,0 +1,11 @@
+package bind
+
+type noopBind struct{}
+
+func (m noopBind) ToYdb(sql string, args ...any) (yql string, newArgs []any, _ error) {
+	return sql, args, nil
+}
+
+func (m noopBind) blockID() blockID {
+	return blockCastArgs
+}

--- a/internal/bind/numeric_args.go
+++ b/internal/bind/numeric_args.go
@@ -17,7 +17,7 @@ func (m NumericArgs) blockID() blockID {
 	return blockYQL
 }
 
-func (m NumericArgs) ToYdb(sql string, args ...interface{}) (yql string, newArgs []interface{}, err error) {
+func (m NumericArgs) ToYdb(sql string, args ...any) (yql string, newArgs []any, err error) {
 	l := &sqlLexer{
 		src:        sql,
 		stateFn:    numericArgsStateFn,
@@ -36,7 +36,7 @@ func (m NumericArgs) ToYdb(sql string, args ...interface{}) (yql string, newArgs
 		if err != nil {
 			return "", nil, err
 		}
-		newArgs = make([]interface{}, len(parameters))
+		newArgs = make([]any, len(parameters))
 		for i, param := range parameters {
 			newArgs[i] = param
 		}
@@ -119,7 +119,7 @@ func numericArgsStateFn(l *sqlLexer) stateFn {
 	}
 }
 
-func parsePositionalParameters(args []interface{}) ([]*params.Parameter, error) {
+func parsePositionalParameters(args []any) ([]*params.Parameter, error) {
 	newArgs := make([]*params.Parameter, len(args))
 	for i, arg := range args {
 		paramName := fmt.Sprintf("$p%d", i)

--- a/internal/bind/numeric_args_test.go
+++ b/internal/bind/numeric_args_test.go
@@ -17,58 +17,58 @@ func TestNumericArgsBindRewriteQuery(t *testing.T) {
 	)
 	for _, tt := range []struct {
 		sql    string
-		args   []interface{}
+		args   []any
 		yql    string
-		params []interface{}
+		params []any
 		err    error
 	}{
 		{
 			sql: `SELECT $123abc, $2`,
-			args: []interface{}{
+			args: []any{
 				100,
 			},
 			err: ErrInconsistentArgs,
 		},
 		{
 			sql: `SELECT $123abc, $1`,
-			args: []interface{}{
+			args: []any{
 				200,
 			},
 			yql: `-- origin query with numeric args replacement
 SELECT $123abc, $p0`,
-			params: []interface{}{
+			params: []any{
 				table.ValueParam("$p0", types.Int32Value(200)),
 			},
 		},
 		{
 			sql: `SELECT $1, $2`,
-			args: []interface{}{
+			args: []any{
 				table.ValueParam("$name1", types.Int32Value(100)),
 				table.ValueParam("$name2", types.Int32Value(200)),
 			},
 			yql: `-- origin query with numeric args replacement
 SELECT $name1, $name2`,
-			params: []interface{}{
+			params: []any{
 				table.ValueParam("$name1", types.Int32Value(100)),
 				table.ValueParam("$name2", types.Int32Value(200)),
 			},
 		},
 		{
 			sql: `SELECT $1, $2`,
-			args: []interface{}{
+			args: []any{
 				table.ValueParam("$namedArg", types.Int32Value(100)),
 				200,
 			},
 			yql: `-- origin query with numeric args replacement
 SELECT $namedArg, $p1`,
-			params: []interface{}{
+			params: []any{
 				table.ValueParam("$namedArg", types.Int32Value(100)),
 				table.ValueParam("$p1", types.Int32Value(200)),
 			},
 		},
 		{
 			sql: `SELECT $0, $1`,
-			args: []interface{}{
+			args: []any{
 				100,
 				200,
 			},
@@ -76,64 +76,64 @@ SELECT $namedArg, $p1`,
 		},
 		{
 			sql: `SELECT $1, $2`,
-			args: []interface{}{
+			args: []any{
 				100,
 				200,
 			},
 			yql: `-- origin query with numeric args replacement
 SELECT $p0, $p1`,
-			params: []interface{}{
+			params: []any{
 				table.ValueParam("$p0", types.Int32Value(100)),
 				table.ValueParam("$p1", types.Int32Value(200)),
 			},
 		},
 		{
 			sql: `SELECT $1, $2`,
-			args: []interface{}{
+			args: []any{
 				100,
 			},
 			err: ErrInconsistentArgs,
 		},
 		{
 			sql: `SELECT $1, "$2"`,
-			args: []interface{}{
+			args: []any{
 				100,
 			},
 			yql: `-- origin query with numeric args replacement
 SELECT $p0, "$2"`,
-			params: []interface{}{
+			params: []any{
 				table.ValueParam("$p0", types.Int32Value(100)),
 			},
 		},
 		{
 			sql: `SELECT $1, '$2'`,
-			args: []interface{}{
+			args: []any{
 				100,
 			},
 			yql: `-- origin query with numeric args replacement
 SELECT $p0, '$2'`,
-			params: []interface{}{
+			params: []any{
 				table.ValueParam("$p0", types.Int32Value(100)),
 			},
 		},
 		{
 			sql: "SELECT $1, `$2`",
-			args: []interface{}{
+			args: []any{
 				100,
 			},
 			yql: "-- origin query with numeric args replacement\nSELECT $p0, `$2`",
-			params: []interface{}{
+			params: []any{
 				table.ValueParam("$p0", types.Int32Value(100)),
 			},
 		},
 		{
 			sql:    "SELECT ?, $1, $p0",
-			params: []interface{}{},
+			params: []any{},
 			err:    ErrInconsistentArgs,
 		},
 		{
 			sql: "SELECT $1, $2, $3",
-			args: []interface{}{
+			args: []any{
 				1,
 				"test",
 				[]string{
@@ -144,7 +144,7 @@ SELECT $p0, '$2'`,
 			},
 			yql: `-- origin query with numeric args replacement
 SELECT $p0, $p1, $p2`,
-			params: []interface{}{
+			params: []any{
 				table.ValueParam("$p0", types.Int32Value(1)),
 				table.ValueParam("$p1", types.TextValue("test")),
 				table.ValueParam("$p2", types.ListValue(
@@ -156,7 +156,7 @@ SELECT $p0, $p1, $p2`,
 		},
 		{
 			sql: "SELECT $1, $2, $3, $1, $2",
-			args: []interface{}{
+			args: []any{
 				1,
 				"test",
 				[]string{
@@ -167,7 +167,7 @@ SELECT $p0, $p1, $p2`,
 			},
 			yql: `-- origin query with numeric args replacement
 SELECT $p0, $p1, $p2, $p0, $p1`,
-			params: []interface{}{
+			params: []any{
 				table.ValueParam("$p0", types.Int32Value(1)),
 				table.ValueParam("$p1", types.TextValue("test")),
 				table.ValueParam("$p2", types.ListValue(
@@ -179,7 +179,7 @@ SELECT $p0, $p1, $p2, $p0, $p1`,
 		},
 		{
 			sql: "SELECT $1, $2, $3",
-			args: []interface{}{
+			args: []any{
 				types.Int32Value(1),
 				types.TextValue("test"),
 				types.ListValue(
@@ -190,7 +190,7 @@ SELECT $p0, $p1, $p2, $p0, $p1`,
 			},
 			yql: `-- origin query with numeric args replacement
 SELECT $p0, $p1, $p2`,
-			params: []interface{}{
+			params: []any{
 				table.ValueParam("$p0", types.Int32Value(1)),
 				table.ValueParam("$p1", types.TextValue("test")),
 				table.ValueParam("$p2", types.ListValue(
@@ -202,12 +202,12 @@ SELECT $p0, $p1, $p2`,
 		},
 		{
 			sql: "SELECT $1, a, b, c WHERE id = $1 AND date < $2 AND value IN ($3)",
-			args: []interface{}{
+			args: []any{
 				1, now, []string{"3"},
 			},
 			yql: `-- origin query with numeric args replacement
 SELECT $p0, a, b, c WHERE id = $p0 AND date < $p1 AND value IN ($p2)`,
-			params: []interface{}{
+			params: []any{
 				table.ValueParam("$p0", types.Int32Value(1)),
 				table.ValueParam("$p1", types.TimestampValueFromTime(now)),
 				table.ValueParam("$p2", types.ListValue(types.TextValue("3"))),
@@ -225,47 +225,47 @@ SELECT 1`,
 		},
 		{
 			sql: "SELECT $1, $2",
-			args: []interface{}{
+			args: []any{
 				1,
 			},
 			err: ErrInconsistentArgs,
 		},
 		{
 			sql: "SELECT $1, $2 -- some comment with $3",
-			args: []interface{}{
+			args: []any{
 				100,
 				200,
 			},
 			yql: `-- origin query with numeric args replacement
 SELECT $p0, $p1 -- some comment with $3`,
-			params: []interface{}{
+			params: []any{
 				table.ValueParam("$p0", types.Int32Value(100)),
 				table.ValueParam("$p1", types.Int32Value(200)),
 			},
 		},
 		{
 			sql: "SELECT $1 /* some comment with $3 */, $2",
-			args: []interface{}{
+			args: []any{
 				100,
 				200,
 			},
 			yql: `-- origin query with numeric args replacement
 SELECT $p0 /* some comment with $3 */, $p1`,
-			params: []interface{}{
+			params: []any{
 				table.ValueParam("$p0", types.Int32Value(100)),
 				table.ValueParam("$p1", types.Int32Value(200)),
 			},
 		},
 		{
 			sql: "SELECT $1, $2 -- some comment with $3",
-			args: []interface{}{
+			args: []any{
 				100,
 			},
 			err: ErrInconsistentArgs,
 		},
 		{
 			sql: "SELECT $1, $2, $3",
-			args: []interface{}{
+			args: []any{
 				100,
 				200,
 			},
@@ -274,40 +274,40 @@ SELECT $p0 /* some comment with $3 */, $p1`,
 		{
 			sql: `
 SELECT $1 /* some comment with $3 */, $2`,
-			args: []interface{}{
+			args: []any{
 				100,
 				200,
 			},
 			yql: `-- origin query with numeric args replacement
 
 SELECT $p0 /* some comment with $3 */, $p1`,
-			params: []interface{}{
+			params: []any{
 				table.ValueParam("$p0", types.Int32Value(100)),
 				table.ValueParam("$p1", types.Int32Value(200)),
 			},
 		},
 		{
 			sql: "SELECT $1, $2",
-			args: []interface{}{
+			args: []any{
 				100,
 				200,
 			},
 			yql: `-- origin query with numeric args replacement
 SELECT $p0, $p1`,
-			params: []interface{}{
+			params: []any{
 				table.ValueParam("$p0", types.Int32Value(100)),
 				table.ValueParam("$p1", types.Int32Value(200)),
 			},
 		},
 		{
 			sql: "SELECT $1, $2",
-			args: []interface{}{
+			args: []any{
 				100,
 				200,
 			},
 			yql: `-- origin query with numeric args replacement
 SELECT $p0, $p1`,
-			params: []interface{}{
+			params: []any{
 				table.ValueParam("$p0", types.Int32Value(100)),
 				table.ValueParam("$p1", types.Int32Value(200)),
 			},

--- a/internal/bind/params.go
+++ b/internal/bind/params.go
@@ -29,7 +29,7 @@ var (
 	uuidPtrType = reflect.TypeOf((*uuid.UUID)(nil))
 )
 
-func asUUID(v interface{}) (value.Value, bool) {
+func asUUID(v any) (value.Value, bool) {
 	switch reflect.TypeOf(v) {
 	case uuidType:
 		return value.Uuid(v.(uuid.UUID)), true //nolint:forcetypeassert
@@ -45,7 +45,7 @@ func asUUID(v interface{}) (value.Value, bool) {
 	return nil, false
 }
 
-func toType(v interface{}) (_ types.Type, err error) { //nolint:funlen
+func toType(v any) (_ types.Type, err error) { //nolint:funlen
 	switch x := v.(type) {
 	case bool:
 		return types.Bool, nil
@@ -156,7 +156,7 @@ func toType(v interface{}) (_ types.Type, err error) { //nolint:funlen
 }
 
 //nolint:gocyclo,funlen
-func toValue(v interface{}) (_ value.Value, err error) {
+func toValue(v any) (_ value.Value, err error) {
 	if x, ok := asUUID(v); ok {
 		return x, nil
 	}
@@ -338,7 +338,7 @@ func toValue(v interface{}) (_ value.Value, err error) {
 	}
 }
 
-func supportNewTypeLink(x interface{}) string {
+func supportNewTypeLink(x any) string {
 	v := url.Values{}
 	v.Add("labels", "enhancement,database/sql")
 	v.Add("template", "02_FEATURE_REQUEST.md")
@@ -347,7 +347,7 @@ func supportNewTypeLink(x interface{}) string {
 	return "https://github.com/ydb-platform/ydb-go-sdk/issues/new?" + v.Encode()
 }
 
-func toYdbParam(name string, value interface{}) (*params.Parameter, error) {
+func toYdbParam(name string, value any) (*params.Parameter, error) {
 	switch tv := value.(type) {
 	case driver.NamedValue:
 		n, v := tv.Name, tv.Value
@@ -373,7 +373,7 @@ func toYdbParam(name string, value interface{}) (*params.Parameter, error) {
 	return params.Named(name, v), nil
 }
 
-func Params(args ...interface{}) ([]*params.Parameter, error) {
+func Params(args ...any) ([]*params.Parameter, error) {
 	parameters := make([]*params.Parameter, 0, len(args))
 	for i, arg := range args {
 		var newParam *params.Parameter

--- a/internal/bind/params_test.go
+++ b/internal/bind/params_test.go
@@ -28,7 +28,7 @@ func (v testValuer) Value() (driver.Value, error) {
 func TestToValue(t *testing.T) {
 	for _, tt := range []struct {
 		name string
-		src  interface{}
+		src  any
 		dst  value.Value
 		err  error
 	}{
@@ -649,7 +649,7 @@ func TestToValue(t *testing.T) {
 	}
 }
 
-func named(name string, value interface{}) driver.NamedValue {
+func named(name string, value any) driver.NamedValue {
 	return driver.NamedValue{
 		Name:  name,
 		Value: value,
@@ -659,7 +659,7 @@ func named(name string, value interface{}) driver.NamedValue {
 func TestYdbParam(t *testing.T) {
 	for _, tt := range []struct {
 		name string
-		src  interface{}
+		src  any
 		dst  *params.Parameter
 		err  error
 	}{
@@ -708,19 +708,19 @@ func TestYdbParam(t *testing.T) {
 func TestArgsToParams(t *testing.T) {
 	for _, tt := range []struct {
 		name   string
-		args   []interface{}
+		args   []any
 		params []*params.Parameter
 		err    error
 	}{
 		{
 			name:   xtest.CurrentFileLine(),
-			args:   []interface{}{},
+			args:   []any{},
 			params: []*params.Parameter{},
 			err:    nil,
 		},
 		{
 			name: xtest.CurrentFileLine(),
-			args: []interface{}{
+			args: []any{
 				1, uint64(2), "3",
 			},
 			params: []*params.Parameter{
@@ -732,7 +732,7 @@ func TestArgsToParams(t *testing.T) {
 		},
 		{
 			name: xtest.CurrentFileLine(),
-			args: []interface{}{
+			args: []any{
 				table.NewQueryParameters(
 					params.Named("$p0", value.Int32Value(1)),
 					params.Named("$p1", value.Uint64Value(2)),
@@ -748,7 +748,7 @@ func TestArgsToParams(t *testing.T) {
 		},
 		{
 			name: xtest.CurrentFileLine(),
-			args: []interface{}{
+			args: []any{
 				params.Named("$p0", value.Int32Value(1)),
 				params.Named("$p1", value.Uint64Value(2)),
 				params.Named("$p2", value.TextValue("3")),
@@ -762,7 +762,7 @@ func TestArgsToParams(t *testing.T) {
 		},
 		{
 			name: xtest.CurrentFileLine(),
-			args: []interface{}{
+			args: []any{
 				sql.Named("$p0", value.Int32Value(1)),
 				sql.Named("$p1", value.Uint64Value(2)),
 				sql.Named("$p2", value.TextValue("3")),
@@ -776,7 +776,7 @@ func TestArgsToParams(t *testing.T) {
 		},
 		{
 			name: xtest.CurrentFileLine(),
-			args: []interface{}{
+			args: []any{
 				driver.NamedValue{Name: "$p0", Value: value.Int32Value(1)},
 				driver.NamedValue{Name: "$p1", Value: value.Uint64Value(2)},
 				driver.NamedValue{Name: "$p2", Value: value.TextValue("3")},
@@ -790,7 +790,7 @@ func TestArgsToParams(t *testing.T) {
 		},
 		{
 			name: xtest.CurrentFileLine(),
-			args: []interface{}{
+			args: []any{
 				driver.NamedValue{Value: params.Named("$p0", value.Int32Value(1))},
 				driver.NamedValue{Value: params.Named("$p1", value.Uint64Value(2))},
 				driver.NamedValue{Value: params.Named("$p2", value.TextValue("3"))},
@@ -804,7 +804,7 @@ func TestArgsToParams(t *testing.T) {
 		},
 		{
 			name: xtest.CurrentFileLine(),
-			args: []interface{}{
+			args: []any{
 				driver.NamedValue{Value: 1},
 				driver.NamedValue{Value: uint64(2)},
 				driver.NamedValue{Value: "3"},
@@ -818,7 +818,7 @@ func TestArgsToParams(t *testing.T) {
 		},
 		{
 			name: xtest.CurrentFileLine(),
-			args: []interface{}{
+			args: []any{
 				driver.NamedValue{Value: table.NewQueryParameters(
 					params.Named("$p0", value.Int32Value(1)),
 					params.Named("$p1", value.Uint64Value(2)),
@@ -834,7 +834,7 @@ func TestArgsToParams(t *testing.T) {
 		},
 		{
 			name: xtest.CurrentFileLine(),
-			args: []interface{}{
+			args: []any{
 				driver.NamedValue{Value: table.NewQueryParameters(
 					params.Named("$p0", value.Int32Value(1)),
 					params.Named("$p1", value.Uint64Value(2)),
@@ -898,7 +898,7 @@ func TestAsUUIDCastToInterface(t *testing.T) {
 	})
 }
 
-func asUUIDCastToInterface(v interface{}) (value.Value, bool) {
+func asUUIDCastToInterface(v any) (value.Value, bool) {
 	// explicit casting of type [16]byte to uuid.UUID will success,
 	// but casting of [16]byte to some interface with  methods from uuid.UUID will failed
 	if _, ok := v.(interface {
@@ -921,7 +921,7 @@ func asUUIDCastToInterface(v interface{}) (value.Value, bool) {
 	}
 }
 
-func asUUIDForceTypeCast(v interface{}) (value.Value, bool) {
+func asUUIDForceTypeCast(v any) (value.Value, bool) {
 	return value.Uuid(v.(uuid.UUID)), true
 }
 
@@ -948,7 +948,7 @@ var (
 	expUUIDValue = value.Uuid(uuid.UUID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
 )
 
-func asUUIDUsingReflect(v interface{}) (value.Value, bool) {
+func asUUIDUsingReflect(v any) (value.Value, bool) {
 	switch reflect.TypeOf(v) {
 	case uuidType:
 		return value.Uuid(v.(uuid.UUID)), true

--- a/internal/bind/positional_args.go
+++ b/internal/bind/positional_args.go
@@ -16,8 +16,8 @@ func (m PositionalArgs) blockID() blockID {
 	return blockYQL
 }
 
-func (m PositionalArgs) ToYdb(sql string, args ...interface{}) (
-	yql string, newArgs []interface{}, err error,
+func (m PositionalArgs) ToYdb(sql string, args ...any) (
+	yql string, newArgs []any, err error,
 ) {
 	l := &sqlLexer{
 		src:        sql,

--- a/internal/bind/positional_args_test.go
+++ b/internal/bind/positional_args_test.go
@@ -17,60 +17,60 @@ func TestPositionalArgsBindRewriteQuery(t *testing.T) {
 	)
 	for _, tt := range []struct {
 		sql    string
-		args   []interface{}
+		args   []any
 		yql    string
-		params []interface{}
+		params []any
 		err    error
 	}{
 		{
 			sql: `SELECT ?, ?`,
-			args: []interface{}{
+			args: []any{
 				100,
 				200,
 			},
 			yql: `-- origin query with positional args replacement
 SELECT $p0, $p1`,
-			params: []interface{}{
+			params: []any{
 				table.ValueParam("$p0", types.Int32Value(100)),
 				table.ValueParam("$p1", types.Int32Value(200)),
 			},
 		},
 		{
 			sql: `SELECT ?, ?`,
-			args: []interface{}{
+			args: []any{
 				100,
 			},
 			err: ErrInconsistentArgs,
 		},
 		{
 			sql: `SELECT ?, "?"`,
-			args: []interface{}{
+			args: []any{
 				100,
 			},
 			yql: `-- origin query with positional args replacement
 SELECT $p0, "?"`,
-			params: []interface{}{
+			params: []any{
 				table.ValueParam("$p0", types.Int32Value(100)),
 			},
 		},
 		{
 			sql: `SELECT ?, '?'`,
-			args: []interface{}{
+			args: []any{
 				100,
 			},
 			yql: `-- origin query with positional args replacement
 SELECT $p0, '?'`,
-			params: []interface{}{
+			params: []any{
 				table.ValueParam("$p0", types.Int32Value(100)),
 			},
 		},
 		{
 			sql: "SELECT ?, `?`",
-			args: []interface{}{
+			args: []any{
 				100,
 			},
 			yql: "-- origin query with positional args replacement\nSELECT $p0, `?`",
-			params: []interface{}{
+			params: []any{
 				table.ValueParam("$p0", types.Int32Value(100)),
 			},
 		},
@@ -80,7 +80,7 @@ SELECT $p0, '?'`,
 		},
 		{
 			sql: "SELECT ?, ?, ?",
-			args: []interface{}{
+			args: []any{
 				1,
 				"test",
 				[]string{
@@ -91,7 +91,7 @@ SELECT $p0, '?'`,
 			},
 			yql: `-- origin query with positional args replacement
 SELECT $p0, $p1, $p2`,
-			params: []interface{}{
+			params: []any{
 				table.ValueParam("$p0", types.Int32Value(1)),
 				table.ValueParam("$p1", types.TextValue("test")),
 				table.ValueParam("$p2", types.ListValue(
@@ -103,7 +103,7 @@ SELECT $p0, $p1, $p2`,
 		},
 		{
 			sql: "SELECT ?, ?, ?",
-			args: []interface{}{
+			args: []any{
 				types.Int32Value(1),
 				types.TextValue("test"),
 				types.ListValue(
@@ -114,7 +114,7 @@ SELECT $p0, $p1, $p2`,
 			},
 			yql: `-- origin query with positional args replacement
 SELECT $p0, $p1, $p2`,
-			params: []interface{}{
+			params: []any{
 				table.ValueParam("$p0", types.Int32Value(1)),
 				table.ValueParam("$p1", types.TextValue("test")),
 				table.ValueParam("$p2", types.ListValue(
@@ -126,12 +126,12 @@ SELECT $p0, $p1, $p2`,
 		},
 		{
 			sql: "SELECT a, b, c WHERE id = ? AND date < ? AND value IN (?)",
-			args: []interface{}{
+			args: []any{
 				1, now, []string{"3"},
 			},
 			yql: `-- origin query with positional args replacement
 SELECT a, b, c WHERE id = $p0 AND date < $p1 AND value IN ($p2)`,
-			params: []interface{}{
+			params: []any{
 				table.ValueParam("$p0", types.Int32Value(1)),
 				table.ValueParam("$p1", types.TimestampValueFromTime(now)),
 				table.ValueParam("$p2", types.ListValue(types.TextValue("3"))),
@@ -149,47 +149,47 @@ SELECT 1`,
 		},
 		{
 			sql: "SELECT ?, ?",
-			args: []interface{}{
+			args: []any{
 				1,
 			},
 			err: ErrInconsistentArgs,
 		},
 		{
 			sql: "SELECT ?, ? -- some comment with ?",
-			args: []interface{}{
+			args: []any{
 				100,
 				200,
 			},
 			yql: `-- origin query with positional args replacement
 SELECT $p0, $p1 -- some comment with ?`,
-			params: []interface{}{
+			params: []any{
 				table.ValueParam("$p0", types.Int32Value(100)),
 				table.ValueParam("$p1", types.Int32Value(200)),
 			},
 		},
 		{
 			sql: "SELECT ? /* some comment with ? */, ?",
-			args: []interface{}{
+			args: []any{
 				100,
 				200,
 			},
 			yql: `-- origin query with positional args replacement
 SELECT $p0 /* some comment with ? */, $p1`,
-			params: []interface{}{
+			params: []any{
 				table.ValueParam("$p0", types.Int32Value(100)),
 				table.ValueParam("$p1", types.Int32Value(200)),
 			},
 		},
 		{
 			sql: "SELECT ?, ? -- some comment with ?",
-			args: []interface{}{
+			args: []any{
 				100,
 			},
 			err: ErrInconsistentArgs,
 		},
 		{
 			sql: "SELECT ?, ?, ?",
-			args: []interface{}{
+			args: []any{
 				100,
 				200,
 			},
@@ -198,40 +198,40 @@ SELECT $p0 /* some comment with ? */, $p1`,
 		{
 			sql: `
 SELECT ? /* some comment with ? */, ?`,
-			args: []interface{}{
+			args: []any{
 				100,
 				200,
 			},
 			yql: `-- origin query with positional args replacement
 
 SELECT $p0 /* some comment with ? */, $p1`,
-			params: []interface{}{
+			params: []any{
 				table.ValueParam("$p0", types.Int32Value(100)),
 				table.ValueParam("$p1", types.Int32Value(200)),
 			},
 		},
 		{
 			sql: "SELECT ?, ?",
-			args: []interface{}{
+			args: []any{
 				100,
 				200,
 			},
 			yql: `-- origin query with positional args replacement
 SELECT $p0, $p1`,
-			params: []interface{}{
+			params: []any{
 				table.ValueParam("$p0", types.Int32Value(100)),
 				table.ValueParam("$p1", types.Int32Value(200)),
 			},
 		},
 		{
 			sql: "SELECT ?, ?",
-			args: []interface{}{
+			args: []any{
 				100,
 				200,
 			},
 			yql: `-- origin query with positional args replacement
 SELECT $p0, $p1`,
-			params: []interface{}{
+			params: []any{
 				table.ValueParam("$p0", types.Int32Value(100)),
 				table.ValueParam("$p1", types.Int32Value(200)),
 			},

--- a/internal/bind/sql_lexer.go
+++ b/internal/bind/sql_lexer.go
@@ -9,7 +9,7 @@ type sqlLexer struct {
 	nested     int // multiline comment nesting level.
 	stateFn    stateFn
 	rawStateFn stateFn
-	parts      []interface{}
+	parts      []any
 }
 
 type (

--- a/internal/bind/table_path_prefix.go
+++ b/internal/bind/table_path_prefix.go
@@ -24,8 +24,8 @@ func (tablePathPrefix TablePathPrefix) NormalizePath(folderOrTable string) strin
 	}
 }
 
-func (tablePathPrefix TablePathPrefix) ToYdb(sql string, args ...interface{}) (
-	yql string, newArgs []interface{}, err error,
+func (tablePathPrefix TablePathPrefix) ToYdb(sql string, args ...any) (
+	yql string, newArgs []any, err error,
 ) {
 	buffer := xstring.Buffer()
 	defer buffer.Free()

--- a/internal/bind/wide_time_types.go
+++ b/internal/bind/wide_time_types.go
@@ -6,9 +6,9 @@ import (
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/value"
 )
 
-type WideTypes struct{}
+type WideTimeTypes struct{}
 
-func (m WideTypes) ToYdb(sql string, args ...any) (yql string, newArgs []any, _ error) {
+func (m WideTimeTypes) ToYdb(sql string, args ...any) (yql string, newArgs []any, _ error) {
 	newArgs = make([]any, 0, len(args))
 	for _, arg := range args {
 		switch t := arg.(type) {
@@ -24,6 +24,6 @@ func (m WideTypes) ToYdb(sql string, args ...any) (yql string, newArgs []any, _ 
 	return sql, newArgs, nil
 }
 
-func (m WideTypes) blockID() blockID {
+func (m WideTimeTypes) blockID() blockID {
 	return blockCastArgs
 }

--- a/internal/bind/wide_time_types_test.go
+++ b/internal/bind/wide_time_types_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/value"
 )
 
-func TestWideTypesBindRewriteQuery(t *testing.T) {
+func TestWideTimeTypesBind(t *testing.T) {
 	for _, tt := range []struct {
 		bind   Bind
 		sql    string
@@ -58,7 +58,7 @@ func TestWideTypesBindRewriteQuery(t *testing.T) {
 			},
 		},
 		{
-			bind: WideTypes{},
+			bind: WideTimeTypes{},
 			sql:  `SELECT ?, ?`,
 			args: []any{
 				100,
@@ -71,7 +71,7 @@ func TestWideTypesBindRewriteQuery(t *testing.T) {
 			},
 		},
 		{
-			bind: WideTypes{},
+			bind: WideTimeTypes{},
 			sql:  `SELECT ?, ?`,
 			args: []any{
 				time.Unix(123, 456),
@@ -84,7 +84,7 @@ func TestWideTypesBindRewriteQuery(t *testing.T) {
 			},
 		},
 		{
-			bind: WideTypes{},
+			bind: WideTimeTypes{},
 			sql:  `SELECT ?, ?`,
 			args: []any{
 				time.Duration(123) * time.Millisecond,

--- a/internal/bind/wide_types.go
+++ b/internal/bind/wide_types.go
@@ -1,0 +1,29 @@
+package bind
+
+import (
+	"time"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/value"
+)
+
+type WideTypes struct{}
+
+func (m WideTypes) ToYdb(sql string, args ...any) (yql string, newArgs []any, _ error) {
+	newArgs = make([]any, 0, len(args))
+	for _, arg := range args {
+		switch t := arg.(type) {
+		case time.Time:
+			newArgs = append(newArgs, value.Timestamp64ValueFromTime(t))
+		case time.Duration:
+			newArgs = append(newArgs, value.Interval64ValueFromDuration(t))
+		default:
+			newArgs = append(newArgs, arg)
+		}
+	}
+
+	return sql, newArgs, nil
+}
+
+func (m WideTypes) blockID() blockID {
+	return blockCastArgs
+}

--- a/internal/bind/wide_types_test.go
+++ b/internal/bind/wide_types_test.go
@@ -1,0 +1,112 @@
+package bind
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/value"
+)
+
+func TestWideTypesBindRewriteQuery(t *testing.T) {
+	for _, tt := range []struct {
+		bind   Bind
+		sql    string
+		args   []any
+		yql    string
+		params []any
+		err    error
+	}{
+		{
+			bind: noopBind{},
+			sql:  `SELECT ?, ?`,
+			args: []any{
+				100,
+				200,
+			},
+			yql: `SELECT ?, ?`,
+			params: []any{
+				100,
+				200,
+			},
+		},
+		{
+			bind: noopBind{},
+			sql:  `SELECT ?, ?`,
+			args: []any{
+				time.Unix(123, 456),
+				200,
+			},
+			yql: `SELECT ?, ?`,
+			params: []any{
+				time.Unix(123, 456),
+				200,
+			},
+		},
+		{
+			bind: noopBind{},
+			sql:  `SELECT ?, ?`,
+			args: []any{
+				time.Duration(123) * time.Millisecond,
+				200,
+			},
+			yql: `SELECT ?, ?`,
+			params: []any{
+				time.Duration(123) * time.Millisecond,
+				200,
+			},
+		},
+		{
+			bind: WideTypes{},
+			sql:  `SELECT ?, ?`,
+			args: []any{
+				100,
+				200,
+			},
+			yql: `SELECT ?, ?`,
+			params: []any{
+				100,
+				200,
+			},
+		},
+		{
+			bind: WideTypes{},
+			sql:  `SELECT ?, ?`,
+			args: []any{
+				time.Unix(123, 456),
+				200,
+			},
+			yql: `SELECT ?, ?`,
+			params: []any{
+				value.Timestamp64ValueFromTime(time.Unix(123, 456)),
+				200,
+			},
+		},
+		{
+			bind: WideTypes{},
+			sql:  `SELECT ?, ?`,
+			args: []any{
+				time.Duration(123) * time.Millisecond,
+				200,
+			},
+			yql: `SELECT ?, ?`,
+			params: []any{
+				value.Interval64ValueFromDuration(time.Duration(123) * time.Millisecond),
+				200,
+			},
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			yql, params, err := tt.bind.ToYdb(tt.sql, tt.args...)
+			if tt.err != nil {
+				require.Error(t, err)
+				require.ErrorIs(t, err, tt.err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.yql, yql)
+				require.Equal(t, tt.params, params)
+			}
+		})
+	}
+}

--- a/internal/params/builder.go
+++ b/internal/params/builder.go
@@ -6,7 +6,7 @@ type (
 	}
 )
 
-func (b Builder) Build() Parameters {
+func (b Builder) Build() *Params {
 	return &b.params
 }
 

--- a/internal/params/parameters.go
+++ b/internal/params/parameters.go
@@ -170,177 +170,202 @@ func (p *Parameter) BeginVariant() *variant {
 
 func (p *Parameter) Text(v string) Builder {
 	p.value = value.TextValue(v)
-	p.parent.params = append(p.parent.params, p)
 
-	return p.parent
+	return Builder{
+		params: append(p.parent.params, p),
+	}
 }
 
 func (p *Parameter) Bytes(v []byte) Builder {
 	p.value = value.BytesValue(v)
-	p.parent.params = append(p.parent.params, p)
 
-	return p.parent
+	return Builder{
+		params: append(p.parent.params, p),
+	}
 }
 
 func (p *Parameter) Bool(v bool) Builder {
 	p.value = value.BoolValue(v)
-	p.parent.params = append(p.parent.params, p)
 
-	return p.parent
+	return Builder{
+		params: append(p.parent.params, p),
+	}
 }
 
 func (p *Parameter) Uint64(v uint64) Builder {
 	p.value = value.Uint64Value(v)
-	p.parent.params = append(p.parent.params, p)
 
-	return p.parent
+	return Builder{
+		params: append(p.parent.params, p),
+	}
 }
 
 func (p *Parameter) Int64(v int64) Builder {
 	p.value = value.Int64Value(v)
-	p.parent.params = append(p.parent.params, p)
 
-	return p.parent
+	return Builder{
+		params: append(p.parent.params, p),
+	}
 }
 
 func (p *Parameter) Uint32(v uint32) Builder {
 	p.value = value.Uint32Value(v)
-	p.parent.params = append(p.parent.params, p)
 
-	return p.parent
+	return Builder{
+		params: append(p.parent.params, p),
+	}
 }
 
 func (p *Parameter) Int32(v int32) Builder {
 	p.value = value.Int32Value(v)
-	p.parent.params = append(p.parent.params, p)
 
-	return p.parent
+	return Builder{
+		params: append(p.parent.params, p),
+	}
 }
 
 func (p *Parameter) Uint16(v uint16) Builder {
 	p.value = value.Uint16Value(v)
-	p.parent.params = append(p.parent.params, p)
 
-	return p.parent
+	return Builder{
+		params: append(p.parent.params, p),
+	}
 }
 
 func (p *Parameter) Int16(v int16) Builder {
 	p.value = value.Int16Value(v)
-	p.parent.params = append(p.parent.params, p)
 
-	return p.parent
+	return Builder{
+		params: append(p.parent.params, p),
+	}
 }
 
 func (p *Parameter) Uint8(v uint8) Builder {
 	p.value = value.Uint8Value(v)
-	p.parent.params = append(p.parent.params, p)
 
-	return p.parent
+	return Builder{
+		params: append(p.parent.params, p),
+	}
 }
 
 func (p *Parameter) Int8(v int8) Builder {
 	p.value = value.Int8Value(v)
-	p.parent.params = append(p.parent.params, p)
 
-	return p.parent
+	return Builder{
+		params: append(p.parent.params, p),
+	}
 }
 
 func (p *Parameter) Float(v float32) Builder {
 	p.value = value.FloatValue(v)
-	p.parent.params = append(p.parent.params, p)
 
-	return p.parent
+	return Builder{
+		params: append(p.parent.params, p),
+	}
 }
 
 func (p *Parameter) Double(v float64) Builder {
 	p.value = value.DoubleValue(v)
-	p.parent.params = append(p.parent.params, p)
 
-	return p.parent
+	return Builder{
+		params: append(p.parent.params, p),
+	}
 }
 
 func (p *Parameter) Decimal(v [16]byte, precision, scale uint32) Builder {
 	p.value = value.DecimalValue(v, precision, scale)
-	p.parent.params = append(p.parent.params, p)
 
-	return p.parent
+	return Builder{
+		params: append(p.parent.params, p),
+	}
 }
 
 func (p *Parameter) Timestamp(v time.Time) Builder {
 	p.value = value.TimestampValueFromTime(v)
-	p.parent.params = append(p.parent.params, p)
 
-	return p.parent
+	return Builder{
+		params: append(p.parent.params, p),
+	}
 }
 
 func (p *Parameter) Timestamp64(v time.Time) Builder {
 	p.value = value.Timestamp64ValueFromTime(v)
-	p.parent.params = append(p.parent.params, p)
 
-	return p.parent
+	return Builder{
+		params: append(p.parent.params, p),
+	}
 }
 
 func (p *Parameter) Date(v time.Time) Builder {
 	p.value = value.DateValueFromTime(v)
-	p.parent.params = append(p.parent.params, p)
 
-	return p.parent
+	return Builder{
+		params: append(p.parent.params, p),
+	}
 }
 
 func (p *Parameter) Date32(v time.Time) Builder {
 	p.value = value.Date32ValueFromTime(v)
-	p.parent.params = append(p.parent.params, p)
 
-	return p.parent
+	return Builder{
+		params: append(p.parent.params, p),
+	}
 }
 
 func (p *Parameter) Datetime(v time.Time) Builder {
 	p.value = value.DatetimeValueFromTime(v)
-	p.parent.params = append(p.parent.params, p)
 
-	return p.parent
+	return Builder{
+		params: append(p.parent.params, p),
+	}
 }
 
 func (p *Parameter) Datetime64(v time.Time) Builder {
 	p.value = value.Datetime64ValueFromTime(v)
-	p.parent.params = append(p.parent.params, p)
 
-	return p.parent
+	return Builder{
+		params: append(p.parent.params, p),
+	}
 }
 
 func (p *Parameter) Interval(v time.Duration) Builder {
 	p.value = value.IntervalValueFromDuration(v)
-	p.parent.params = append(p.parent.params, p)
 
-	return p.parent
+	return Builder{
+		params: append(p.parent.params, p),
+	}
 }
 
 func (p *Parameter) Interval64(v time.Duration) Builder {
 	p.value = value.Interval64ValueFromDuration(v)
-	p.parent.params = append(p.parent.params, p)
 
-	return p.parent
+	return Builder{
+		params: append(p.parent.params, p),
+	}
 }
 
 func (p *Parameter) JSON(v string) Builder {
 	p.value = value.JSONValue(v)
-	p.parent.params = append(p.parent.params, p)
 
-	return p.parent
+	return Builder{
+		params: append(p.parent.params, p),
+	}
 }
 
 func (p *Parameter) JSONDocument(v string) Builder {
 	p.value = value.JSONDocumentValue(v)
-	p.parent.params = append(p.parent.params, p)
 
-	return p.parent
+	return Builder{
+		params: append(p.parent.params, p),
+	}
 }
 
 func (p *Parameter) YSON(v []byte) Builder {
 	p.value = value.YSONValue(v)
-	p.parent.params = append(p.parent.params, p)
 
-	return p.parent
+	return Builder{
+		params: append(p.parent.params, p),
+	}
 }
 
 //// removed for https://github.com/ydb-platform/ydb-go-sdk/issues/1501
@@ -353,51 +378,58 @@ func (p *Parameter) YSON(v []byte) Builder {
 // https://github.com/ydb-platform/ydb-go-sdk/issues/1501
 func (p *Parameter) UUIDWithIssue1501Value(v [16]byte) Builder {
 	p.value = value.UUIDWithIssue1501Value(v)
-	p.parent.params = append(p.parent.params, p)
 
-	return p.parent
+	return Builder{
+		params: append(p.parent.params, p),
+	}
 }
 
 func (p *Parameter) Uuid(val uuid.UUID) Builder { //nolint:revive,stylecheck
 	p.value = value.Uuid(val)
-	p.parent.params = append(p.parent.params, p)
 
-	return p.parent
+	return Builder{
+		params: append(p.parent.params, p),
+	}
 }
 
 func (p *Parameter) Any(v types.Value) Builder {
 	p.value = v
-	p.parent.params = append(p.parent.params, p)
 
-	return p.parent
+	return Builder{
+		params: append(p.parent.params, p),
+	}
 }
 
 func (p *Parameter) TzDate(v time.Time) Builder {
 	p.value = value.TzDateValueFromTime(v)
-	p.parent.params = append(p.parent.params, p)
 
-	return p.parent
+	return Builder{
+		params: append(p.parent.params, p),
+	}
 }
 
 func (p *Parameter) TzTimestamp(v time.Time) Builder {
 	p.value = value.TzTimestampValueFromTime(v)
-	p.parent.params = append(p.parent.params, p)
 
-	return p.parent
+	return Builder{
+		params: append(p.parent.params, p),
+	}
 }
 
 func (p *Parameter) TzDatetime(v time.Time) Builder {
 	p.value = value.TzDatetimeValueFromTime(v)
-	p.parent.params = append(p.parent.params, p)
 
-	return p.parent
+	return Builder{
+		params: append(p.parent.params, p),
+	}
 }
 
 func (p *Parameter) Raw(pb *Ydb.TypedValue) Builder {
 	p.value = value.FromProtobuf(pb)
-	p.parent.params = append(p.parent.params, p)
 
-	return p.parent
+	return Builder{
+		params: append(p.parent.params, p),
+	}
 }
 
 func Declare(p *Parameter) string {

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -486,7 +486,7 @@ func (v date32Value) toYDB(a *allocator.Allocator) *Ydb.Value {
 	return vvv
 }
 
-// Date32Value returns ydb date value by given days since Epoch
+// Date32Value returns ydb date value from days around epoch time
 func Date32Value(v int32) date32Value {
 	return date32Value(v)
 }
@@ -596,7 +596,7 @@ func (v datetime64Value) toYDB(a *allocator.Allocator) *Ydb.Value {
 	return vvv
 }
 
-// Datetime64Value makes ydb datetime value from seconds since Epoch
+// Datetime64Value makes ydb datetime value from seconds around epoch time
 func Datetime64Value(v int64) datetime64Value {
 	return datetime64Value(v)
 }
@@ -1385,7 +1385,7 @@ func (v interval64Value) toYDB(a *allocator.Allocator) *Ydb.Value {
 	return vvv
 }
 
-// Interval64Value makes Value from given microseconds value
+// Interval64Value makes Value from given nanoseconds around epoch time
 func Interval64Value(v int64) interval64Value {
 	return interval64Value(v)
 }
@@ -2011,7 +2011,7 @@ func (v timestamp64Value) toYDB(a *allocator.Allocator) *Ydb.Value {
 	return vvv
 }
 
-// Timestamp64Value makes ydb timestamp value by given microseconds since Epoch
+// Timestamp64Value makes ydb timestamp value by given signed microseconds around Epoch
 func Timestamp64Value(v int64) timestamp64Value {
 	return timestamp64Value(v)
 }

--- a/query_bind_test.go
+++ b/query_bind_test.go
@@ -565,6 +565,35 @@ SELECT $param1, $param2`,
 				table.ValueParam("$param2", types.Int32Value(200)),
 			),
 		},
+		{
+			b: testutil.QueryBind(
+				ydb.WithAutoDeclare(),
+				ydb.WithPositionalArgs(),
+			),
+			sql:  `SELECT ?;`,
+			args: []interface{}{time.Unix(123, 456)},
+			yql: `-- bind declares
+DECLARE $p0 AS Timestamp;
+
+-- origin query with positional args replacement
+SELECT $p0;`,
+			params: ydb.ParamsBuilder().Param("$p0").Timestamp(time.Unix(123, 456)).Build(),
+		},
+		{
+			b: testutil.QueryBind(
+				ydb.WithAutoDeclare(),
+				ydb.WithPositionalArgs(),
+				ydb.WithWideTypes(),
+			),
+			sql:  `SELECT ?;`,
+			args: []interface{}{time.Unix(123, 456)},
+			yql: `-- bind declares
+DECLARE $p0 AS Timestamp64;
+
+-- origin query with positional args replacement
+SELECT $p0;`,
+			params: ydb.ParamsBuilder().Param("$p0").Timestamp64(time.Unix(123, 456)).Build(),
+		},
 	} {
 		t.Run("", func(t *testing.T) {
 			yql, parameters, err := tt.b.ToYdb(tt.sql, tt.args...)

--- a/query_bind_test.go
+++ b/query_bind_test.go
@@ -583,7 +583,7 @@ SELECT $p0;`,
 			b: testutil.QueryBind(
 				ydb.WithAutoDeclare(),
 				ydb.WithPositionalArgs(),
-				ydb.WithWideTypes(),
+				ydb.WithWideTimeTypes(),
 			),
 			sql:  `SELECT ?;`,
 			args: []interface{}{time.Unix(123, 456)},

--- a/sql.go
+++ b/sql.go
@@ -189,6 +189,10 @@ func WithPositionalArgs() QueryBindConnectorOption {
 	return xsql.WithQueryBind(bind.PositionalArgs{})
 }
 
+func WithWideTypes() QueryBindConnectorOption {
+	return xsql.WithQueryBind(bind.WideTypes{})
+}
+
 func WithNumericArgs() QueryBindConnectorOption {
 	return xsql.WithQueryBind(bind.NumericArgs{})
 }

--- a/sql.go
+++ b/sql.go
@@ -189,8 +189,8 @@ func WithPositionalArgs() QueryBindConnectorOption {
 	return xsql.WithQueryBind(bind.PositionalArgs{})
 }
 
-func WithWideTypes() QueryBindConnectorOption {
-	return xsql.WithQueryBind(bind.WideTypes{})
+func WithWideTimeTypes() QueryBindConnectorOption {
+	return xsql.WithQueryBind(bind.WideTimeTypes{})
 }
 
 func WithNumericArgs() QueryBindConnectorOption {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
