### PR TITLE
feat: Added ydb.WithCommitTxContext for committing database/sql transactions with query execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Added `ydb.WithCommitTxContext(ctx)` to request commit along with query execution in database/sql transactions
+
 ## v3.126.4
 * Fixed a bug where the `internal/value.Any()` method was prematurely converting `*decimalValue` to `decimal.Decimal`, preventing users from implementing custom scanners that need to work with the underlying YDB value type.
 

--- a/internal/tx/context.go
+++ b/internal/tx/context.go
@@ -8,6 +8,7 @@ type (
 	ctxTxControlKey     struct{}
 	ctxTxControlHookKey struct{}
 	ctxLazyTxKey        struct{}
+	ctxCommitTxKey      struct{}
 
 	txControlHook func(txControl *Control)
 )
@@ -43,4 +44,14 @@ func LazyTxFromContext(ctx context.Context, defaultValue bool) bool {
 	}
 
 	return defaultValue
+}
+
+func WithCommitTx(ctx context.Context) context.Context {
+	return context.WithValue(ctx, ctxCommitTxKey{}, true)
+}
+
+func CommitTxFromContext(ctx context.Context) bool {
+	v, ok := ctx.Value(ctxCommitTxKey{}).(bool)
+
+	return ok && v
 }

--- a/internal/tx/context_test.go
+++ b/internal/tx/context_test.go
@@ -42,3 +42,16 @@ func TestWithLazyTx(t *testing.T) {
 		require.True(t, LazyTxFromContext(ctx, false))
 	})
 }
+
+func TestWithCommitTx(t *testing.T) {
+	t.Run("NotSet", func(t *testing.T) {
+		ctx := context.Background()
+		require.False(t, CommitTxFromContext(ctx))
+	})
+
+	t.Run("Set", func(t *testing.T) {
+		ctx := context.Background()
+		ctx = WithCommitTx(ctx)
+		require.True(t, CommitTxFromContext(ctx))
+	})
+}

