### PR TITLE
Fixed incorrect string conversion of `Uint64Value` values greater than `int64` max value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed incorrect string conversion of `Uint64Value` values greater than `int64` max value
+
 ## v3.113.3
 * Marked as non-retryable operation error `ABORTED` with internal issue `200509` ("Datashard program size limit exceeded")
 

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -2230,11 +2230,11 @@ func (v uint8Value) castTo(dst any) error {
 
 		return nil
 	case *string:
-		*vv = strconv.FormatInt(int64(v), 10)
+		*vv = strconv.FormatUint(uint64(v), 10)
 
 		return nil
 	case *[]byte:
-		*vv = xstring.ToBytes(strconv.FormatInt(int64(v), 10))
+		*vv = xstring.ToBytes(strconv.FormatUint(uint64(v), 10))
 
 		return nil
 	case *uint64:
@@ -2310,11 +2310,11 @@ func (v uint16Value) castTo(dst any) error {
 
 		return nil
 	case *string:
-		*vv = strconv.FormatInt(int64(v), 10)
+		*vv = strconv.FormatUint(uint64(v), 10)
 
 		return nil
 	case *[]byte:
-		*vv = xstring.ToBytes(strconv.FormatInt(int64(v), 10))
+		*vv = xstring.ToBytes(strconv.FormatUint(uint64(v), 10))
 
 		return nil
 	case *uint64:
@@ -2382,11 +2382,11 @@ func (v uint32Value) castTo(dst any) error {
 
 		return nil
 	case *string:
-		*vv = strconv.FormatInt(int64(v), 10)
+		*vv = strconv.FormatUint(uint64(v), 10)
 
 		return nil
 	case *[]byte:
-		*vv = xstring.ToBytes(strconv.FormatInt(int64(v), 10))
+		*vv = xstring.ToBytes(strconv.FormatUint(uint64(v), 10))
 
 		return nil
 	case *uint64:
@@ -2442,11 +2442,11 @@ func (v uint64Value) castTo(dst any) error {
 
 		return nil
 	case *string:
-		*vv = strconv.FormatInt(int64(v), 10)
+		*vv = strconv.FormatUint(uint64(v), 10)
 
 		return nil
 	case *[]byte:
-		*vv = xstring.ToBytes(strconv.FormatInt(int64(v), 10))
+		*vv = xstring.ToBytes(strconv.FormatUint(uint64(v), 10))
 
 		return nil
 

--- a/internal/value/value_test.go
+++ b/internal/value/value_test.go
@@ -1166,6 +1166,147 @@ func TestCastNumbers(t *testing.T) {
 			})
 		}
 	}
+	for _, tt := range []struct {
+		v      Value
+		dst    interface{}
+		result interface{}
+		error  bool
+	}{
+		{
+			v:      Int8Value(-128),
+			dst:    func(v string) *string { return &v }(""),
+			result: func(v string) *string { return &v }("-128"),
+		},
+		{
+			v:      Int8Value(127),
+			dst:    func(v string) *string { return &v }(""),
+			result: func(v string) *string { return &v }("127"),
+		},
+		{
+			v:      Uint8Value(128),
+			dst:    func(v string) *string { return &v }(""),
+			result: func(v string) *string { return &v }("128"),
+		},
+		{
+			v:      Int8Value(-128),
+			dst:    func(v []byte) *[]byte { return &v }([]byte("")),
+			result: func(v []byte) *[]byte { return &v }([]byte("-128")),
+		},
+		{
+			v:      Int8Value(127),
+			dst:    func(v []byte) *[]byte { return &v }([]byte("")),
+			result: func(v []byte) *[]byte { return &v }([]byte("127")),
+		},
+		{
+			v:      Uint8Value(128),
+			dst:    func(v []byte) *[]byte { return &v }([]byte("")),
+			result: func(v []byte) *[]byte { return &v }([]byte("128")),
+		},
+		{
+			v:      Int16Value(-32768),
+			dst:    func(v string) *string { return &v }(""),
+			result: func(v string) *string { return &v }("-32768"),
+		},
+		{
+			v:      Int16Value(32767),
+			dst:    func(v string) *string { return &v }(""),
+			result: func(v string) *string { return &v }("32767"),
+		},
+		{
+			v:      Uint16Value(32768),
+			dst:    func(v string) *string { return &v }(""),
+			result: func(v string) *string { return &v }("32768"),
+		},
+		{
+			v:      Int16Value(-32768),
+			dst:    func(v []byte) *[]byte { return &v }([]byte("")),
+			result: func(v []byte) *[]byte { return &v }([]byte("-32768")),
+		},
+		{
+			v:      Int16Value(32767),
+			dst:    func(v []byte) *[]byte { return &v }([]byte("")),
+			result: func(v []byte) *[]byte { return &v }([]byte("32767")),
+		},
+		{
+			v:      Uint16Value(32768),
+			dst:    func(v []byte) *[]byte { return &v }([]byte("")),
+			result: func(v []byte) *[]byte { return &v }([]byte("32768")),
+		},
+		{
+			v:      Int32Value(-2147483648),
+			dst:    func(v string) *string { return &v }(""),
+			result: func(v string) *string { return &v }("-2147483648"),
+		},
+		{
+			v:      Int32Value(2147483647),
+			dst:    func(v string) *string { return &v }(""),
+			result: func(v string) *string { return &v }("2147483647"),
+		},
+		{
+			v:      Uint32Value(2147483648),
+			dst:    func(v string) *string { return &v }(""),
+			result: func(v string) *string { return &v }("2147483648"),
+		},
+		{
+			v:      Int32Value(-2147483648),
+			dst:    func(v []byte) *[]byte { return &v }([]byte("")),
+			result: func(v []byte) *[]byte { return &v }([]byte("-2147483648")),
+		},
+		{
+			v:      Int32Value(2147483647),
+			dst:    func(v []byte) *[]byte { return &v }([]byte("")),
+			result: func(v []byte) *[]byte { return &v }([]byte("2147483647")),
+		},
+		{
+			v:      Uint32Value(2147483648),
+			dst:    func(v []byte) *[]byte { return &v }([]byte("")),
+			result: func(v []byte) *[]byte { return &v }([]byte("2147483648")),
+		},
+		{
+			v:      Int64Value(-9223372036854775808),
+			dst:    func(v string) *string { return &v }(""),
+			result: func(v string) *string { return &v }("-9223372036854775808"),
+		},
+		{
+			v:      Int64Value(9223372036854775807),
+			dst:    func(v string) *string { return &v }(""),
+			result: func(v string) *string { return &v }("9223372036854775807"),
+		},
+		{
+			v:      Uint64Value(9223372036854775808),
+			dst:    func(v string) *string { return &v }(""),
+			result: func(v string) *string { return &v }("9223372036854775808"),
+		},
+		{
+			v:      Int64Value(-9223372036854775808),
+			dst:    func(v []byte) *[]byte { return &v }([]byte("")),
+			result: func(v []byte) *[]byte { return &v }([]byte("-9223372036854775808")),
+		},
+		{
+			v:      Int64Value(9223372036854775807),
+			dst:    func(v []byte) *[]byte { return &v }([]byte("")),
+			result: func(v []byte) *[]byte { return &v }([]byte("9223372036854775807")),
+		},
+		{
+			v:      Uint64Value(9223372036854775808),
+			dst:    func(v []byte) *[]byte { return &v }([]byte("")),
+			result: func(v []byte) *[]byte { return &v }([]byte("9223372036854775808")),
+		},
+	} {
+		t.Run(fmt.Sprintf("%s(%s)→%s",
+			tt.v.Type().Yql(), tt.v.Yql(), reflect.ValueOf(tt.dst).Type().Elem()),
+			func(t *testing.T) {
+				if err := CastTo(tt.v, tt.dst); (err != nil) != tt.error {
+					t.Errorf("castTo() error = %v, want %v", err, tt.error)
+				} else if !reflect.DeepEqual(tt.dst, tt.result) {
+					t.Errorf("castTo() result = %+v, want %+v",
+						reflect.ValueOf(tt.dst).Elem(),
+						reflect.ValueOf(tt.result).Elem(),
+					)
+				}
+			},
+		)
+	}
 }
 
 func TestCastList(t *testing.T) {


### PR DESCRIPTION
Fixed incorrect string conversion of `Uint64Value` values greater than `int64` max value

<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

Issue Number: #1842

## What is the new behavior?

When cast Uint64Value with val 9223372036854775808 to string, the string value is 9223372036854775808