### PR TITLE
fix integration test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+Fixed race in integration test `TestTopicWriterLogMessagesWithoutData` 
+
 ## v3.117.0
 * Fixed `conn/pool.Get()` behaviour for YDB databases with public IPs. Bug was introduced in v3.116.2
 * Added helper methods `log.WithFields` and `log.FieldsFromContext` for working with structured logging fields via context.

--- a/tests/integration/topic_read_writer_test.go
+++ b/tests/integration/topic_read_writer_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/version"
 	"github.com/ydb-platform/ydb-go-sdk/v3/log"
 	xtest "github.com/ydb-platform/ydb-go-sdk/v3/pkg/xtest"
+	tu "github.com/ydb-platform/ydb-go-sdk/v3/testutil"
 	"github.com/ydb-platform/ydb-go-sdk/v3/topic/topicoptions"
 	"github.com/ydb-platform/ydb-go-sdk/v3/topic/topicsugar"
 	"github.com/ydb-platform/ydb-go-sdk/v3/topic/topictypes"
@@ -44,7 +45,7 @@ func TestTopicWriterLogMessagesWithoutData(t *testing.T) {
 	metaKey := "gyoeexiufo"
 	metaValue := "fjedeikeosbv"
 
-	logs := &strings.Builder{}
+	logs := &tu.ThreadSafeBuilder{}
 	writer, err := scope.Driver().Topic().StartWriter(
 		scope.TopicPath(),
 		topicoptions.WithWriterProducerID(producerID),

--- a/testutil/thread_safe_builder.go
+++ b/testutil/thread_safe_builder.go
@@ -1,0 +1,35 @@
+package testutil
+
+import (
+	"strings"
+	"sync"
+)
+
+type ThreadSafeBuilder struct {
+	mu sync.Mutex
+	b  strings.Builder
+}
+
+func (tsb *ThreadSafeBuilder) WriteString(s string) (int, error) {
+	tsb.mu.Lock()
+	defer tsb.mu.Unlock()
+	return tsb.b.WriteString(s)
+}
+
+func (tsb *ThreadSafeBuilder) Write(p []byte) (int, error) {
+	tsb.mu.Lock()
+	defer tsb.mu.Unlock()
+	return tsb.b.Write(p)
+}
+
+func (tsb *ThreadSafeBuilder) String() string {
+	tsb.mu.Lock()
+	defer tsb.mu.Unlock()
+	return tsb.b.String()
+}
+
+func (tsb *ThreadSafeBuilder) Reset() {
+	tsb.mu.Lock()
+	defer tsb.mu.Unlock()
+	tsb.b.Reset()
+}


### PR DESCRIPTION
fix race in TestTopicWriterLogMessagesWithoutData test

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information
test race info

WARNING: DATA RACE
Write at 0x00c00337f3e8 by goroutine 68657:
  strings.(*Builder).WriteString()
      /home/aklepov/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/strings/builder.go:116 +0x14e
  io.WriteString()
      /home/aklepov/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/io/io.go:316 +0x6c
  github.com/ydb-platform/ydb-go-sdk/v3/log.(*defaultLogger).Log()
      /home/aklepov/repoPublic/go/ydb-go-sdk-klepov/log/logger.go:93 +0x264
  github.com/ydb-platform/ydb-go-sdk/v3/log.(*wrapper).Log()
      /home/aklepov/repoPublic/go/ydb-go-sdk-klepov/log/logger.go:138 +0x9b
  github.com/ydb-platform/ydb-go-sdk/v3/log.internalTopic.func30()
      /home/aklepov/repoPublic/go/ydb-go-sdk-klepov/log/topic.go:914 +0x861
  github.com/ydb-platform/ydb-go-sdk/v3/trace.(*Topic).Compose.func34()
      /home/aklepov/repoPublic/go/ydb-go-sdk-klepov/trace/topic_gtrace.go:1067 +0x272
  github.com/ydb-platform/ydb-go-sdk/v3/trace.(*Topic).onWriterReceiveGRPCMessage()
      /home/aklepov/repoPublic/go/ydb-go-sdk-klepov/trace/topic_gtrace.go:1855 +0x22e
  github.com/ydb-platform/ydb-go-sdk/v3/trace.TopicOnWriterReceiveGRPCMessage()
      /home/aklepov/repoPublic/go/ydb-go-sdk-klepov/trace/topic_gtrace.go:2452 +0x127
  github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawtopic/rawtopicwriter.(*StreamWriter).Recv.func1()
      /home/aklepov/repoPublic/go/ydb-go-sdk-klepov/internal/grpcwrapper/rawtopic/rawtopicwriter/streamwriter.go:54 +0x144
  runtime.deferreturn()
      /home/aklepov/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/runtime/panic.go:602 +0x5d
  github.com/ydb-platform/ydb-go-sdk/v3/internal/topic/topicwriterinternal.(*SingleStreamWriter).receiveMessagesLoop()
      /home/aklepov/repoPublic/go/ydb-go-sdk-klepov/internal/topic/topicwriterinternal/writer_single_stream.go:195 +0xa1
  github.com/ydb-platform/ydb-go-sdk/v3/internal/topic/topicwriterinternal.(*SingleStreamWriter).receiveMessagesLoop-fm()
      <autogenerated>:1 +0x47
  runtime/pprof.Do()
      /home/aklepov/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/runtime/pprof/runtime.go:51 +0x117
  github.com/ydb-platform/ydb-go-sdk/v3/internal/background.(*Worker).starterLoop.func1()
      /home/aklepov/repoPublic/go/ydb-go-sdk-klepov/internal/background/worker.go:154 +0x394
  github.com/ydb-platform/ydb-go-sdk/v3/internal/background.(*Worker).starterLoop.gowrap2()
      /home/aklepov/repoPublic/go/ydb-go-sdk-klepov/internal/background/worker.go:155 +0x61

Previous read at 0x00c00337f3e8 by goroutine 68627:
  strings.(*Builder).String()
      /home/aklepov/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/strings/builder.go:49 +0x889
  github.com/ydb-platform/ydb-go-sdk/v3/tests/integration.TestTopicWriterLogMessagesWithoutData()
      /home/aklepov/repoPublic/go/ydb-go-sdk-klepov/tests/integration/topic_read_writer_test.go:73 +0x87c
  testing.tRunner()
      /home/aklepov/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /home/aklepov/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/testing/testing.go:1742 +0x44

Goroutine 68657 (running) created at:
  github.com/ydb-platform/ydb-go-sdk/v3/internal/background.(*Worker).starterLoop()
      /home/aklepov/repoPublic/go/ydb-go-sdk-klepov/internal/background/worker.go:149 +0x10d
  github.com/ydb-platform/ydb-go-sdk/v3/internal/background.(*Worker).Start.(*Worker).init.func2.1.gowrap1()
      /home/aklepov/repoPublic/go/ydb-go-sdk-klepov/internal/background/worker.go:138 +0x4f

Goroutine 68627 (running) created at:
  testing.(*T).Run()
      /home/aklepov/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/testing/testing.go:1742 +0x825
  testing.runTests.func1()
      /home/aklepov/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/testing/testing.go:2161 +0x85
  testing.tRunner()
      /home/aklepov/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/testing/testing.go:1689 +0x21e
  testing.runTests()
      /home/aklepov/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/testing/testing.go:2159 +0x8be
  testing.(*M).Run()
      /home/aklepov/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/testing/testing.go:2027 +0xf17
  main.main()
      _testmain.go:335 +0x2bd
==================
--- FAIL: TestTopicWriterLogMessagesWithoutData (0.05s)
    helpers_test.go:128: Connect with connection string, driver name "default": grpc://ydb:12136/local
    helpers_test.go:146: Connect with connection string: grpc://ydb:12136/local
    helpers_test.go:150: With empty auth token
    helpers_test.go:158: Without tls
    helpers_test.go:204: Creating folder: /local/TestTopicWriterLogMessagesWithoutData
    helpers_test.go:211: Creating folder done: /local/TestTopicWriterLogMessagesWithoutData
    helpers_test.go:246: Drop topic if exists: "/local/TestTopicWriterLogMessagesWithoutData/TestTopicWriterLogMessagesWithoutData"
    helpers_test.go:251: Creating topic "/local/TestTopicWriterLogMessagesWithoutData/TestTopicWriterLogMessagesWithoutData"
    helpers_test.go:258: Topic created: "/local/TestTopicWriterLogMessagesWithoutData/TestTopicWriterLogMessagesWithoutData"
    testing.go:1398: race detected during execution of test

