### PR TITLE
fix panic in database/sql traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* fix panic in `database/sql` traces
+
 ## v3.113.0
 * Added experimental `config.WithDisableOptimisticUnban` option to disable fast node unban after pessimization
 * Fixed respect start offset from `topicoptions.WithReaderGetPartitionStartOffset` for commit messages

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,8 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jonboulle/clockwork v0.5.0
 	github.com/ydb-platform/ydb-go-genproto v0.0.0-20241112172322-ea1f63298f77
+	github.com/ydb-platform/ydb-go-sdk-otel v0.10.1
+	go.opentelemetry.io/otel v1.31.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/sync v0.11.0
@@ -24,7 +26,11 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-logr/logr v1.4.2 // indirect
+	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	go.opentelemetry.io/otel/metric v1.31.0 // indirect
+	go.opentelemetry.io/otel/trace v1.31.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/net v0.35.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -21,6 +21,7 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.mod h1:KJwIaB5Mv44NWtYuAOFCVOjcI94vtpEz2JU/D2v6IjE=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
@@ -78,6 +79,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/ydb-platform/ydb-go-genproto v0.0.0-20241112172322-ea1f63298f77 h1:LY6cI8cP4B9rrpTleZk95+08kl2gF4rixG7+V/dwL6Q=
 github.com/ydb-platform/ydb-go-genproto v0.0.0-20241112172322-ea1f63298f77/go.mod h1:Er+FePu1dNUieD+XTMDduGpQuCPssK5Q4BjF+IIXJ3I=
+github.com/ydb-platform/ydb-go-sdk-otel v0.10.1 h1:S01aZMBfG/Th16YWoWQs8mCxMC5ZmV82Upwc9Nn4GU4=
+github.com/ydb-platform/ydb-go-sdk-otel v0.10.1/go.mod h1:E8DxVOlm9ubIbAZ25gZI8s00Q5GnNJwV4XXlu63KPFE=
 go.opentelemetry.io/otel v1.31.0 h1:NsJcKPIW0D0H3NgzPDHmo0WW6SptzPdqg/L1zsIm2hY=
 go.opentelemetry.io/otel v1.31.0/go.mod h1:O0C14Yl9FgkjqcCZAsE053C13OaddMYr/hz6clDkEJE=
 go.opentelemetry.io/otel/metric v1.31.0 h1:FSErL0ATQAmYHUIzSezZibnyVlft1ybhy4ozRPcF2fE=

--- a/internal/xsql/conn.go
+++ b/internal/xsql/conn.go
@@ -60,7 +60,11 @@ func (c *Conn) BeginTx(ctx context.Context, opts driver.TxOptions) (_ driver.Tx,
 		stack.FunctionID("database/sql.(*Conn).BeginTx", stack.Package("database/sql")),
 	)
 	defer func() {
-		onDone(c.currentTx, finalErr)
+		if c.currentTx != nil {
+			onDone(c.currentTx, finalErr)
+		} else {
+			onDone(nil, finalErr)
+		}
 	}()
 
 	if c.currentTx != nil {
@@ -102,7 +106,11 @@ func (c *Conn) Begin() (_ driver.Tx, finalErr error) {
 		stack.FunctionID("database/sql.(*Conn).Begin", stack.Package("database/sql")),
 	)
 	defer func() {
-		onDone(c.currentTx, finalErr)
+		if c.currentTx != nil {
+			onDone(c.currentTx, finalErr)
+		} else {
+			onDone(nil, finalErr)
+		}
 	}()
 
 	if c.currentTx != nil {

--- a/tests/integration/database_sql_trace_test.go
+++ b/tests/integration/database_sql_trace_test.go
@@ -1,0 +1,77 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/ydb-platform/ydb-go-genproto/Ydb_Table_V1"
+	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Table"
+	ydbOtel "github.com/ydb-platform/ydb-go-sdk-otel"
+	"go.opentelemetry.io/otel"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3"
+	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
+)
+
+func TestDatabaseSQLBeginTxTracePanic(t *testing.T) {
+	scope := newScope(t)
+
+	ctx, cancel := context.WithCancel(scope.Ctx)
+	defer cancel()
+
+	tracer := otel.Tracer("noop")
+
+	nativeDriver := scope.Driver(
+		ydb.WithSessionPoolSizeLimit(1),
+		ydbOtel.WithTraces(
+			ydbOtel.WithTracer(tracer),
+			ydbOtel.WithDetails(trace.DetailsAll),
+		),
+	)
+	connector, err := ydb.Connector(nativeDriver)
+	require.NoError(t, err)
+	db := sql.OpenDB(connector)
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+
+	conn, err := grpc.NewClient(scope.Endpoint(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	defer func(conn *grpc.ClientConn) {
+		err := conn.Close()
+		require.NoError(t, err)
+	}(conn)
+	tableClient := Ydb_Table_V1.NewTableServiceClient(conn)
+
+	cc1, err := db.Conn(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, cc1)
+
+	var ccID *string
+
+	err = cc1.Raw(func(driverConn any) error {
+		if ider, has := driverConn.(interface{ ID() string }); has {
+			v := ider.ID()
+			ccID = &v
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+
+	require.NotNil(t, ccID)
+
+	_, err = tableClient.DeleteSession(scope.Ctx, &Ydb_Table.DeleteSessionRequest{SessionId: *ccID})
+	require.NoError(t, err)
+
+	tx1, err := cc1.BeginTx(ctx, nil)
+	require.Nil(t, tx1)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Session not found")
+}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

`database/sql` driver panics, when traces are enabled and internal call to begin a transaction fails.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

no panics