### PR TITLE
fix fill decimal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+
+Fixed scan a column of type Decimal(22,9) into a struct field of type types.Decimal using ScanStruct.
+
 ## v3.117.0
 * Fixed `conn/pool.Get()` behaviour for YDB databases with public IPs. Bug was introduced in v3.116.2
 * Added helper methods `log.WithFields` and `log.FieldsFromContext` for working with structured logging fields via context.

--- a/internal/query/scanner/struct_test.go
+++ b/internal/query/scanner/struct_test.go
@@ -966,12 +966,7 @@ func TestScannerDecimalNegative(t *testing.T) {
 	var row struct {
 		A ttypes.Decimal
 	}
-	expectedVal := -2005000000
-	expectedBytes := make([]byte, 8)
-	binary.BigEndian.PutUint64(expectedBytes, uint64(expectedVal))
-	var bArr [16]byte
-	copy(bArr[8:], expectedBytes)
-	expected := ttypes.Decimal{Bytes: bArr, Precision: 22, Scale: 9}
+	expected := ttypes.Decimal{Bytes: decimal.BigIntToByte(big.NewInt(-2005000000), 22, 9), Precision: 22, Scale: 9}
 	err := scanner.ScanStruct(&row)
 	require.NoError(t, err)
 	require.Equal(t, expected, row.A)

--- a/internal/query/scanner/struct_test.go
+++ b/internal/query/scanner/struct_test.go
@@ -1002,9 +1002,10 @@ func TestScannerDecimalBigDecimal(t *testing.T) {
 	var row struct {
 		A ttypes.Decimal
 	}
-	expectedVal := decimal.Decimal{Bytes: [16]byte{0, 19, 66, 97, 114, 199, 77, 130, 43, 135, 143, 232, 0, 0, 0, 0}, Precision: 22, Scale: 9}
+	expectedVal := decimal.Decimal{
+		Bytes:     [16]byte{0, 19, 66, 97, 114, 199, 77, 130, 43, 135, 143, 232, 0, 0, 0, 0},
+		Precision: 22, Scale: 9}
 	err := scanner.ScanStruct(&row)
 	require.NoError(t, err)
 	require.Equal(t, expectedVal, row.A)
 }
-

--- a/internal/query/scanner/struct_test.go
+++ b/internal/query/scanner/struct_test.go
@@ -991,7 +991,7 @@ func TestScannerDecimalBigDecimal(t *testing.T) {
 		},
 		[]*Ydb.Value{
 			{
-				//val: 1844674407370955.1615
+				// val: 1844674407370955.1615
 				Value: &Ydb.Value_Low_128{
 					Low_128: 3136633892082024448,
 				},
@@ -1004,7 +1004,8 @@ func TestScannerDecimalBigDecimal(t *testing.T) {
 	}
 	expectedVal := decimal.Decimal{
 		Bytes:     [16]byte{0, 19, 66, 97, 114, 199, 77, 130, 43, 135, 143, 232, 0, 0, 0, 0},
-		Precision: 22, Scale: 9}
+		Precision: 22, Scale: 9,
+	}
 	err := scanner.ScanStruct(&row)
 	require.NoError(t, err)
 	require.Equal(t, expectedVal, row.A)

--- a/internal/query/scanner/struct_test.go
+++ b/internal/query/scanner/struct_test.go
@@ -1,7 +1,6 @@
 package scanner
 
 import (
-	"encoding/binary"
 	"math/big"
 	"reflect"
 	"testing"
@@ -960,6 +959,7 @@ func TestScannerDecimalNegative(t *testing.T) {
 				Value: &Ydb.Value_Low_128{
 					Low_128: 18446744071704551616,
 				},
+				High_128: 0xffffffffffffffff,
 			},
 		},
 	))

