### PR TITLE
Fixed nil lastErr "%!w()"

### DIFF
--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -2,6 +2,7 @@ package pool
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

> pool.With failed with 1 attempts: non-retryable error occurred on attempt No.1 (idempotent=false): failed to get item from pool after 100 attempts and 50.070609184s, pool has 50 items (50 busy, 0 idle, 0 create_in_progress): %!w(<nil>) at github.com/ydb-platform/ydb-go-sdk/v3/internal/pool.(*Pool).getItem(pool.go:698) at github.com/ydb-platform/ydb-go-sdk/v3/internal/pool.(*Pool).try(pool.go:345) at github.com/ydb-platform/ydb-go-sdk/v3/internal/pool.(*Pool).With.func2(pool.go:382) at github.com/ydb-platform/ydb-go-sdk/v3/retry.Retry.func1(retry.go:264) at github.com/ydb-platform/ydb-go-sdk/v3/retry.opWithRecover(retry.go:418) at github.com/ydb-platform/ydb-go-sdk/v3/retry.RetryWithResult(retry.go:358) at github.com/ydb-platform/ydb-go-sdk/v3/retry.Retry(retry.go:270) at github.com/ydb-platform/ydb-go-sdk/v3/internal/pool.(*Pool).With(pool.go:388) at github.com/ydb-platform/ydb-go-sdk/v3/internal/query.do(client.go:218) at github.com/ydb-platform/ydb-go-sdk/v3/internal/query.clientQuery(client.go:405) at `[github.com/ydb-platform/ydb-go-sdk/v3/internal/query.(*Client).Query(client.go:425)](http://github.com/ydb-platform/ydb-go-sdk/v3/internal/query.(*Client).Query(client.go:425))

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
