### PR TITLE
Catch ErrTxDone in DoTxWithResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+* Fixed error catching in DoTxWithResult
+
+## v3.115.2
+* Fixed bug with wrong literal YQL representation for signed integer YDB types
+
+## v3.115.1
+* Added `ydb.Param.Range()` range iterator
+
 ## v3.115.0
 * Added public package `pkg/xtest` with test helpers
 


### PR DESCRIPTION
Fix bug when DoTxWithResult sometimes returns ErrTxDone on context cancellation

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

When context was cancelled before Commit() call in DoTxWithResult, goroutine in database/sql: sql.go:2221 rollbacks the transaction. When SDK code calls Commit after that, it sees that tx was already rollbacked and throws ErrTxDone instead of context error, DoTxWithResult throws this error up. 

Issue Number: N/A

## What is the new behavior?

DoTxWithResults catches ErrTxDone and if context contains error, it throws up context error instead. This behaviour looks correct, because tx created just in this method and couldn't be commited or rolled back in any other way.
