### PR TITLE
fixed topic.UpdateOffsetsInTransaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed an issue where `topic.UpdateOffsetsInTransaction` was executed on a node different from the one where the transaction was running, which could lead to the error "Database coordinators are unavailable"
+
 ## v3.116.0
 * Added experimental support for query results in `Apache Arrow`
 * Fix flaky unit test TestUnboundedChanContextTimeout

--- a/internal/query/transaction.go
+++ b/internal/query/transaction.go
@@ -179,6 +179,10 @@ func (tx *Transaction) SessionID() string {
 	return tx.s.ID()
 }
 
+func (tx *Transaction) NodeID() uint32 {
+	return tx.s.NodeID()
+}
+
 func (tx *Transaction) txControl() *baseTx.Control {
 	if tx.ID() != baseTx.LazyTxID {
 		return baseTx.NewControl(baseTx.WithTxID(tx.ID()))

--- a/internal/topic/topicreaderinternal/stream_reader_impl.go
+++ b/internal/topic/topicreaderinternal/stream_reader_impl.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/credentials"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/background"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/endpoint"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawtopic"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawtopic/rawtopiccommon"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawtopic/rawtopicreader"
@@ -244,6 +245,10 @@ func (r *topicStreamReaderImpl) commitWithTransaction(
 		defer func() {
 			onDone(err)
 		}()
+
+		// UpdateOffsetsInTransaction operation must be executed on the same Node where the transaction was initiated.
+		// Otherwise, errors such as `Database coordinators are unavailable` may occur.
+		ctx = endpoint.WithNodeID(ctx, tx.NodeID())
 
 		err = r.topicClient.UpdateOffsetsInTransaction(ctx, req)
 

--- a/internal/topic/topicreaderinternal/transaction_mock_test.go
+++ b/internal/topic/topicreaderinternal/transaction_mock_test.go
@@ -21,6 +21,7 @@ type mockTransaction struct {
 	materializedID tx.Identifier
 	materialized   bool
 	sessionID      string
+	nodeID         uint32
 	onCompleted    []tx.OnTransactionCompletedFunc
 	RolledBack     bool
 }
@@ -34,6 +35,10 @@ func (m *mockTransaction) UnLazy(_ context.Context) error {
 
 func (m *mockTransaction) SessionID() string {
 	return m.sessionID
+}
+
+func (m *mockTransaction) NodeID() uint32 {
+	return m.nodeID
 }
 
 func (m *mockTransaction) OnBeforeCommit(f tx.OnTransactionBeforeCommit) {

--- a/internal/tx/transaction.go
+++ b/internal/tx/transaction.go
@@ -11,6 +11,7 @@ type Transaction interface {
 	Identifier
 	UnLazy(ctx context.Context) error
 	SessionID() string
+	NodeID() uint32
 
 	// OnBeforeCommit add callback, which will be called before commit transaction
 	// the method will be not call the method if some error happen and transaction will not be committed


### PR DESCRIPTION
Fixed an issue where `topic.UpdateOffsetsInTransaction` was executed on a node different from the one where the transaction was running, which could lead to the error "Database coordinators are unavailable"

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The error "Database coordinators are unavailable" in scenario like:

```golang
driver.Query().DoTx(ctx, func(ctx context.Context, tx query.TransactionActor) error {
		batch, err := reader.PopMessagesBatchTx(ctx, tx)
		...
}
```

because `PopMessagesBatchTx` uses the `UpdateOffsetsInTransaction` method internally, which is sent to the Node where the Reader is, but it should be sent to the Node where the transaction is.

