### PR TITLE
fix nil pointer dereference for node hint info when getItem fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed `pool.getItem()` panics, if unable to give session for preferred node ID
+
 ## v3.123.0
 * Moved `internal/decimal` package to `pkg/decimal` for public usage
 

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -290,6 +290,12 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 			require.EqualValues(t, 100, preferredID)
 			require.EqualValues(t, item.NodeID(), sessionID)
 			require.EqualValues(t, 3, newItemCalled)
+			_, _ = p.getItem(endpoint.WithNodeID(context.Background(), 32))
+			_, _ = p.getItem(endpoint.WithNodeID(context.Background(), 32))
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			// should not panic
+			_, _ = p.getItem(endpoint.WithNodeID(ctx, 32))
 		})
 		t.Run("CreateItemOnGivenNode", func(t *testing.T) {
 			var newItemCalled uint32


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

getItem panics when not able to get idle session by NodeID



## What is the new behavior?
fixed

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
