### PR TITLE
set session status when `closeOnce()` is called instead of `Close()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Fixed session closing in `ydb.WithExecuteDataQueryOverQueryClient(true)` scenario
 * Added the ability to send BulkRequest exceeding the GrpcMaxMessageSize
 
 ## v3.110.0

--- a/internal/query/session_core.go
+++ b/internal/query/session_core.go
@@ -198,6 +198,7 @@ func (core *sessionCore) attach(ctx context.Context) (finalErr error) {
 	}
 
 	core.closeOnce = sync.OnceFunc(func() {
+		core.SetStatus(StatusClosed)
 		defer close(core.done)
 		defer cancelAttach()
 	})
@@ -273,7 +274,6 @@ func (core *sessionCore) Close(ctx context.Context) (err error) {
 		return nil
 	default:
 		core.SetStatus(StatusClosing)
-		defer core.SetStatus(StatusClosed)
 
 		if err = core.deleteSession(ctx); err != nil {
 			return xerrors.WithStackTrace(err)

--- a/internal/query/session_core_test.go
+++ b/internal/query/session_core_test.go
@@ -1,6 +1,11 @@
 package query
 
 import (
+	"context"
+	"errors"
+	"runtime"
+	"runtime/debug"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -9,6 +14,7 @@ import (
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb"
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Query"
 	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xtest"
 )
@@ -58,5 +64,126 @@ func TestSessionCoreCancelAttachOnDone(t *testing.T) {
 		core.closeOnce()
 		require.GreaterOrEqual(t, recvMsgCounter.Load(), uint32(2))
 		require.LessOrEqual(t, recvMsgCounter.Load(), uint32(3))
+		require.Equal(t, core.Status(), StatusClosed.String())
+	}, xtest.StopAfter(time.Second))
+}
+
+func TestSessionCoreAttachError(t *testing.T) {
+	xtest.TestManyTimes(t, func(t testing.TB) {
+		ctx := xtest.Context(t)
+		ctrl := gomock.NewController(t)
+		client := NewMockQueryServiceClient(ctrl)
+		client.EXPECT().CreateSession(gomock.Any(), gomock.Any()).Return(&Ydb_Query.CreateSessionResponse{
+			Status:    Ydb.StatusIds_SUCCESS,
+			SessionId: "123",
+		}, nil)
+		var sessionDeletes atomic.Int32
+		done := make(chan struct{})
+		sessionDeletes.Store(0)
+		client.EXPECT().DeleteSession(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(
+				context.Context,
+				*Ydb_Query.DeleteSessionRequest,
+				...grpc.CallOption,
+			) (*Ydb_Query.DeleteSessionResponse, error) {
+				sessionDeletes.Add(1)
+
+				return &Ydb_Query.DeleteSessionResponse{}, nil
+			})
+		attachStream := NewMockQueryService_AttachSessionClient(ctrl)
+		attachStream.EXPECT().Recv().DoAndReturn(func() (*Ydb_Query.SessionState, error) {
+			return nil, errSessionClosed
+		}).AnyTimes()
+		client.EXPECT().AttachSession(gomock.Any(), &Ydb_Query.AttachSessionRequest{
+			SessionId: "123",
+		}).Return(attachStream, nil)
+		core, err := Open(ctx, client, func(core *sessionCore) {
+			core.done = done
+		})
+		require.Error(t, err, errSessionClosed)
+		require.Nil(t, core)
+	}, xtest.StopAfter(time.Second))
+}
+
+func TestSessionCoreClose(t *testing.T) {
+	debug.SetTraceback("all")
+	xtest.TestManyTimes(t, func(t testing.TB) {
+		ctx := xtest.Context(t)
+		ctrl := gomock.NewController(t)
+		client := NewMockQueryServiceClient(ctrl)
+		client.EXPECT().CreateSession(gomock.Any(), gomock.Any()).Return(&Ydb_Query.CreateSessionResponse{
+			Status:    Ydb.StatusIds_SUCCESS,
+			SessionId: "123",
+		}, nil)
+		attachStream := NewMockQueryService_AttachSessionClient(ctrl)
+		var (
+			done           chan struct{}
+			startRecv      = make(chan struct{}, 1)
+			stopRecv       = make(chan struct{}, 1)
+			unblock        atomic.Bool
+			sessionDeletes atomic.Uint32
+		)
+		unblock.Store(false)
+		sessionDeletes.Store(0)
+		attachStream.EXPECT().Recv().DoAndReturn(func() (*Ydb_Query.SessionState, error) {
+			startRecv <- struct{}{}
+			select {
+			case <-done:
+				return nil, errSessionClosed
+			case stopRecv <- struct{}{}:
+				return &Ydb_Query.SessionState{
+					Status: Ydb.StatusIds_SUCCESS,
+				}, nil
+			}
+		}).AnyTimes()
+		client.EXPECT().AttachSession(gomock.Any(), &Ydb_Query.AttachSessionRequest{
+			SessionId: "123",
+		}).Return(attachStream, nil)
+		client.EXPECT().DeleteSession(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(
+				context.Context,
+				*Ydb_Query.DeleteSessionRequest,
+				...grpc.CallOption,
+			) (*Ydb_Query.DeleteSessionResponse, error) {
+				if sessionDeletes.CompareAndSwap(0, 1) {
+					return &Ydb_Query.DeleteSessionResponse{
+						Status: Ydb.StatusIds_SUCCESS,
+					}, nil
+				}
+				sessionDeletes.Add(1)
+
+				return nil, errors.New("session not found")
+			}).AnyTimes()
+		core, err := Open(ctx, client, func(core *sessionCore) {
+			done = core.done
+		})
+		require.NoError(t, err)
+		require.NotNil(t, core)
+		<-stopRecv
+
+		var wg sync.WaitGroup
+		parallel := runtime.GOMAXPROCS(0)
+		if parallel > 10 {
+			parallel = 10
+		}
+		for i := 0; i < parallel; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				for {
+					if unblock.Load() {
+						_ = core.Close(ctx)
+
+						break
+					}
+				}
+			}(i)
+		}
+		unblock.Store(true)
+		wg.Wait()
+		_, ok := <-done
+		require.False(t, ok)
+		require.GreaterOrEqual(t, sessionDeletes.Load(), uint32(1))
+		require.LessOrEqual(t, sessionDeletes.Load(), uint32(10))
 	}, xtest.StopAfter(time.Second))
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

session status can be wrong, and users can sometimes experience timout when using `ExecuteDataQueryOverQueryService`
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

fix resolves a concrete example of degradation on https://github.com/yandex/temporal-over-ydb/

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
