### PR TITLE
fix(table_service): support both underlying types for YSON bytes and text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Fixed YSON scanning in `TableService` to support both underlying `TextValue` and `BytesValue` wire representations
 * Fixed inverted success/error handling in the `ExampleWriter_Write` doc example for `topicwriter`, which printed `OK` on failure and aborted on success
 
 ## v3.139.6

--- a/internal/query/scanner/indexed_test.go
+++ b/internal/query/scanner/indexed_test.go
@@ -77,6 +77,64 @@ func TestIndexed(t *testing.T) {
 			},
 		},
 		{
+			name: "Ydb.Type_YSON_TextValue",
+			s: Indexed(NewData(
+				[]*Ydb.Column{
+					{
+						Type: &Ydb.Type{
+							Type: &Ydb.Type_TypeId{
+								TypeId: Ydb.Type_YSON,
+							},
+						},
+					},
+				},
+				[]*Ydb.Value{
+					{
+						Value: &Ydb.Value_TextValue{
+							TextValue: "<a=1>[3;%false]",
+						},
+					},
+				},
+			)),
+			dst: [][]any{
+				{func(v string) *string { return &v }("")},
+				{func(v []byte) *[]byte { return &v }([]byte(""))},
+			},
+			exp: [][]any{
+				{func(v string) *string { return &v }("<a=1>[3;%false]")},
+				{func(v []byte) *[]byte { return &v }([]byte("<a=1>[3;%false]"))},
+			},
+		},
+		{
+			name: "Ydb.Type_YSON_BytesValue",
+			s: Indexed(NewData(
+				[]*Ydb.Column{
+					{
+						Type: &Ydb.Type{
+							Type: &Ydb.Type_TypeId{
+								TypeId: Ydb.Type_YSON,
+							},
+						},
+					},
+				},
+				[]*Ydb.Value{
+					{
+						Value: &Ydb.Value_BytesValue{
+							BytesValue: []byte("<a=1>[3;%false]"),
+						},
+					},
+				},
+			)),
+			dst: [][]any{
+				{func(v string) *string { return &v }("")},
+				{func(v []byte) *[]byte { return &v }([]byte(""))},
+			},
+			exp: [][]any{
+				{func(v string) *string { return &v }("<a=1>[3;%false]")},
+				{func(v []byte) *[]byte { return &v }([]byte("<a=1>[3;%false]"))},
+			},
+		},
+		{
 			name: "Ydb.Type_UINT64",
 			s: Indexed(NewData(
 				[]*Ydb.Column{

--- a/internal/query/scanner/named_test.go
+++ b/internal/query/scanner/named_test.go
@@ -79,6 +79,66 @@ func TestNamed(t *testing.T) {
 			},
 		},
 		{
+			name: "Ydb.Type_YSON_TextValue",
+			s: Named(NewData(
+				[]*Ydb.Column{
+					{
+						Name: "a",
+						Type: &Ydb.Type{
+							Type: &Ydb.Type_TypeId{
+								TypeId: Ydb.Type_YSON,
+							},
+						},
+					},
+				},
+				[]*Ydb.Value{
+					{
+						Value: &Ydb.Value_TextValue{
+							TextValue: "<a=1>[3;%false]",
+						},
+					},
+				},
+			)),
+			dst: [][]any{
+				{func(v string) *string { return &v }("")},
+				{func(v []byte) *[]byte { return &v }([]byte(""))},
+			},
+			exp: [][]any{
+				{func(v string) *string { return &v }("<a=1>[3;%false]")},
+				{func(v []byte) *[]byte { return &v }([]byte("<a=1>[3;%false]"))},
+			},
+		},
+		{
+			name: "Ydb.Type_YSON_BytesValue",
+			s: Named(NewData(
+				[]*Ydb.Column{
+					{
+						Name: "a",
+						Type: &Ydb.Type{
+							Type: &Ydb.Type_TypeId{
+								TypeId: Ydb.Type_YSON,
+							},
+						},
+					},
+				},
+				[]*Ydb.Value{
+					{
+						Value: &Ydb.Value_BytesValue{
+							BytesValue: []byte("<a=1>[3;%false]"),
+						},
+					},
+				},
+			)),
+			dst: [][]any{
+				{func(v string) *string { return &v }("")},
+				{func(v []byte) *[]byte { return &v }([]byte(""))},
+			},
+			exp: [][]any{
+				{func(v string) *string { return &v }("<a=1>[3;%false]")},
+				{func(v []byte) *[]byte { return &v }([]byte("<a=1>[3;%false]"))},
+			},
+		},
+		{
 			name: "Ydb.Type_UINT64",
 			s: Named(NewData(
 				[]*Ydb.Column{

--- a/internal/table/scanner/scanner.go
+++ b/internal/table/scanner/scanner.go
@@ -460,10 +460,18 @@ func (s *valueScanner) any() any {
 		return src
 	case internalTypes.Text, internalTypes.DyNumber:
 		return s.text()
-	case
-		internalTypes.YSON,
-		internalTypes.JSON,
-		internalTypes.JSONDocument:
+	case internalTypes.YSON:
+		switch x := s.stack.currentValue().(type) {
+		case *Ydb.Value_TextValue:
+			return xstring.ToBytes(x.TextValue)
+		case *Ydb.Value_BytesValue:
+			return x.BytesValue
+		default:
+			_ = s.errorf(0, "valueScanner.any(): incorrect YSON underlying type %T (expected TextValue or BytesValue)", x)
+
+			return nil
+		}
+	case internalTypes.JSON, internalTypes.JSONDocument:
 		return xstring.ToBytes(s.text())
 	default:
 		_ = s.errorf(0, "unknown primitive type '%+v'", p)
@@ -794,8 +802,17 @@ func (s *valueScanner) setString(dst *string) {
 	switch t := s.stack.current().t.GetTypeId(); t {
 	case Ydb.Type_UUID:
 		_ = s.errorf(0, "ydb: failed scan uuid: %w", value.ErrIssue1501BadUUID)
-	case Ydb.Type_UTF8, Ydb.Type_DYNUMBER, Ydb.Type_YSON, Ydb.Type_JSON, Ydb.Type_JSON_DOCUMENT:
+	case Ydb.Type_UTF8, Ydb.Type_DYNUMBER, Ydb.Type_JSON, Ydb.Type_JSON_DOCUMENT:
 		*dst = s.text()
+	case Ydb.Type_YSON:
+		switch x := s.stack.currentValue().(type) {
+		case *Ydb.Value_TextValue:
+			*dst = x.TextValue
+		case *Ydb.Value_BytesValue:
+			*dst = xstring.FromBytes(x.BytesValue)
+		default:
+			_ = s.errorf(0, "scan row failed: incorrect YSON underlying type %T (expected TextValue or BytesValue)", x)
+		}
 	case Ydb.Type_STRING:
 		*dst = xstring.FromBytes(s.bytes())
 	default:
@@ -807,8 +824,17 @@ func (s *valueScanner) setByte(dst *[]byte) {
 	switch t := s.stack.current().t.GetTypeId(); t {
 	case Ydb.Type_UUID:
 		_ = s.errorf(0, "ydb: failed to scan uuid: %w", value.ErrIssue1501BadUUID)
-	case Ydb.Type_UTF8, Ydb.Type_DYNUMBER, Ydb.Type_YSON, Ydb.Type_JSON, Ydb.Type_JSON_DOCUMENT:
+	case Ydb.Type_UTF8, Ydb.Type_DYNUMBER, Ydb.Type_JSON, Ydb.Type_JSON_DOCUMENT:
 		*dst = xstring.ToBytes(s.text())
+	case Ydb.Type_YSON:
+		switch x := s.stack.currentValue().(type) {
+		case *Ydb.Value_TextValue:
+			*dst = xstring.ToBytes(x.TextValue)
+		case *Ydb.Value_BytesValue:
+			*dst = x.BytesValue
+		default:
+			_ = s.errorf(0, "scan row failed: incorrect YSON underlying type %T (expected TextValue or BytesValue)", x)
+		}
 	case Ydb.Type_STRING:
 		*dst = s.bytes()
 	default:

--- a/internal/table/scanner/scanner_test.go
+++ b/internal/table/scanner/scanner_test.go
@@ -782,6 +782,120 @@ func TestScanToJsonUnmarshaller(t *testing.T) {
 	}
 }
 
+func TestScanYSON(t *testing.T) {
+	s := initScanner()
+
+	expected := []byte("<a=1>[3;%false]")
+	for _, test := range []struct {
+		name  string
+		value *Ydb.Value
+	}{
+		{
+			name: "TextValue",
+			value: &Ydb.Value{
+				Value: &Ydb.Value_TextValue{
+					TextValue: string(expected),
+				},
+			},
+		},
+		{
+			name: "BytesValue",
+			value: &Ydb.Value{
+				Value: &Ydb.Value_BytesValue{
+					BytesValue: expected,
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			set := &Ydb.ResultSet{
+				Columns: []*Ydb.Column{
+					{
+						Name: "yson",
+						Type: &Ydb.Type{
+							Type: &Ydb.Type_TypeId{
+								TypeId: Ydb.Type_YSON,
+							},
+						},
+					},
+				},
+				Rows: []*Ydb.Value{
+					{
+						Items: []*Ydb.Value{
+							test.value,
+						},
+					},
+				},
+			}
+
+			s.reset(set)
+			require.True(t, s.NextRow())
+
+			var got []byte
+			err := s.Scan(&got)
+			require.NoError(t, err)
+			require.Equal(t, expected, got)
+		})
+	}
+}
+
+func TestScanYSONAny(t *testing.T) {
+	s := initScanner()
+
+	expected := []byte("<a=1>[3;%false]")
+	for _, test := range []struct {
+		name  string
+		value *Ydb.Value
+	}{
+		{
+			name: "TextValue",
+			value: &Ydb.Value{
+				Value: &Ydb.Value_TextValue{
+					TextValue: string(expected),
+				},
+			},
+		},
+		{
+			name: "BytesValue",
+			value: &Ydb.Value{
+				Value: &Ydb.Value_BytesValue{
+					BytesValue: expected,
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			set := &Ydb.ResultSet{
+				Columns: []*Ydb.Column{
+					{
+						Name: "yson",
+						Type: &Ydb.Type{
+							Type: &Ydb.Type_TypeId{
+								TypeId: Ydb.Type_YSON,
+							},
+						},
+					},
+				},
+				Rows: []*Ydb.Value{
+					{
+						Items: []*Ydb.Value{
+							test.value,
+						},
+					},
+				},
+			}
+
+			s.reset(set)
+			require.True(t, s.NextRow())
+
+			var got any
+			err := s.Scan(&got)
+			require.NoError(t, err)
+			require.Equal(t, expected, got)
+		})
+	}
+}
+
 // jsonSQLScanner is a struct with a private json.RawMessage field that
 // implements sql.Scanner and json.Marshaler without inheriting driver.Valuer.
 // This mirrors the user-side pattern described in the fix for json.RawMessage binding.

--- a/tests/integration/database_sql_scanner_test.go
+++ b/tests/integration/database_sql_scanner_test.go
@@ -319,6 +319,22 @@ func TestDatabaseSqlScanner(t *testing.T) {
 				return row.Scan(&v), v, testBytes("hello")
 			},
 		},
+		{
+			name: "YSON_TextValue",
+			sql:  "SELECT CAST('<a=1>[3;%false]' AS Yson)",
+			scan: func(row *sql.Row) (_ error, act, exp any) {
+				var v []byte
+				return row.Scan(&v), v, []byte("<a=1>[3;%false]")
+			},
+		},
+		{
+			name: "YSON_TextValue_to_any",
+			sql:  "SELECT CAST('<a=1>[3;%false]' AS Yson)",
+			scan: func(row *sql.Row) (_ error, act, exp any) {
+				var v any
+				return row.Scan(&v), v, []byte("<a=1>[3;%false]")
+			},
+		},
 	} {
 		t.Run(ttt.name, func(t *testing.T) {
 			for _, tt := range []struct {

--- a/tests/integration/database_sql_yson_column_test.go
+++ b/tests/integration/database_sql_yson_column_test.go
@@ -1,0 +1,97 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3"
+	"github.com/ydb-platform/ydb-go-sdk/v3/table"
+	"github.com/ydb-platform/ydb-go-sdk/v3/table/types"
+)
+
+func TestDatabaseSqlYSONColumnBytesValue(t *testing.T) {
+	var (
+		scope    = newScope(t)
+		ctx      = scope.Ctx
+		driver   = scope.Driver()
+		expected = []byte("<a=1>[3;%false]")
+	)
+
+	tablePath := scope.TablePath(withCreateTableQueryTemplate(`
+		PRAGMA TablePathPrefix("{{.TablePathPrefix}}");
+		CREATE TABLE {{.TableName}} (
+			id Int64 NOT NULL,
+			yson Yson,
+			PRIMARY KEY (id)
+		)
+	`))
+
+	err := driver.Table().Do(ctx, func(ctx context.Context, s table.Session) error {
+		return s.BulkUpsert(ctx, tablePath, types.ListValue(
+			types.StructValue(
+				types.StructFieldValue("id", types.Int64Value(1)),
+				types.StructFieldValue("yson", types.YSONValueFromBytes(expected)),
+			),
+		))
+	})
+	require.NoError(t, err)
+
+	selectYSON := fmt.Sprintf("SELECT yson FROM `%s` WHERE id = 1", tablePath)
+
+	for _, tt := range []struct {
+		name         string
+		queryService bool
+	}{
+		{
+			name:         "ydb.WithQueryService(false)",
+			queryService: false,
+		},
+		{
+			name:         "ydb.WithQueryService(true)",
+			queryService: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			db := scope.SQLDriver(ydb.WithQueryService(tt.queryService))
+
+			for _, scanCase := range []struct {
+				name string
+				scan func(row *sql.Row) (any, error)
+			}{
+				{
+					name: "BytesValue",
+					scan: func(row *sql.Row) (any, error) {
+						var got []byte
+						err := row.Scan(&got)
+
+						return got, err
+					},
+				},
+				{
+					name: "BytesValue_to_any",
+					scan: func(row *sql.Row) (any, error) {
+						var got any
+						err := row.Scan(&got)
+
+						return got, err
+					},
+				},
+			} {
+				t.Run(scanCase.name, func(t *testing.T) {
+					row := db.QueryRowContext(ctx, selectYSON)
+
+					got, err := scanCase.scan(row)
+					require.NoError(t, err)
+					require.Equal(t, expected, got)
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

`TableService` scanner handles YSON inconsistently: it expects YSON as `TextValue`, while other parts of SDK accept YSON as either `TextValue` or `BytesValue`.
As a result, scanning via `TableService` fails when server returns YSON as `BytesValue`.

Issue Number: NYDB-2083

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

`TableService` scanner supports both underlying types for YSON: `TextValue` and `BytesValue`.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
