### PR TITLE
docs: document TestSendMessagesLargerThenGRPCLimit skip on nightly (ydb#19449)

### DIFF
--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,0 +1,13 @@
+# Known Issues
+
+This document lists known issues that affect ydb-go-sdk tests or behavior, including upstream (YDB server) bugs and workarounds applied in this repository.
+
+## Integration tests
+
+### YDB server crash on 10MB topic messages (nightly)
+
+- **Upstream issue:** [ydb-platform/ydb#19449](https://github.com/ydb-platform/ydb/issues/19449)
+- **Affected test:** `TestSendMessagesLargerThenGRPCLimit` in `tests/integration/topic_read_writer_test.go`
+- **Symptom:** YDB server hits a VERIFY failure in `CreateFormedBlob()` when handling topic messages of size ~10MB on **nightly** builds.
+- **Workaround:** The test is skipped when `YDB_VERSION=nightly`. The test runs on YDB 25.0+ (non-nightly) where the bug is not present.
+- **Action:** When the upstream issue is fixed and the fix is available in a stable YDB release, the skip in the test can be removed.

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -6,3 +6,7 @@ Package `integration` contains only integration tests for `ydb-go-sdk`. All test
 // +build integration
 ```
 for run this test files as integration tests int github action `integration`.
+
+## Known issues
+
+Some tests are skipped under certain YDB versions due to upstream or environment limitations. See [Known Issues](../../docs/KNOWN_ISSUES.md) for details.

--- a/tests/integration/topic_read_writer_test.go
+++ b/tests/integration/topic_read_writer_test.go
@@ -522,12 +522,16 @@ func TestWriterFlushMessagesBeforeClose(t *testing.T) {
 	}
 }
 
+// Upstream YDB bug: server VERIFY crash on 10MB topic messages in nightly.
+// See docs/KNOWN_ISSUES.md and https://github.com/ydb-platform/ydb/issues/19449
+const upstreamIssueTopicLargeMessageNightly = "https://github.com/ydb-platform/ydb/issues/19449"
+
 func TestSendMessagesLargerThenGRPCLimit(t *testing.T) {
 	if version.Lt(os.Getenv("YDB_VERSION"), "25.0") {
 		t.Skip()
 	}
 	if os.Getenv("YDB_VERSION") == "nightly" {
-		t.Skip("bug: https://github.com/ydb-platform/ydb/issues/19449")
+		t.Skip("skip on nightly: upstream bug (YDB server crash on 10MB topic messages): " + upstreamIssueTopicLargeMessageNightly)
 	}
 	scope := newScope(t)
 


### PR DESCRIPTION
## Pull request type

- [x] Documentation content changes

## What is the current behavior?

- **Failing test:** `TestSendMessagesLargerThenGRPCLimit` in `tests/integration/topic_read_writer_test.go` causes YDB server crash (VERIFY failure in `CreateFormedBlob()`) when run against **nightly** YDB with 10MB topic messages.
- **Upstream bug:** [ydb-platform/ydb#19449](https://github.com/ydb-platform/ydb/issues/19449) (already reported).
- The test is already skipped for `YDB_VERSION=nightly` with a one-line comment; the reason and follow-up action were not documented in the repo.

## What is the new behavior?

- **Known issue documented:** Added `docs/KNOWN_ISSUES.md` describing the upstream bug, affected test, workaround (skip on nightly), and that the skip can be removed once ydb#19449 is fixed.
- **Integration README:** `tests/integration/README.md` now links to the known issues doc.
- **Test code:** Replaced inline skip message with a named constant (`upstreamIssueTopicLargeMessageNightly`) and a clearer comment so maintainers can easily remove the skip when the upstream fix is released.

## Other information

- No functional change: the test continues to be skipped on nightly; CI (including experiment job with nightly) remains green.
- When [ydb-platform/ydb#19449](https://github.com/ydb-platform/ydb/issues/19449) is fixed in a stable YDB release, remove the nightly skip in `TestSendMessagesLargerThenGRPCLimit` and optionally the entry in `docs/KNOWN_ISSUES.md`.

Made with [Cursor](https://cursor.com)