--- a/tests/integration/database_sql_with_commit_tx_test.go
+++ b/tests/integration/database_sql_with_commit_tx_test.go
@@ -1,0 +1,419 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"database/sql"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3"
+	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
+)
+
+func TestDatabaseSqlWithCommitTxContext(t *testing.T) {
+	scope := newScope(t)
+
+	type traceCounters struct {
+		queryTxCommit   atomic.Int64
+		queryTxRollback atomic.Int64
+		sqlTxCommit     atomic.Int64
+		sqlTxRollback   atomic.Int64
+	}
+
+	newDB := func(t *testing.T, counters *traceCounters) (*sql.DB, func()) {
+		t.Helper()
+
+		driver := scope.NonCachingDriver(
+			ydb.WithTraceQuery(trace.Query{
+				OnTxCommit: func(info trace.QueryTxCommitStartInfo) func(trace.QueryTxCommitDoneInfo) {
+					counters.queryTxCommit.Add(1)
+
+					return func(trace.QueryTxCommitDoneInfo) {}
+				},
+				OnTxRollback: func(info trace.QueryTxRollbackStartInfo) func(trace.QueryTxRollbackDoneInfo) {
+					counters.queryTxRollback.Add(1)
+
+					return func(trace.QueryTxRollbackDoneInfo) {}
+				},
+			}),
+		)
+
+		connector, err := ydb.Connector(driver,
+			ydb.WithTablePathPrefix(scope.Folder()),
+			ydb.WithAutoDeclare(),
+			ydb.WithQueryService(true),
+			ydb.WithDatabaseSQLTrace(trace.DatabaseSQL{
+				OnTxCommit: func(info trace.DatabaseSQLTxCommitStartInfo) func(trace.DatabaseSQLTxCommitDoneInfo) {
+					counters.sqlTxCommit.Add(1)
+
+					return func(trace.DatabaseSQLTxCommitDoneInfo) {}
+				},
+				OnTxRollback: func(info trace.DatabaseSQLTxRollbackStartInfo) func(trace.DatabaseSQLTxRollbackDoneInfo) {
+					counters.sqlTxRollback.Add(1)
+
+					return func(trace.DatabaseSQLTxRollbackDoneInfo) {}
+				},
+			}),
+		)
+		require.NoError(t, err)
+
+		db := sql.OpenDB(connector)
+
+		return db, func() {
+			_ = db.Close()
+			_ = driver.Close(scope.Ctx)
+		}
+	}
+
+	t.Run("ExecWithCommitTxContext", func(t *testing.T) {
+		var counters traceCounters
+		db, cleanup := newDB(t, &counters)
+		defer cleanup()
+
+		tx, err := db.BeginTx(scope.Ctx, nil)
+		require.NoError(t, err)
+
+		_, err = tx.ExecContext(ydb.WithCommitTxContext(scope.Ctx), "SELECT 1")
+		require.NoError(t, err)
+
+		err = tx.Commit()
+		require.NoError(t, err)
+
+		require.Equal(t, int64(1), counters.sqlTxCommit.Load())
+		require.Equal(t, int64(1), counters.queryTxCommit.Load())
+		require.Equal(t, int64(0), counters.sqlTxRollback.Load())
+		require.Equal(t, int64(0), counters.queryTxRollback.Load())
+	})
+
+	t.Run("ExecWithCommitTxContextThenCommit", func(t *testing.T) {
+		var counters traceCounters
+		db, cleanup := newDB(t, &counters)
+		defer cleanup()
+
+		tx, err := db.BeginTx(scope.Ctx, nil)
+		require.NoError(t, err)
+
+		_, err = tx.ExecContext(scope.Ctx, "SELECT 1")
+		require.NoError(t, err)
+
+		_, err = tx.ExecContext(ydb.WithCommitTxContext(scope.Ctx), "SELECT 2")
+		require.NoError(t, err)
+
+		err = tx.Commit()
+		require.NoError(t, err)
+
+		require.Equal(t, int64(1), counters.sqlTxCommit.Load())
+		require.Equal(t, int64(1), counters.queryTxCommit.Load())
+		require.Equal(t, int64(0), counters.sqlTxRollback.Load())
+		require.Equal(t, int64(0), counters.queryTxRollback.Load())
+	})
+
+	t.Run("ExecWithCommitTxContextThenRollback", func(t *testing.T) {
+		var counters traceCounters
+		db, cleanup := newDB(t, &counters)
+		defer cleanup()
+
+		tx, err := db.BeginTx(scope.Ctx, nil)
+		require.NoError(t, err)
+
+		_, err = tx.ExecContext(ydb.WithCommitTxContext(scope.Ctx), "SELECT 1")
+		require.NoError(t, err)
+
+		err = tx.Rollback()
+		require.NoError(t, err)
+
+		require.Equal(t, int64(1), counters.sqlTxRollback.Load())
+		require.Equal(t, int64(0), counters.queryTxRollback.Load())
+		require.Equal(t, int64(0), counters.sqlTxCommit.Load())
+		require.Equal(t, int64(0), counters.queryTxCommit.Load())
+	})
+
+	t.Run("QueryWithCommitTxContext", func(t *testing.T) {
+		var counters traceCounters
+		db, cleanup := newDB(t, &counters)
+		defer cleanup()
+
+		tx, err := db.BeginTx(scope.Ctx, nil)
+		require.NoError(t, err)
+
+		rows, err := tx.QueryContext(ydb.WithCommitTxContext(scope.Ctx), "SELECT 1")
+		require.NoError(t, err)
+
+		for rows.Next() {
+			var v int
+			require.NoError(t, rows.Scan(&v))
+			require.Equal(t, 1, v)
+		}
+		require.NoError(t, rows.Err())
+		require.NoError(t, rows.Close())
+
+		err = tx.Commit()
+		require.NoError(t, err)
+
+		require.Equal(t, int64(1), counters.sqlTxCommit.Load())
+		require.Equal(t, int64(1), counters.queryTxCommit.Load())
+		require.Equal(t, int64(0), counters.sqlTxRollback.Load())
+		require.Equal(t, int64(0), counters.queryTxRollback.Load())
+	})
+
+	t.Run("QueryWithCommitTxContextThenRollback", func(t *testing.T) {
+		var counters traceCounters
+		db, cleanup := newDB(t, &counters)
+		defer cleanup()
+
+		tx, err := db.BeginTx(scope.Ctx, nil)
+		require.NoError(t, err)
+
+		rows, err := tx.QueryContext(ydb.WithCommitTxContext(scope.Ctx), "SELECT 1")
+		require.NoError(t, err)
+
+		for rows.Next() {
+			var v int
+			require.NoError(t, rows.Scan(&v))
+		}
+		require.NoError(t, rows.Err())
+		require.NoError(t, rows.Close())
+
+		err = tx.Rollback()
+		require.NoError(t, err)
+
+		require.Equal(t, int64(1), counters.sqlTxRollback.Load())
+		require.Equal(t, int64(0), counters.queryTxRollback.Load())
+		require.Equal(t, int64(0), counters.sqlTxCommit.Load())
+		require.Equal(t, int64(0), counters.queryTxCommit.Load())
+	})
+
+	t.Run("QueryWithCommitTxContextCommitBeforeRowsClose", func(t *testing.T) {
+		var counters traceCounters
+		db, cleanup := newDB(t, &counters)
+		defer cleanup()
+
+		tx, err := db.BeginTx(scope.Ctx, nil)
+		require.NoError(t, err)
+
+		rows, err := tx.QueryContext(ydb.WithCommitTxContext(scope.Ctx), "SELECT 1")
+		require.NoError(t, err)
+
+		err = tx.Commit()
+		require.NoError(t, err)
+
+		require.NoError(t, rows.Close())
+
+		require.Equal(t, int64(1), counters.sqlTxCommit.Load())
+		require.Equal(t, int64(1), counters.queryTxCommit.Load())
+		require.Equal(t, int64(0), counters.sqlTxRollback.Load())
+		require.Equal(t, int64(0), counters.queryTxRollback.Load())
+	})
+
+	t.Run("QueryWithCommitTxContextRollbackBeforeRowsClose", func(t *testing.T) {
+		var counters traceCounters
+		db, cleanup := newDB(t, &counters)
+		defer cleanup()
+
+		tx, err := db.BeginTx(scope.Ctx, nil)
+		require.NoError(t, err)
+
+		rows, err := tx.QueryContext(ydb.WithCommitTxContext(scope.Ctx), "SELECT 1")
+		require.NoError(t, err)
+
+		err = tx.Rollback()
+		require.NoError(t, err)
+
+		require.NoError(t, rows.Close())
+
+		require.Equal(t, int64(1), counters.sqlTxRollback.Load())
+		require.Equal(t, int64(0), counters.queryTxRollback.Load())
+		require.Equal(t, int64(0), counters.sqlTxCommit.Load())
+		require.Equal(t, int64(0), counters.queryTxCommit.Load())
+	})
+
+	t.Run("CommitWithoutCommitTxContext", func(t *testing.T) {
+		var counters traceCounters
+		db, cleanup := newDB(t, &counters)
+		defer cleanup()
+
+		tx, err := db.BeginTx(scope.Ctx, nil)
+		require.NoError(t, err)
+
+		_, err = tx.ExecContext(scope.Ctx, "SELECT 1")
+		require.NoError(t, err)
+
+		err = tx.Commit()
+		require.NoError(t, err)
+
+		require.Equal(t, int64(1), counters.sqlTxCommit.Load())
+		require.Equal(t, int64(1), counters.queryTxCommit.Load())
+		require.Equal(t, int64(0), counters.sqlTxRollback.Load())
+		require.Equal(t, int64(0), counters.queryTxRollback.Load())
+	})
+
+	t.Run("RollbackWithoutCommitTxContext", func(t *testing.T) {
+		var counters traceCounters
+		db, cleanup := newDB(t, &counters)
+		defer cleanup()
+
+		tx, err := db.BeginTx(scope.Ctx, nil)
+		require.NoError(t, err)
+
+		_, err = tx.ExecContext(scope.Ctx, "SELECT 1")
+		require.NoError(t, err)
+
+		err = tx.Rollback()
+		require.NoError(t, err)
+
+		require.Equal(t, int64(1), counters.sqlTxRollback.Load())
+		require.Equal(t, int64(1), counters.queryTxRollback.Load())
+		require.Equal(t, int64(0), counters.sqlTxCommit.Load())
+		require.Equal(t, int64(0), counters.queryTxCommit.Load())
+	})
+}
+
+func TestDatabaseSqlWithCommitTxContextExecThenRollbackDataPersisted(t *testing.T) {
+	scope := newScope(t)
+	tableName := scope.TableName()
+
+	driver := scope.NonCachingDriver()
+
+	connector, err := ydb.Connector(driver,
+		ydb.WithTablePathPrefix(scope.Folder()),
+		ydb.WithAutoDeclare(),
+		ydb.WithQueryService(true),
+	)
+	require.NoError(t, err)
+
+	db := sql.OpenDB(connector)
+	defer func() {
+		_ = db.Close()
+		_ = driver.Close(scope.Ctx)
+	}()
+
+	_, err = db.ExecContext(scope.Ctx, fmt.Sprintf("DELETE FROM %s", tableName))
+	require.NoError(t, err)
+
+	tx, err := db.BeginTx(scope.Ctx, nil)
+	require.NoError(t, err)
+
+	_, err = tx.ExecContext(
+		ydb.WithCommitTxContext(scope.Ctx),
+		fmt.Sprintf("INSERT INTO %s (id, val) VALUES (1, 'test')", tableName),
+	)
+	require.NoError(t, err)
+
+	err = tx.Rollback()
+	require.NoError(t, err)
+
+	var count int
+	err = db.QueryRowContext(scope.Ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", tableName)).Scan(&count)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+}
+
+func TestDatabaseSqlWithCommitTxContextRollbackBeforeRowsCloseDataPersisted(t *testing.T) {
+	scope := newScope(t)
+	tableName := scope.TableName()
+
+	driver := scope.NonCachingDriver()
+
+	connector, err := ydb.Connector(driver,
+		ydb.WithTablePathPrefix(scope.Folder()),
+		ydb.WithAutoDeclare(),
+		ydb.WithQueryService(true),
+	)
+	require.NoError(t, err)
+
+	db := sql.OpenDB(connector)
+	defer func() {
+		_ = db.Close()
+		_ = driver.Close(scope.Ctx)
+	}()
+
+	_, err = db.ExecContext(scope.Ctx, fmt.Sprintf("DELETE FROM %s", tableName))
+	require.NoError(t, err)
+
+	tx, err := db.BeginTx(scope.Ctx, nil)
+	require.NoError(t, err)
+
+	_, err = tx.ExecContext(scope.Ctx, fmt.Sprintf("INSERT INTO %s (id, val) VALUES (1, 'test')", tableName))
+	require.NoError(t, err)
+
+	rows, err := tx.QueryContext(
+		ydb.WithCommitTxContext(scope.Ctx),
+		fmt.Sprintf("SELECT id, val FROM %s", tableName),
+	)
+	require.NoError(t, err)
+
+	err = tx.Rollback()
+	require.NoError(t, err)
+
+	_ = rows.Close()
+
+	var count int
+	err = db.QueryRowContext(scope.Ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", tableName)).Scan(&count)
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+}
+
+func TestDatabaseSqlWithCommitTxContextQueryReturnsRows(t *testing.T) {
+	scope := newScope(t)
+	tableName := scope.TableName()
+
+	driver := scope.NonCachingDriver()
+
+	connector, err := ydb.Connector(driver,
+		ydb.WithTablePathPrefix(scope.Folder()),
+		ydb.WithAutoDeclare(),
+		ydb.WithQueryService(true),
+	)
+	require.NoError(t, err)
+
+	db := sql.OpenDB(connector)
+	defer func() {
+		_ = db.Close()
+		_ = driver.Close(scope.Ctx)
+	}()
+
+	_, err = db.ExecContext(scope.Ctx, fmt.Sprintf("DELETE FROM %s", tableName))
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(scope.Ctx,
+		fmt.Sprintf("INSERT INTO %s (id, val) VALUES (1, 'one'), (2, 'two'), (3, 'three')", tableName),
+	)
+	require.NoError(t, err)
+
+	tx, err := db.BeginTx(scope.Ctx, nil)
+	require.NoError(t, err)
+
+	rows, err := tx.QueryContext(
+		ydb.WithCommitTxContext(scope.Ctx),
+		fmt.Sprintf("SELECT id, val FROM %s ORDER BY id", tableName),
+	)
+	require.NoError(t, err)
+
+	type row struct {
+		id  int64
+		val string
+	}
+
+	var got []row
+	for rows.Next() {
+		var r row
+		require.NoError(t, rows.Scan(&r.id, &r.val))
+		got = append(got, r)
+	}
+	require.NoError(t, rows.Err())
+	require.NoError(t, rows.Close())
+
+	err = tx.Commit()
+	require.NoError(t, err)
+
+	require.Equal(t, []row{
+		{id: 1, val: "one"},
+		{id: 2, val: "two"},
+		{id: 3, val: "three"},
+	}, got)
+}


### PR DESCRIPTION
## Pull request type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

In `database/sql` transactions, committing a transaction always requires a separate RPC call after query execution (`tx.Commit()`). There is no way to combine query execution and commit into a single RPC call to reduce latency.

Issue Number: N/A

## What is the new behavior?

- Added `ydb.WithCommitTxContext(ctx)` for `database/sql` transactions to commit the transaction together with query execution in a single RPC call
- After using `WithCommitTxContext`, subsequent `tx.Commit()` or `tx.Rollback()` calls become no-ops
- Works with both `ExecContext` and `QueryContext`

### ExecContext — commit happens immediately with the query

```go
tx, _ := db.BeginTx(ctx, nil)
tx.ExecContext(ydb.WithCommitTxContext(ctx), "INSERT INTO table ...")
tx.Commit() // no-op, already committed
```

### ExecContext — Rollback after commit via context is also a no-op

```go
tx, _ := db.BeginTx(ctx, nil)
tx.ExecContext(ydb.WithCommitTxContext(ctx), "INSERT INTO table ...")
tx.Rollback() // no-op, data already persisted
```

### QueryContext — commit happens after rows are fully consumed

```go
tx, _ := db.BeginTx(ctx, nil)
rows, _ := tx.QueryContext(ydb.WithCommitTxContext(ctx), "SELECT ...")
for rows.Next() { /* consume rows */ }
rows.Close() // commit happens here
tx.Commit()  // no-op
```

### QueryContext — Commit before rows are consumed sends extra RPC

```go
tx, _ := db.BeginTx(ctx, nil)
rows, _ := tx.QueryContext(ydb.WithCommitTxContext(ctx), "SELECT ...")
tx.Commit()  // rows not consumed yet, extra CommitTx RPC will be sent
rows.Close()
```

### QueryContext — Rollback before rows are consumed does NOT cancel the commit

```go
tx, _ := db.BeginTx(ctx, nil)
rows, _ := tx.QueryContext(ydb.WithCommitTxContext(ctx), "SELECT ...")
tx.Rollback() // server already committed during query execution, data IS persisted
```

## Other information

- This is an experimental feature, following the existing `ydb.WithTxControl` convention
- Supported only with query service (`ydb.WithQueryService(true)`)
- Integration tests use tracing (`trace.Query` and `trace.DatabaseSQL`) to verify that `CommitTx` / `Rollback` RPCs are correctly skipped or sent depending on the scenario
- Fixed `return err` → `return nil` in `xsql/xquery/tx.go` Rollback method for consistency
