### PR TITLE
added json unmarshaler for castTo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Added support for the `json.Unmarshaler` interface in the `CastTo` function for use in scanners, such as the `ScanStruct` method
+
 ## v3.111.3
 * Fixed session closing in `ydb.WithExecuteDataQueryOverQueryClient(true)` scenario
 

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -3,6 +3,7 @@ package value
 import (
 	"database/sql/driver"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"math/big"
 	"reflect"
@@ -1370,6 +1371,16 @@ func (v jsonValue) castTo(dst any) error {
 		*vv = xstring.ToBytes(string(v))
 
 		return nil
+	case json.Unmarshaler:
+		err := vv.UnmarshalJSON(xstring.ToBytes(string(v)))
+		if err != nil {
+			return xerrors.WithStackTrace(fmt.Errorf(
+				"%w '%s(%+v)' to '%T' destination: %w",
+				ErrCannotCast, v.Type().Yql(), v, vv, err,
+			))
+		}
+
+		return nil
 	default:
 		return xerrors.WithStackTrace(fmt.Errorf(
 			"%w '%s(%+v)' to '%T' destination",
@@ -1412,6 +1423,16 @@ func (v jsonDocumentValue) castTo(dst any) error {
 		return nil
 	case *[]byte:
 		*vv = xstring.ToBytes(string(v))
+
+		return nil
+	case json.Unmarshaler:
+		err := vv.UnmarshalJSON(xstring.ToBytes(string(v)))
+		if err != nil {
+			return xerrors.WithStackTrace(fmt.Errorf(
+				"%w '%s(%+v)' to '%T' destination: %w",
+				ErrCannotCast, v.Type().Yql(), v, vv, err,
+			))
+		}
 
 		return nil
 	default:


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

**-**

## What is the new behavior?

query.Row.ScanStruct supports json.Marshaller, but it does not work in the reverse direction (when receiving data from the database), for this purpose I add json.Unmarshaler for convenient work with QueryClient.

## Other information

**-**
