### PR TITLE
Remove $ sign from parameter when suing database/sql package

### DIFF
--- a/SQL.md
+++ b/SQL.md
@@ -314,7 +314,7 @@ err := retry.DoTx(context.TODO(), db, func(ctx context.Context, tx *sql.Tx) erro
         DECLARE $ts AS Datetime;
         SELECT season_id FROM seasons WHERE title LIKE $title AND views > $views AND first_aired > $ts;
       `,
-      sql.Named("title", "%Season 1%"), // argument name with witout prefix `$` 
+      sql.Named("title", "%Season 1%"), // argument name with without prefix `$` 
       sql.Named("views", uint64(1000)),  // argument name without prefix `$` (driver will prepend `$` if necessary)
       sql.Named("ts", types.DatetimeValueFromTime( // native ydb type
         time.Now().Add(-time.Hour*24*365), 
@@ -329,8 +329,8 @@ err := retry.DoTx(context.TODO(), db, func(ctx context.Context, tx *sql.Tx) erro
         DECLARE $views AS Uint64;
         SELECT season_id FROM seasons WHERE title LIKE $title AND views > $views;
       `,
-      table.ValueParam("seasonTitle", types.TextValue("%Season 1%")),
-      table.ValueParam("views", types.Uint64Value((1000)),
+      table.ValueParam("$seasonTitle", types.TextValue("%Season 1%")),
+      table.ValueParam("$views", types.Uint64Value((1000)),
    )
    ```
 * single `*table.QueryParameters` argument:
@@ -342,8 +342,8 @@ err := retry.DoTx(context.TODO(), db, func(ctx context.Context, tx *sql.Tx) erro
         SELECT season_id FROM seasons WHERE title LIKE $title AND views > $views;
       `,
       table.NewQueryParameters(
-          table.ValueParam("seasonTitle", types.TextValue("%Season 1%")),
-          table.ValueParam("views", types.Uint64Value((1000)),
+          table.ValueParam("$seasonTitle", types.TextValue("%Season 1%")),
+          table.ValueParam("$views", types.Uint64Value((1000)),
       ),
    )
    ```
@@ -402,7 +402,7 @@ func main() {
     DECLARE $p1 AS Utf8;
     SELECT $p0, $p1`, 
     sql.Named("p0", 42), 
-    table.ValueParam("p1", types.TextValue("my string")),
+    table.ValueParam("$p1", types.TextValue("my string")),
   )
   // process row ...
 }
@@ -519,9 +519,9 @@ DECLARE $p2 AS Utf8;
 -- origin query with positional args replacement
 SELECT $p0, $p1, $p2`, query)
   require.Equal(t, table.NewQueryParameters(
-    table.ValueParam("p0", types.Int32Value(1)),
-    table.ValueParam("p1", types.Uint64Value(2)),
-    table.ValueParam("p2", types.TextValue("3")),
+    table.ValueParam("$p0", types.Int32Value(1)),
+    table.ValueParam("$p1", types.Uint64Value(2)),
+    table.ValueParam("$p2", types.TextValue("3")),
   ), params)
 }
 ```


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Issing $ sign with parameters is not necessary when database/sql package is used

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Remove  $ sign from parameters 


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