--- a/internal/query/scanner/struct_test.go
+++ b/internal/query/scanner/struct_test.go
@@ -1,6 +1,8 @@
 package scanner
 
 import (
+	"encoding/binary"
+	"math/big"
 	"reflect"
 	"testing"
 	"time"
@@ -8,8 +10,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb"
 
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/decimal"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/value"
 	"github.com/ydb-platform/ydb-go-sdk/v3/pkg/xtest"
+	ttypes "github.com/ydb-platform/ydb-go-sdk/v3/table/types"
 )
 
 func TestFieldName(t *testing.T) {
@@ -909,3 +913,98 @@ func TestScannerStructOrdering(t *testing.T) {
 	require.Equal(t, "B", row.B)
 	require.Equal(t, "C", row.C)
 }
+
+func TestScannerDecimal(t *testing.T) {
+	scanner := Struct(NewData(
+		[]*Ydb.Column{
+			{
+				Name: "A",
+				Type: &Ydb.Type{
+					Type: &Ydb.Type_DecimalType{
+						DecimalType: &Ydb.DecimalType{Scale: 9, Precision: 22},
+					},
+				},
+			},
+		},
+		[]*Ydb.Value{
+			{
+				Value: &Ydb.Value_Low_128{
+					Low_128: 10200000000,
+				},
+			},
+		},
+	))
+	var row struct {
+		A ttypes.Decimal
+	}
+	expected := ttypes.Decimal{Bytes: decimal.BigIntToByte(big.NewInt(10200000000), 22, 9), Precision: 22, Scale: 9}
+	err := scanner.ScanStruct(&row)
+	require.NoError(t, err)
+	require.Equal(t, expected, row.A)
+}
+
+func TestScannerDecimalNegative(t *testing.T) {
+	scanner := Struct(NewData(
+		[]*Ydb.Column{
+			{
+				Name: "A",
+				Type: &Ydb.Type{
+					Type: &Ydb.Type_DecimalType{
+						DecimalType: &Ydb.DecimalType{Scale: 9, Precision: 22},
+					},
+				},
+			},
+		},
+		[]*Ydb.Value{
+			{
+				Value: &Ydb.Value_Low_128{
+					Low_128: 18446744071704551616,
+				},
+			},
+		},
+	))
+	var row struct {
+		A ttypes.Decimal
+	}
+	expectedVal := -2005000000
+	expectedBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(expectedBytes, uint64(expectedVal))
+	var bArr [16]byte
+	copy(bArr[8:], expectedBytes)
+	expected := ttypes.Decimal{Bytes: bArr, Precision: 22, Scale: 9}
+	err := scanner.ScanStruct(&row)
+	require.NoError(t, err)
+	require.Equal(t, expected, row.A)
+}
+
+func TestScannerDecimalBigDecimal(t *testing.T) {
+	scanner := Struct(NewData(
+		[]*Ydb.Column{
+			{
+				Name: "A",
+				Type: &Ydb.Type{
+					Type: &Ydb.Type_DecimalType{
+						DecimalType: &Ydb.DecimalType{Scale: 9, Precision: 22},
+					},
+				},
+			},
+		},
+		[]*Ydb.Value{
+			{
+				//val: 1844674407370955.1615
+				Value: &Ydb.Value_Low_128{
+					Low_128: 3136633892082024448,
+				},
+				High_128: 5421010862427522,
+			},
+		},
+	))
+	var row struct {
+		A ttypes.Decimal
+	}
+	expectedVal := decimal.Decimal{Bytes: [16]byte{0, 19, 66, 97, 114, 199, 77, 130, 43, 135, 143, 232, 0, 0, 0, 0}, Precision: 22, Scale: 9}
+	err := scanner.ScanStruct(&row)
+	require.NoError(t, err)
+	require.Equal(t, expectedVal, row.A)
+}
+

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -610,10 +610,12 @@ func (v *decimalValue) castTo(dst any) error {
 	switch dstValue := dst.(type) {
 	case *driver.Value:
 		*dstValue = v
+
 		return nil
 	case *decimal.Decimal:
 		decVal := decimal.Decimal{Bytes: v.value, Precision: v.Precision(), Scale: v.Scale()}
 		*dstValue = decVal
+
 		return nil
 	default:
 		return xerrors.WithStackTrace(fmt.Errorf(

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -610,7 +610,10 @@ func (v *decimalValue) castTo(dst any) error {
 	switch dstValue := dst.(type) {
 	case *driver.Value:
 		*dstValue = v
-
+		return nil
+	case *decimal.Decimal:
+		decVal := decimal.Decimal{Bytes: v.value, Precision: v.Precision(), Scale: v.Scale()}
+		*dstValue = decVal
 		return nil
 	default:
 		return xerrors.WithStackTrace(fmt.Errorf(

--- a/tests/integration/query_execute_test.go
+++ b/tests/integration/query_execute_test.go
@@ -763,7 +763,6 @@ func TestIssue1785FillDecimalFields(t *testing.T) {
 		err = row.ScanStruct(&rd)
 		require.NoError(t, err)
 		require.EqualValues(t, uint64(2), rd.Id)
-		require.NoError(t, err)
 		require.EqualValues(t, types.Decimal{Bytes: decimal.BigIntToByte(big.NewInt(-5330000000), 22, 9), Precision: 22, Scale: 9}, rd.DecimalVal)
 		row, err = resultSet.NextRow(ctx)
 		require.NoError(t, err)

--- a/tests/integration/query_execute_test.go
+++ b/tests/integration/query_execute_test.go
@@ -756,7 +756,6 @@ func TestIssue1785FillDecimalFields(t *testing.T) {
 		err = row.ScanStruct(&rd)
 		require.NoError(t, err)
 		require.EqualValues(t, uint64(1), rd.Id)
-		require.NoError(t, err)
 		require.EqualValues(t, types.Decimal{Bytes: decimal.BigIntToByte(big.NewInt(10010000000), 22, 9), Precision: 22, Scale: 9}, rd.DecimalVal)
 		row, err = resultSet.NextRow(ctx)
 		require.NoError(t, err)

--- a/tests/integration/query_execute_test.go
+++ b/tests/integration/query_execute_test.go
@@ -712,7 +712,6 @@ func TestQueryWideIntervalTypes(t *testing.T) {
 
 // https://github.com/ydb-platform/ydb-go-sdk/issues/1785
 func TestIssue1785FillDecimalFields(t *testing.T) {
-
 	ctx, cancel := context.WithCancel(xtest.Context(t))
 	defer cancel()
 	db, err := ydb.Open(ctx,

--- a/tests/integration/query_execute_test.go
+++ b/tests/integration/query_execute_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/big"
 	"math/rand"
 	"os"
 	"path"
@@ -20,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/decimal"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/value"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/version"
 	"github.com/ydb-platform/ydb-go-sdk/v3/log"
@@ -706,4 +708,69 @@ func TestQueryWideIntervalTypes(t *testing.T) {
 			require.Equal(t, tt.expGoValue, actInterval)
 		})
 	}
+}
+
+// https://github.com/ydb-platform/ydb-go-sdk/issues/1785
+func TestIssue1785FillDecimalFields(t *testing.T) {
+
+	ctx, cancel := context.WithCancel(xtest.Context(t))
+	defer cancel()
+	db, err := ydb.Open(ctx,
+		os.Getenv("YDB_CONNECTION_STRING"),
+		ydb.WithAccessTokenCredentials(os.Getenv("YDB_ACCESS_TOKEN_CREDENTIALS")),
+		ydb.WithTraceQuery(
+			log.Query(
+				log.Default(os.Stdout,
+					log.WithLogQuery(),
+					log.WithColoring(),
+					log.WithMinLevel(log.INFO),
+				),
+				trace.QueryEvents,
+			),
+		),
+	)
+	require.NoError(t, err)
+	t.Run("Query", func(t *testing.T) {
+		type RowData struct {
+			Id         uint64        `sql:"id"`
+			DecimalVal types.Decimal `sql:"dc"`
+		}
+		result, err := db.Query().Query(ctx, `
+        SELECT id, dc
+        FROM AS_TABLE(
+          AsList(
+            AsStruct(1u AS id, decimal("10.01",22,9) AS dc),
+            AsStruct(2u AS id, decimal("-5.33",22,9) AS dc),
+			AsStruct(3u AS id, decimal("1844674407370955.1615",22,9) AS dc)
+            )
+          );
+        `,
+			query.WithSyntax(query.SyntaxYQL),
+			query.WithIdempotent(),
+		)
+		require.NoError(t, err)
+		resultSet, err := result.NextResultSet(ctx)
+		require.NoError(t, err)
+		row, err := resultSet.NextRow(ctx)
+		require.NoError(t, err)
+		var rd RowData
+		err = row.ScanStruct(&rd)
+		require.NoError(t, err)
+		require.EqualValues(t, uint64(1), rd.Id)
+		require.NoError(t, err)
+		require.EqualValues(t, types.Decimal{Bytes: decimal.BigIntToByte(big.NewInt(10010000000), 22, 9), Precision: 22, Scale: 9}, rd.DecimalVal)
+		row, err = resultSet.NextRow(ctx)
+		require.NoError(t, err)
+		err = row.ScanStruct(&rd)
+		require.NoError(t, err)
+		require.EqualValues(t, uint64(2), rd.Id)
+		require.NoError(t, err)
+		require.EqualValues(t, types.Decimal{Bytes: decimal.BigIntToByte(big.NewInt(-5330000000), 22, 9), Precision: 22, Scale: 9}, rd.DecimalVal)
+		row, err = resultSet.NextRow(ctx)
+		require.NoError(t, err)
+		err = row.ScanStruct(&rd)
+		require.NoError(t, err)
+		expectedVal := types.Decimal{Bytes: [16]byte{0, 19, 66, 97, 114, 199, 77, 130, 43, 135, 143, 232, 0, 0, 0, 0}, Precision: 22, Scale: 9}
+		require.EqualValues(t, expectedVal, rd.DecimalVal)
+	})
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 1785

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

fix scan a YDB column of type Decimal(22,9) into a struct field of type types.Decimal using ScanStruct. example in query_execute_test.go (TestIssue1785FillDecimalFields)
