### PR TITLE
made WithDoRetryOptions and WithDoTxRetryOptions undeprecated

### DIFF
--- a/retry/sql.go
+++ b/retry/sql.go
@@ -35,9 +35,6 @@ func (retryOptions doRetryOptionsOption) ApplyDoOption(opts *doOptions) {
 }
 
 // WithDoRetryOptions specified retry options
-// Deprecated: use explicit options instead.
-// Will be removed after Oct 2024.
-// Read about versioning policy: https://github.com/ydb-platform/ydb-go-sdk/blob/master/VERSIONING.md#deprecated
 func WithDoRetryOptions(opts ...Option) doRetryOptionsOption {
 	return opts
 }
@@ -135,9 +132,6 @@ func (doTxRetryOptions doTxRetryOptionsOption) ApplyDoTxOption(o *doTxOptions) {
 }
 
 // WithDoTxRetryOptions specified retry options
-// Deprecated: use explicit options instead.
-// Will be removed after Oct 2024.
-// Read about versioning policy: https://github.com/ydb-platform/ydb-go-sdk/blob/master/VERSIONING.md#deprecated
 func WithDoTxRetryOptions(opts ...Option) doTxRetryOptionsOption {
 	return opts
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

I'm currently working on adding support for YDB to `ent` ORM. It relies heavily on using `database/sql` driver. Because of that, I needed to add manual retries to query implementations. But I also needed to somehow pass retry options from user code to these retries.

The only way to do it now is to use `WithDoRetryOptions` and `WithDoTxRetryOptions` because `doOption` and `doTxOption` interfaces are not exported. Therefore, I'm making `WithDoRetryOptions` and `WithDoTxRetryOptions` not deprecated because there is a use case for them

## What is the new behavior?

`WithDoRetryOptions` and `WithDoTxRetryOptions` are not deprecated now

