### PR TITLE
use resolved address instead of address in conn/pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Fixed `conn/pool.Get()` behaviour for YDB databases with public IPs. Bug was introduced in v3.116.2
 * Added helper methods `log.WithFields` and `log.FieldsFromContext` for working with structured logging fields via context.
   These methods allow adding custom fields to the context, which are later extracted by the logger.
 

--- a/internal/conn/pool.go
+++ b/internal/conn/pool.go
@@ -46,8 +46,7 @@ func (p *Pool) Get(endpoint endpoint.Endpoint) Conn {
 		has bool
 	)
 
-	cc, has = p.conns.Get(endpoint.Key())
-	if has && cc.Endpoint().NodeID() == endpoint.NodeID() && cc.Endpoint().OverrideHost() == endpoint.OverrideHost() {
+	if cc, has = p.conns.Get(endpoint.Key()); has {
 		return cc
 	}
 

--- a/internal/endpoint/endpoint.go
+++ b/internal/endpoint/endpoint.go
@@ -57,7 +57,7 @@ type endpoint struct {
 
 func (e *endpoint) Key() Key {
 	return Key{
-		Address:      e.address,
+		Address:      e.Address(),
 		NodeID:       e.id,
 		HostOverride: e.sslNameOverride,
 	}
@@ -87,7 +87,7 @@ func (e *endpoint) String() string {
 
 	return fmt.Sprintf(`{id:%d,address:%q,local:%t,location:%q,loadFactor:%f,lastUpdated:%q}`,
 		e.id,
-		e.address,
+		e.Address(),
 		e.local,
 		e.location,
 		e.loadFactor,


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

If YDB server uses public IP addresses in ListEndpoints response, old IPs are not removed from connection pool (due to `endpoint.Key()` using `e.address` instead of resolved address). And, after a rolling restart of YDB dynnodes, if all of them get new IPs, database becomes unavailable.

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- `conns/pool.Get()` now stores endpoints based on resolved IP, not on address, if that is possible

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
