### PR TITLE
* Improved the `ydb.WithSessionPoolSessionUsageLimit` option for allow `time.Duration` as argument type for limit max session time to live since create time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Improved the `ydb.WithSessionPoolSessionUsageLimit` option for allow `time.Duration` as argument type for limit max session time to live since create time 
+
 ## v3.105.1
 * Changed the gRPC DNS balancer policy to `round_robin` for internal `discovery/ListEndpoints` call (reverted v3.90.2 changes)
 

--- a/internal/query/client.go
+++ b/internal/query/client.go
@@ -575,6 +575,7 @@ func New(ctx context.Context, cc grpc.ClientConnInterface, cfg *config.Config) *
 		pool: pool.New(ctx,
 			pool.WithLimit[*Session, Session](cfg.PoolLimit()),
 			pool.WithItemUsageLimit[*Session, Session](cfg.PoolSessionUsageLimit()),
+			pool.WithItemUsageTTL[*Session, Session](cfg.PoolSessionUsageTTL()),
 			pool.WithTrace[*Session, Session](poolTrace(cfg.Trace())),
 			pool.WithCreateItemTimeout[*Session, Session](cfg.SessionCreateTimeout()),
 			pool.WithCloseItemTimeout[*Session, Session](cfg.SessionDeleteTimeout()),

--- a/internal/query/config/config.go
+++ b/internal/query/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 
 	poolLimit             int
 	poolSessionUsageLimit uint64
+	poolSessionUsageTTL   time.Duration
 
 	sessionCreateTimeout   time.Duration
 	sessionDeleteTimeout   time.Duration
@@ -63,6 +64,10 @@ func (c *Config) PoolLimit() int {
 
 func (c *Config) PoolSessionUsageLimit() uint64 {
 	return c.poolSessionUsageLimit
+}
+
+func (c *Config) PoolSessionUsageTTL() time.Duration {
+	return c.poolSessionUsageTTL
 }
 
 // SessionCreateTimeout limits maximum time spent on Create session request

--- a/internal/query/config/options.go
+++ b/internal/query/config/options.go
@@ -34,9 +34,17 @@ func WithPoolLimit(size int) Option {
 	}
 }
 
-func WithPoolSessionUsageLimit(sessionUsageLimit uint64) Option {
+// WithSessionPoolSessionUsageLimit set pool session max usage:
+// - if argument type is uint64 - WithSessionPoolSessionUsageLimit limits max usage count of pool session
+// - if argument type is time.Duration - WithSessionPoolSessionUsageLimit limits max time to live of pool session
+func WithSessionPoolSessionUsageLimit[T interface{ uint64 | time.Duration }](limit T) Option {
 	return func(c *Config) {
-		c.poolSessionUsageLimit = sessionUsageLimit
+		switch v := any(limit).(type) {
+		case uint64:
+			c.poolSessionUsageLimit = v
+		case time.Duration:
+			c.poolSessionUsageTTL = v
+		}
 	}
 }
 

--- a/internal/table/client.go
+++ b/internal/table/client.go
@@ -42,6 +42,7 @@ func New(ctx context.Context, cc grpc.ClientConnInterface, config *config.Config
 		pool: pool.New[*Session, Session](ctx,
 			pool.WithLimit[*Session, Session](config.SizeLimit()),
 			pool.WithItemUsageLimit[*Session, Session](config.SessionUsageLimit()),
+			pool.WithItemUsageTTL[*Session, Session](config.SessionUsageTTL()),
 			pool.WithIdleTimeToLive[*Session, Session](config.IdleThreshold()),
 			pool.WithCreateItemTimeout[*Session, Session](config.CreateSessionTimeout()),
 			pool.WithCloseItemTimeout[*Session, Session](config.DeleteTimeout()),

--- a/options.go
+++ b/options.go
@@ -531,11 +531,13 @@ func WithSessionPoolSizeLimit(sizeLimit int) Option {
 	}
 }
 
-// WithSessionPoolSessionUsageLimit set max count for use session
-func WithSessionPoolSessionUsageLimit(sessionUsageLimit uint64) Option {
+// WithSessionPoolSessionUsageLimit set pool session max usage:
+// - if argument type is uint64 - WithSessionPoolSessionUsageLimit limits max usage count of pool session
+// - if argument type is time.Duration - WithSessionPoolSessionUsageLimit limits max time to live of pool session
+func WithSessionPoolSessionUsageLimit[T interface{ uint64 | time.Duration }](limit T) Option {
 	return func(ctx context.Context, d *Driver) error {
-		d.tableOptions = append(d.tableOptions, tableConfig.WithPoolSessionUsageLimit(sessionUsageLimit))
-		d.queryOptions = append(d.queryOptions, queryConfig.WithPoolSessionUsageLimit(sessionUsageLimit))
+		d.tableOptions = append(d.tableOptions, tableConfig.WithSessionPoolSessionUsageLimit(limit))
+		d.queryOptions = append(d.queryOptions, queryConfig.WithSessionPoolSessionUsageLimit(limit))
 
 		return nil
 	}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
