### PR TITLE
Invoke OnWriterReceiveResult when topic writer receives ack from server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Invoke `OnWriterReceiveResult` trace callback when topic writer receives ack from server (enables client-side logging for sync write diagnostics)
 * Added `ydb.WithCommitTxContext(ctx)` to request commit along with query execution in database/sql transactions
 
 ## v3.126.4

--- a/internal/topic/topicwriterinternal/writer_single_stream.go
+++ b/internal/topic/topicwriterinternal/writer_single_stream.go
@@ -202,6 +202,15 @@ func (w *SingleStreamWriter) receiveMessagesLoop(ctx context.Context) {
 
 		switch m := mess.(type) {
 		case *rawtopicwriter.WriteResult:
+			logCtx := w.cfg.LogContext
+			trace.TopicOnWriterReceiveResult(
+				w.cfg.Tracer,
+				&logCtx,
+				w.cfg.reconnectorInstanceID,
+				w.SessionID,
+				m.PartitionID,
+				m,
+			)
 			if err = w.cfg.queue.AcksReceived(m.Acks); err != nil && !errors.Is(err, errCloseClosedMessageQueue) {
 				reason := xerrors.WithStackTrace(err)
 				closeCtx, closeCtxCancel := xcontext.WithCancel(ctx)


### PR DESCRIPTION
Invokes `OnWriterReceiveResult` trace callback when topic writer receives WriteResult (ack) from server. This enables client-side logging (e.g. with `trace.TopicWriterStreamEvents`) to see "topic writer received result from server" and helps diagnose sync Write() hangs.

Made with [Cursor](https://cursor.com)