### PR TITLE
return context error on client context cancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed a bug when sometimes in cases of context cancellation returner error was not `errors.Is(err, context.Canceled)`
+
 ## v3.126.5
 * Invoke `OnWriterReceiveResult` trace callback when topic writer receives ack from server (enables client-side logging for sync write diagnostics)
 * Added `ydb.WithCommitTxContext(ctx)` to request commit along with query execution in database/sql transactions


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

sometimes when client context is cancelled, returned error from `Invoke` does not satisfy `errors.Is(err, context.Canceled)`.

Issue Number: N/A

## What is the new behavior?

checked for context cancel in `invoke` and return `ctx.Err()`.