### PR TITLE
Node hint traces for session pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* Added `trace.NodeHintInfo` field for OnPoolGet trace callback which stores info for node hint misses
+* Added `ydb_go_sdk_ydb_table_pool_node_hint_miss` and `ydb_go_sdk_ydb_query_pool_node_hint_miss` metrics for node hint misses
+
 ## v3.121.1
 * Added support for `Timestamp64` type in `value.Any` converter
 * Masked the sensitive credential data in the connection string (DSN, data source name) from error messages for security reasons

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -27,6 +27,7 @@ import (
 	xtest "github.com/ydb-platform/ydb-go-sdk/v3/pkg/xtest"
 	"github.com/ydb-platform/ydb-go-sdk/v3/retry"
 	"github.com/ydb-platform/ydb-go-sdk/v3/testutil"
+	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
 )
 
 type (
@@ -67,8 +68,13 @@ var defaultTrace = &Trace{
 		return func(err error) {
 		}
 	},
-	OnGet: func(ctx *context.Context, call stack.Caller) func(item any, attempts int, err error) {
-		return func(item any, attempts int, err error) {
+	OnGet: func(ctx *context.Context, call stack.Caller) func(
+		item any,
+		attempts int,
+		nodeHintInfo *trace.NodeHintInfo,
+		err error,
+	) {
+		return func(item any, attempts int, nodeHintInfo *trace.NodeHintInfo, err error) {
 		}
 	},
 	onWait: func() func(item any, err error) {
@@ -183,6 +189,22 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 			require.NoError(t, err)
 		})
 		t.Run("RequireNodeIdFromPool", func(t *testing.T) {
+			hintTrace := defaultTrace
+			var preferredID uint32
+			var sessionID uint32
+			hintTrace.OnGet = func(ctx *context.Context, call stack.Caller) func(
+				item any,
+				attempts int,
+				nodeHintInfo *trace.NodeHintInfo,
+				err error,
+			) {
+				return func(item any, attempts int, nodeHintInfo *trace.NodeHintInfo, err error) {
+					if nodeHintInfo != nil {
+						preferredID = nodeHintInfo.PreferredNodeID
+						sessionID = nodeHintInfo.SessionNodeID
+					}
+				}
+			}
 			nextNodeID := uint32(0)
 			var newItemCalled uint32
 			p := New[*testItem, testItem](rootCtx,
@@ -201,6 +223,7 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 
 					return &v, nil
 				}),
+				WithLimit[*testItem, testItem](3),
 			)
 
 			item := mustGetItem(t, p)
@@ -262,7 +285,10 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 			mustPutItem(t, p, item)
 			mustPutItem(t, p, item2)
 			mustPutItem(t, p, item3)
-
+			item, err = p.getItem(endpoint.WithNodeID(context.Background(), 100))
+			require.NoError(t, err)
+			require.EqualValues(t, 100, preferredID)
+			require.EqualValues(t, item.NodeID(), sessionID)
 			require.EqualValues(t, 3, newItemCalled)
 		})
 		t.Run("CreateItemOnGivenNode", func(t *testing.T) {
@@ -471,7 +497,12 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 					mustGetItem(t, p)
 
 					go func() {
-						p.config.trace.OnGet = func(ctx *context.Context, call stack.Caller) func(item any, attempts int, err error) {
+						p.config.trace.OnGet = func(ctx *context.Context, call stack.Caller) func(
+							item any,
+							attempts int,
+							_ *trace.NodeHintInfo,
+							err error,
+						) {
 							get <- struct{}{}
 
 							return nil

--- a/internal/pool/trace.go
+++ b/internal/pool/trace.go
@@ -4,16 +4,22 @@ import (
 	"context"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/stack"
+	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
 )
 
 type (
 	Trace struct {
-		OnNew    func(ctx *context.Context, call stack.Caller) func(limit int)
-		OnClose  func(ctx *context.Context, call stack.Caller) func(err error)
-		OnTry    func(ctx *context.Context, call stack.Caller) func(err error)
-		OnWith   func(ctx *context.Context, call stack.Caller) func(attempts int, err error)
-		OnPut    func(ctx *context.Context, call stack.Caller, item any) func(err error)
-		OnGet    func(ctx *context.Context, call stack.Caller) func(item any, attempts int, err error)
+		OnNew   func(ctx *context.Context, call stack.Caller) func(limit int)
+		OnClose func(ctx *context.Context, call stack.Caller) func(err error)
+		OnTry   func(ctx *context.Context, call stack.Caller) func(err error)
+		OnWith  func(ctx *context.Context, call stack.Caller) func(attempts int, err error)
+		OnPut   func(ctx *context.Context, call stack.Caller, item any) func(err error)
+		OnGet   func(ctx *context.Context, call stack.Caller) func(
+			item any,
+			attempts int,
+			nodeHintInfo *trace.NodeHintInfo,
+			err error,
+		)
 		onWait   func() func(item any, err error)
 		OnChange func(Stats)
 	}

--- a/internal/query/client.go
+++ b/internal/query/client.go
@@ -685,11 +685,16 @@ func poolTrace(t *trace.Query) *pool.Trace {
 				onDone(err)
 			}
 		},
-		OnGet: func(ctx *context.Context, call stack.Caller) func(item any, attempts int, err error) {
+		OnGet: func(ctx *context.Context, call stack.Caller) func(
+			item any,
+			attempts int,
+			hint *trace.NodeHintInfo,
+			err error,
+		) {
 			onDone := trace.QueryOnPoolGet(t, ctx, call)
 
-			return func(item any, attempts int, err error) {
-				onDone(item.(*Session), attempts, err) //nolint:forcetypeassert
+			return func(item any, attempts int, hint *trace.NodeHintInfo, err error) {
+				onDone(item.(*Session), attempts, hint, err) //nolint:forcetypeassert
 			}
 		},
 		OnChange: func(stats pool.Stats) {

--- a/internal/table/client.go
+++ b/internal/table/client.go
@@ -78,11 +78,16 @@ func New(ctx context.Context, cc grpc.ClientConnInterface, config *config.Config
 						onDone(err)
 					}
 				},
-				OnGet: func(ctx *context.Context, call stack.Caller) func(item any, attempts int, err error) {
+				OnGet: func(ctx *context.Context, call stack.Caller) func(
+					item any,
+					attempts int,
+					hintInfo *trace.NodeHintInfo,
+					err error,
+				) {
 					onDone := trace.TableOnPoolGet(config.Trace(), ctx, call)
 
-					return func(item any, attempts int, err error) {
-						onDone(item.(*Session), attempts, err) //nolint:forcetypeassert
+					return func(item any, attempts int, hintInfo *trace.NodeHintInfo, err error) {
+						onDone(item.(*Session), attempts, hintInfo, err) //nolint:forcetypeassert
 					}
 				},
 				OnWith: func(ctx *context.Context, call stack.Caller) func(attempts int, err error) {

--- a/trace/node_hint_info.go
+++ b/trace/node_hint_info.go
@@ -1,0 +1,6 @@
+package trace
+
+type NodeHintInfo struct {
+	PreferredNodeID uint32
+	SessionNodeID   uint32
+}

--- a/trace/query.go
+++ b/trace/query.go
@@ -591,9 +591,10 @@ type (
 	}
 	// Internals: https://github.com/ydb-platform/ydb-go-sdk/blob/master/VERSIONING.md#internals
 	QueryPoolGetDoneInfo struct {
-		Session  sessionInfo
-		Attempts int
-		Error    error
+		Session      sessionInfo
+		Attempts     int
+		NodeHintInfo *NodeHintInfo
+		Error        error
 	}
 	// Internals: https://github.com/ydb-platform/ydb-go-sdk/blob/master/VERSIONING.md#internals
 	QueryPoolChange struct {

--- a/trace/query_gtrace.go
+++ b/trace/query_gtrace.go
@@ -1752,15 +1752,16 @@ func QueryOnPoolPut(t *Query, c *context.Context, call call, session sessionInfo
 	}
 }
 // Internals: https://github.com/ydb-platform/ydb-go-sdk/blob/master/VERSIONING.md#internals
-func QueryOnPoolGet(t *Query, c *context.Context, call call) func(session sessionInfo, attempts int, _ error) {
+func QueryOnPoolGet(t *Query, c *context.Context, call call) func(session sessionInfo, attempts int, _ *NodeHintInfo, _ error) {
 	var p QueryPoolGetStartInfo
 	p.Context = c
 	p.Call = call
 	res := t.onPoolGet(p)
-	return func(session sessionInfo, attempts int, e error) {
+	return func(session sessionInfo, attempts int, n *NodeHintInfo, e error) {
 		var p QueryPoolGetDoneInfo
 		p.Session = session
 		p.Attempts = attempts
+		p.NodeHintInfo = n
 		p.Error = e
 		res(p)
 	}

--- a/trace/table.go
+++ b/trace/table.go
@@ -394,9 +394,10 @@ type (
 	}
 	// Internals: https://github.com/ydb-platform/ydb-go-sdk/blob/master/VERSIONING.md#internals
 	TablePoolGetDoneInfo struct {
-		Session  sessionInfo
-		Attempts int
-		Error    error
+		Session      sessionInfo
+		Attempts     int
+		NodeHintInfo *NodeHintInfo
+		Error        error
 	}
 	// Deprecated
 	// Will be removed after March 2025.

--- a/trace/table_gtrace.go
+++ b/trace/table_gtrace.go
@@ -1619,15 +1619,16 @@ func TableOnPoolPut(t *Table, c *context.Context, call call, session sessionInfo
 	}
 }
 // Internals: https://github.com/ydb-platform/ydb-go-sdk/blob/master/VERSIONING.md#internals
-func TableOnPoolGet(t *Table, c *context.Context, call call) func(session sessionInfo, attempts int, _ error) {
+func TableOnPoolGet(t *Table, c *context.Context, call call) func(session sessionInfo, attempts int, _ *NodeHintInfo, _ error) {
 	var p TablePoolGetStartInfo
 	p.Context = c
 	p.Call = call
 	res := t.onPoolGet(p)
-	return func(session sessionInfo, attempts int, e error) {
+	return func(session sessionInfo, attempts int, n *NodeHintInfo, e error) {
 		var p TablePoolGetDoneInfo
 		p.Session = session
 		p.Attempts = attempts
+		p.NodeHintInfo = n
 		p.Error = e
 		res(p)
 	}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

no metrics and/or traces for node hints behaviour

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- added node_hints info to `OnPoolGet` trace callback which gets filled on node hint miss
- added `ydb_go_sdk_ydb_table_pool_node_hint_miss` and `ydb_go_sdk_ydb_query_pool_node_hint_miss` metrics for node hint misses
```
# HELP ydb_go_sdk_ydb_table_pool_node_hint_miss 
# TYPE ydb_go_sdk_ydb_table_pool_node_hint_miss counter
ydb_go_sdk_ydb_table_pool_node_hint_miss{preferred_node_id="50010",session_node_id="50042"} 12
```