### PR TITLE
describe topic partition stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Added `topicoptions.IncludePartitionStats()` for `Topic().Describe()` in order to get partition stats from server
+
 ## v3.106.1
 * Dropped `internal/allocator` package and all usages of it for further switch (test) protobuf opaque API
 

--- a/topic/topicoptions/topicoptions_describe.go
+++ b/topic/topicoptions/topicoptions_describe.go
@@ -2,12 +2,21 @@ package topicoptions
 
 import "github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawtopic"
 
-// DescribeOption type for options of describe method. Not used now.
+// DescribeOption type for options of describe method.
 type DescribeOption func(req *rawtopic.DescribeTopicRequest)
+
+// IncludePartitionStats additionally fetches DescribeTopicResult.PartitionInfo.PartitionSettings from server
+func IncludePartitionStats() DescribeOption {
+	return func(req *rawtopic.DescribeTopicRequest) {
+		req.IncludeStats = true
+	}
+}
 
 // DescribeConsumerOption type for options of describe consumer method.
 type DescribeConsumerOption func(req *rawtopic.DescribeConsumerRequest)
 
+// IncludeConsumerStats additionally fetches
+// DescribeConsumerResult.DescribeConsumerResultPartitionInfo.PartitionConsumerStats from server
 func IncludeConsumerStats() DescribeConsumerOption {
 	return func(req *rawtopic.DescribeConsumerRequest) {
 		req.IncludeStats = true

--- a/topic/topictypes/topictypes.go
+++ b/topic/topictypes/topictypes.go
@@ -169,6 +169,7 @@ type PartitionInfo struct {
 	Active             bool
 	ChildPartitionIDs  []int64
 	ParentPartitionIDs []int64
+	PartitionStats     PartitionStats
 }
 
 // FromRaw convert from internal format to public. Used internally only.
@@ -178,6 +179,7 @@ func (p *PartitionInfo) FromRaw(raw *rawtopic.PartitionInfo) {
 
 	p.ChildPartitionIDs = clone.Int64Slice(raw.ChildPartitionIDs)
 	p.ParentPartitionIDs = clone.Int64Slice(raw.ParentPartitionIDs)
+	p.PartitionStats.FromRaw(&raw.PartitionStats)
 }
 
 type MultipleWindowsStat struct {

--- a/topic/topictypes/topictypes_test.go
+++ b/topic/topictypes/topictypes_test.go
@@ -11,6 +11,11 @@ import (
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawtopic/rawtopiccommon"
 )
 
+var (
+	fourPM = time.Date(2024, 0o1, 0o1, 16, 0, 0, 0, time.UTC)
+	hour   = time.Hour
+)
+
 func TestTopicDescriptionFromRaw(t *testing.T) {
 	testData := []struct {
 		testName            string
@@ -64,6 +69,20 @@ func TestTopicDescriptionFromRaw(t *testing.T) {
 						ParentPartitionIDs: []int64{
 							1, 2, 3,
 						},
+						PartitionStats: PartitionStats{
+							PartitionsOffset: OffsetRange{
+								Start: 10,
+								End:   20,
+							},
+							StoreSizeBytes:  1024,
+							LastWriteTime:   &fourPM,
+							MaxWriteTimeLag: &hour,
+							BytesWritten: MultipleWindowsStat{
+								PerMinute: 1,
+								PerHour:   60,
+								PerDay:    1440,
+							},
+						},
 					},
 					{
 						PartitionID: 43,
@@ -103,6 +122,26 @@ func TestTopicDescriptionFromRaw(t *testing.T) {
 						},
 						ParentPartitionIDs: []int64{
 							1, 2, 3,
+						},
+						PartitionStats: rawtopic.PartitionStats{
+							PartitionsOffset: rawtopiccommon.OffsetRange{
+								Start: 10,
+								End:   20,
+							},
+							StoreSizeBytes: 1024,
+							LastWriteTime: rawoptional.Time{
+								Value:    fourPM,
+								HasValue: true,
+							},
+							MaxWriteTimeLag: rawoptional.Duration{
+								Value:    hour,
+								HasValue: true,
+							},
+							BytesWritten: rawtopic.MultipleWindowsStat{
+								PerMinute: 1,
+								PerHour:   60,
+								PerDay:    1440,
+							},
 						},
 					},
 					{
@@ -165,8 +204,6 @@ func TestTopicDescriptionFromRaw(t *testing.T) {
 }
 
 func TestTopicConsumerDescriptionFromRaw(t *testing.T) {
-	fourPM := time.Date(2024, 0o1, 0o1, 16, 0, 0, 0, time.UTC)
-	hour := time.Hour
 	testData := []struct {
 		testName               string
 		expectedDescription    TopicConsumerDescription


### PR DESCRIPTION
Added an option do describe topic partition stats

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

no possibility to get partition stats for topic
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

Added `topicoptions.IncludePartitionStats()` for `Topic().Describe()` that gets and parses topic partition stats

<!-- Please describe the behavior or changes that are being added by this PR. -->
