### PR TITLE
Modernize Go codebase: adopt modern idioms and upgrade CI tooling

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,8 +7,8 @@ on:
   pull_request:
   workflow_dispatch:
 env:
-  GOLANGCI_LINT_VERSION: v2.4.0
-  GO_VERSION: '1.25'
+  GOLANGCI_LINT_VERSION: v2.11.4
+  GO_VERSION: '1.26'
 jobs:
   golangci:
     if: (!contains(github.event.pull_request.labels.*.name, 'no lint'))
@@ -78,7 +78,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24.x"
+          go-version: "1.26.x"
       - name: Install utilities
         run: |
           go install mvdan.cc/gofumpt@v0.7.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.21.x, 1.25.x]
+        go-version: [1.21.x, 1.26.x]
         os: [ubuntu, windows, macOS]
     env:
       OS: ${{ matrix.os }}-latest
@@ -52,8 +52,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.21.x, 1.25.x]
-        ydb-version: [latest, 24.4, 25.2]
+        go-version: [1.21.x, 1.26.x]
+        ydb-version: [24.4, latest, edge]
         os: [ubuntu]
     services:
       ydb:
@@ -109,7 +109,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.25.x]
+        go-version: [1.26.x]
         ydb-version: [nightly]
         os: [ubuntu]
     services:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,6 +33,12 @@ linters:
     - nonamedreturns
     - paralleltest
     - perfsprint
+
+    # Warning from linter's author:
+    #  IMPORTANT: we don't recommend using this linter before doing performance profiling.
+    #  For most programs usage of prealloc will be a premature optimization.
+    - prealloc
+
     - predeclared
     - testableexamples
     - testifylint
@@ -49,6 +55,10 @@ linters:
     # introduced v2.4.0
     - noinlineerr
     - wsl_v5
+
+    # introduced v2.11.4
+    - godoclint
+    - unqueryvet
   settings:
     errcheck:
       check-type-assertions: false

--- a/balancers/balancers.go
+++ b/balancers/balancers.go
@@ -81,13 +81,8 @@ type filterLocations []string
 
 func (locations filterLocations) Allow(_ balancerConfig.Info, e endpoint.Info) bool {
 	location := strings.ToUpper(e.Location())
-	for _, l := range locations {
-		if location == l {
-			return true
-		}
-	}
 
-	return false
+	return slices.Contains(locations, location)
 }
 
 func (locations filterLocations) String() string {

--- a/config/config.go
+++ b/config/config.go
@@ -257,7 +257,7 @@ func WithNoAutoRetry() Option {
 }
 
 // WithPanicCallback applies panic callback to config
-func WithPanicCallback(panicCallback func(e interface{})) Option {
+func WithPanicCallback(panicCallback func(e any)) Option {
 	return func(c *Config) {
 		config.SetPanicCallback(&c.Common, panicCallback)
 	}

--- a/coordination/config.go
+++ b/coordination/config.go
@@ -8,7 +8,9 @@ const (
 	ConsistencyModeUnset ConsistencyMode = iota
 	ConsistencyModeStrict
 	ConsistencyModeRelaxed
+)
 
+const (
 	consistencyAggregated = "Aggregated"
 	consistencyDetailed   = "Detailed"
 	consistencyRelaxed    = "Relaxed"

--- a/credentials/options.go
+++ b/credentials/options.go
@@ -142,7 +142,7 @@ func WithSigningMethodName(method string) credentials.JWTTokenSourceOption {
 }
 
 // PrivateKey
-func WithPrivateKey(key interface{}) credentials.JWTTokenSourceOption {
+func WithPrivateKey(key any) credentials.JWTTokenSourceOption {
 	return credentials.WithPrivateKey(key)
 }
 

--- a/driver.go
+++ b/driver.go
@@ -109,7 +109,7 @@ type (
 		onClose     []func(c *Driver)
 		closed      atomic.Bool
 
-		panicCallback func(e interface{})
+		panicCallback func(e any)
 	}
 	balancerWithMeta struct {
 		balancer *balancer.Balancer

--- a/dsn.go
+++ b/dsn.go
@@ -100,7 +100,7 @@ func parseConnectionString(dataSourceName string) (opts []Option, _ error) {
 		}
 	}
 	if fakeTx := info.Params.Get("go_fake_tx"); fakeTx != "" {
-		for _, queryMode := range strings.Split(fakeTx, ",") {
+		for queryMode := range strings.SplitSeq(fakeTx, ",") {
 			switch mode := queryModeFromString(queryMode); mode {
 			case unknownQueryMode:
 				return nil, xerrors.WithStackTrace(fmt.Errorf("unknown query mode: %s", queryMode))
@@ -111,8 +111,8 @@ func parseConnectionString(dataSourceName string) (opts []Option, _ error) {
 	}
 	if info.Params.Has("go_query_bind") {
 		var binders []xsql.Option
-		queryTransformers := strings.Split(info.Params.Get("go_query_bind"), ",")
-		for _, transformer := range queryTransformers {
+		queryTransformers := strings.SplitSeq(info.Params.Get("go_query_bind"), ",")
+		for transformer := range queryTransformers {
 			switch transformer {
 			case "declare":
 				binders = append(binders, xsql.WithQueryBind(bind.AutoDeclare{}))

--- a/examples/basic/database/sql/series.go
+++ b/examples/basic/database/sql/series.go
@@ -169,7 +169,7 @@ func selectScan(ctx context.Context, db *sql.DB) (err error) {
 
 func fillTablesWithData(ctx context.Context, db *sql.DB) (err error) {
 	series, seasonsData, episodesData := getData()
-	args := []interface{}{
+	args := []any{
 		sql.Named("seriesData", types.ListValue(series...)),
 		sql.Named("seasonsData", types.ListValue(seasonsData...)),
 		sql.Named("episodesData", types.ListValue(episodesData...)),

--- a/examples/basic/native/table/series.go
+++ b/examples/basic/native/table/series.go
@@ -407,7 +407,7 @@ func describeTable(ctx context.Context, c table.Client, path string) error {
 	)
 }
 
-func render(t *template.Template, data interface{}) string {
+func render(t *template.Template, data any) string {
 	var buf bytes.Buffer
 	if err := t.Execute(&buf, data); err != nil {
 		panic(err)

--- a/examples/decimal/decimal.go
+++ b/examples/decimal/decimal.go
@@ -28,7 +28,7 @@ PRAGMA TablePathPrefix("{{ .TablePathPrefix }}");
 SELECT value FROM decimals;
 `))
 
-func render(t *template.Template, data interface{}) string {
+func render(t *template.Template, data any) string {
 	var buf bytes.Buffer
 	if err := t.Execute(&buf, data); err != nil {
 		panic(err)

--- a/examples/read_table/orders.go
+++ b/examples/read_table/orders.go
@@ -71,7 +71,7 @@ FROM AS_TABLE($ordersData);
 	dateLayout = "2006-01-02"
 )
 
-func render(t *template.Template, data interface{}) string {
+func render(t *template.Template, data any) string {
 	var buf bytes.Buffer
 	if err := t.Execute(&buf, data); err != nil {
 		panic(err)

--- a/examples/serverless/healthcheck/service.go
+++ b/examples/serverless/healthcheck/service.go
@@ -129,7 +129,7 @@ func (s *service) check(ctx context.Context, urls []string) error {
 	wg := &sync.WaitGroup{}
 	rows := make([]row, len(urls))
 	for idx := range urls {
-		for _, u := range strings.Split(urls[idx], " ") {
+		for u := range strings.SplitSeq(urls[idx], " ") {
 			wg.Add(1)
 			go func(idx int, u string) {
 				defer wg.Done()

--- a/examples/serverless/url_shortener/service.go
+++ b/examples/serverless/url_shortener/service.go
@@ -56,7 +56,7 @@ func isLongCorrect(link string) bool {
 	return long.FindStringIndex(link) != nil
 }
 
-func render(t *template.Template, data interface{}) string {
+func render(t *template.Template, data any) string {
 	var buf bytes.Buffer
 	if err := t.Execute(&buf, data); err != nil {
 		panic(err)
@@ -349,7 +349,7 @@ func (s *service) handleIndex(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "text/html")
 	w.WriteHeader(http.StatusOK)
-	data := map[string]interface{}{
+	data := map[string]any{
 		"userAgent": r.UserAgent(),
 	}
 	if err = tpl.Execute(w, data); err != nil {

--- a/examples/topic/cdc-cache-bus-freeseats/balancer.go
+++ b/examples/topic/cdc-cache-bus-freeseats/balancer.go
@@ -7,7 +7,7 @@ import (
 
 type balancer struct {
 	handlers []http.Handler
-	counter  int32
+	counter  atomic.Int32
 }
 
 func newBalancer(handlers ...http.Handler) *balancer {
@@ -17,7 +17,7 @@ func newBalancer(handlers ...http.Handler) *balancer {
 }
 
 func (b *balancer) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
-	counter := atomic.AddInt32(&b.counter, 1)
+	counter := b.counter.Add(1)
 	if counter < 0 {
 		counter = -counter
 	}

--- a/examples/topic/cdc-cache-bus-freeseats/database.go
+++ b/examples/topic/cdc-cache-bus-freeseats/database.go
@@ -65,7 +65,7 @@ UPSERT INTO bus (id, freeSeats) VALUES ("bus1", 40), ("bus2", 60);
 }
 
 func createCosumers(ctx context.Context, db *ydb.Driver, consumersCount int) error {
-	for i := 0; i < consumersCount; i++ {
+	for i := range consumersCount {
 		err := db.Topic().Alter(ctx, "bus/updates", topicoptions.AlterWithAddConsumers(topictypes.Consumer{
 			Name: consumerName(i),
 		}))

--- a/examples/topic/cdc-cache-bus-freeseats/webserver.go
+++ b/examples/topic/cdc-cache-bus-freeseats/webserver.go
@@ -21,7 +21,7 @@ type server struct {
 	cache     *Cache
 	mux       http.ServeMux
 	db        *ydb.Driver
-	dbCounter int64
+	dbCounter atomic.Int64
 	id        int
 }
 
@@ -102,7 +102,7 @@ func (s *server) getFreeSeats(ctx context.Context, id string) (int64, error) {
 }
 
 func (s *server) getContentFromDB(ctx context.Context, id string) (int64, error) {
-	atomic.AddInt64(&s.dbCounter, 1)
+	s.dbCounter.Add(1)
 	var freeSeats int64
 	err := s.db.Table().DoTx(ctx, func(ctx context.Context, tx table.TransactionActor) error {
 		var err error

--- a/examples/topic/cdc-fill-and-read/cdc-reader.go
+++ b/examples/topic/cdc-fill-and-read/cdc-reader.go
@@ -25,7 +25,7 @@ func cdcRead(ctx context.Context, db *ydb.Driver, consumerName, topicPath string
 			panic(fmt.Errorf("failed to read message: %w", err))
 		}
 
-		var event interface{}
+		var event any
 		err = topicsugar.JSONUnmarshal(msg, &event)
 		if err != nil {
 			panic(fmt.Errorf("failed to unmarshal json cdc: %w", err))

--- a/examples/transaction/query/main.go
+++ b/examples/transaction/query/main.go
@@ -98,7 +98,7 @@ func txWithRetries(ctx context.Context, db *ydb.Driver) (words []string, _ error
 				ORDER BY ord;
 			`,
 			query.WithParameters(
-				ydb.ParamsFromMap(map[string]interface{}{
+				ydb.ParamsFromMap(map[string]any{
 					"$word1": "in",
 					"$word2": "transaction",
 					"$word3": "retries",

--- a/examples/ttl/main.go
+++ b/examples/ttl/main.go
@@ -104,7 +104,7 @@ func main() {
 		panic(fmt.Errorf("read document failed: %w", err))
 	}
 
-	for i := uint64(0); i < expirationQueueCount; i++ {
+	for i := range uint64(expirationQueueCount) {
 		if err = deleteExpired(ctx, db.Table(), prefix, i, 1); err != nil {
 			panic(fmt.Errorf("delete expired failed: %w", err))
 		}
@@ -131,7 +131,7 @@ func main() {
 		panic(fmt.Errorf("add document failed: %w", err))
 	}
 
-	for i := uint64(0); i < expirationQueueCount; i++ {
+	for i := range uint64(expirationQueueCount) {
 		if err = deleteExpired(ctx, db.Table(), prefix, i, 2); err != nil {
 			panic(fmt.Errorf("delete expired failed: %w", err))
 		}

--- a/examples/ttl/series.go
+++ b/examples/ttl/series.go
@@ -267,7 +267,7 @@ func createTables(ctx context.Context, c table.Client, prefix string) (err error
 		return err
 	}
 
-	for i := 0; i < expirationQueueCount; i++ {
+	for i := range expirationQueueCount {
 		tableName := path.Join(prefix, fmt.Sprintf("expiration_queue_%v", i))
 		err = c.Do(ctx,
 			func(ctx context.Context, s table.Session) error {

--- a/internal/background/worker_test.go
+++ b/internal/background/worker_test.go
@@ -108,7 +108,7 @@ func TestWorkerConcurrentStartAndClose(t *testing.T) {
 
 		stopNewStarts := atomic.Bool{}
 		var wgStarters sync.WaitGroup
-		for i := 0; i < parallel; i++ {
+		for range parallel {
 			wgStarters.Add(1)
 			go func() {
 				defer wgStarters.Done()

--- a/internal/backoff/backoff.go
+++ b/internal/backoff/backoff.go
@@ -110,19 +110,3 @@ func (b logBackoff) Delay(i int) time.Duration {
 
 	return f + time.Duration(b.r.Int64(int64(d-f)+1))
 }
-
-func min(a, b uint) uint {
-	if a < b {
-		return a
-	}
-
-	return b
-}
-
-func max(a, b uint) uint {
-	if a > b {
-		return a
-	}
-
-	return b
-}

--- a/internal/balancer/balancer.go
+++ b/internal/balancer/balancer.go
@@ -45,7 +45,7 @@ type streamWrapper struct {
 	onErr func(error)
 }
 
-func (s *streamWrapper) SendMsg(m interface{}) error {
+func (s *streamWrapper) SendMsg(m any) error {
 	err := s.ClientStream.SendMsg(m)
 	if err != nil && !errors.Is(err, io.EOF) {
 		s.onErr(err)
@@ -54,7 +54,7 @@ func (s *streamWrapper) SendMsg(m interface{}) error {
 	return err
 }
 
-func (s *streamWrapper) RecvMsg(m interface{}) error {
+func (s *streamWrapper) RecvMsg(m any) error {
 	err := s.ClientStream.RecvMsg(m)
 	if err != nil && !errors.Is(err, io.EOF) {
 		s.onErr(err)
@@ -370,8 +370,8 @@ func New(ctx context.Context, driverConfig *config.Config, pool *conn.Pool, opts
 func (b *Balancer) Invoke(
 	ctx context.Context,
 	method string,
-	args interface{},
-	reply interface{},
+	args any,
+	reply any,
 	opts ...grpc.CallOption,
 ) error {
 	if b.closed.Load() {

--- a/internal/balancer/balancer_test.go
+++ b/internal/balancer/balancer_test.go
@@ -256,7 +256,7 @@ func TestPessimizationOnOverloaded(t *testing.T) {
 		require.Equal(t, state.Banned, cc1.GetState())
 
 		// nextConn must only return cc2 now.
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			c, nextErr := b.nextConn(ctx)
 			require.NoError(t, nextErr)
 			require.Equal(t, cc2.AddrField, c.Endpoint().Address())
@@ -400,7 +400,7 @@ func TestPessimizationOnOverloaded(t *testing.T) {
 		require.True(t, xerrors.IsOperationError(err, Ydb.StatusIds_OVERLOADED))
 		require.Equal(t, state.Banned, cc1.GetState())
 
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			c, nextErr := b.nextConn(ctx)
 			require.NoError(t, nextErr)
 			require.Equal(t, cc2.AddrField, c.Endpoint().Address())
@@ -454,7 +454,7 @@ func TestPessimizationOnOverloaded(t *testing.T) {
 		require.True(t, xerrors.IsOperationError(err, Ydb.StatusIds_OVERLOADED))
 		require.Equal(t, state.Banned, cc1.GetState())
 
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			c, nextErr := b.nextConn(ctx)
 			require.NoError(t, nextErr)
 			require.Equal(t, cc2.AddrField, c.Endpoint().Address())

--- a/internal/balancer/cluster/cluster_test.go
+++ b/internal/balancer/cluster/cluster_test.go
@@ -276,7 +276,7 @@ func TestCluster(t *testing.T) {
 		)
 		endpoints := make([]endpoint.Endpoint, buckets)
 
-		for i := 0; i < buckets; i++ {
+		for i := range buckets {
 			endpoints[i] = &mock.Endpoint{
 				AddrField:   strconv.Itoa(i),
 				NodeIDField: uint32(i),
@@ -286,7 +286,7 @@ func TestCluster(t *testing.T) {
 		s := New(endpoints)
 
 		distribution := make([]int, len(endpoints))
-		for i := 0; i < total; i++ {
+		for range total {
 			e, err := s.Next(ctx)
 			require.NoError(t, err)
 			require.NotNil(t, e)

--- a/internal/balancer/connections_state_test.go
+++ b/internal/balancer/connections_state_test.go
@@ -192,7 +192,7 @@ func TestSelectRandomConnection(t *testing.T) {
 		}
 		first := 0
 		second := 0
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			c, _ := s.selectRandomConnection(conns, false)
 			if c.Endpoint().Address() == "1" {
 				first++
@@ -210,7 +210,7 @@ func TestSelectRandomConnection(t *testing.T) {
 			&mock.Conn{AddrField: "2", State: state.Banned},
 		}
 		totalFailed := 0
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			c, failed := s.selectRandomConnection(conns, false)
 			require.Nil(t, c)
 			totalFailed += failed
@@ -226,7 +226,7 @@ func TestSelectRandomConnection(t *testing.T) {
 		first := 0
 		second := 0
 		failed := 0
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			c, checkFailed := s.selectRandomConnection(conns, false)
 			failed += checkFailed
 			switch c.Endpoint().Address() {
@@ -421,7 +421,7 @@ func TestConnection(t *testing.T) {
 		}), balancerConfig.Info{}, true)
 		preferred := 0
 		fallback := 0
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			c, failed := s.GetConnection(context.Background())
 			require.NotNil(t, c)
 			require.Equal(t, 2, failed)

--- a/internal/balancer/local_dc_test.go
+++ b/internal/balancer/local_dc_test.go
@@ -38,7 +38,7 @@ func TestCheckFastestAddress(t *testing.T) {
 		var firstCount int64
 		var secondCount int64
 
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			listen1, err := net.ListenTCP("tcp", &net.TCPAddr{IP: localIP})
 			require.NoError(t, err)
 			listen2, err := net.ListenTCP("tcp", &net.TCPAddr{IP: localIP})
@@ -153,7 +153,7 @@ func TestLocalDCDiscovery(t *testing.T) {
 	err := r.clusterDiscoveryAttempt(ctx, nil)
 	require.NoError(t, err)
 
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		conn, _ := r.connections().GetConnection(ctx)
 		require.Equal(t, "b:234", conn.Endpoint().Address())
 		require.Equal(t, "b", conn.Endpoint().Location())

--- a/internal/bind/params.go
+++ b/internal/bind/params.go
@@ -28,8 +28,8 @@ var (
 )
 
 var (
-	uuidType    = reflect.TypeOf(uuid.UUID{})
-	uuidPtrType = reflect.TypeOf((*uuid.UUID)(nil))
+	uuidType    = reflect.TypeFor[uuid.UUID]()
+	uuidPtrType = reflect.TypeFor[*uuid.UUID]()
 )
 
 func asUUID(v any) (value.Value, bool) {

--- a/internal/cmd/gtrace/writer.go
+++ b/internal/cmd/gtrace/writer.go
@@ -173,8 +173,8 @@ func (w *Writer) typeImports(dst []dep, t types.Type) []dep {
 }
 
 func forEachField(s *types.Struct, fn func(*types.Var)) {
-	for i := 0; i < s.NumFields(); i++ {
-		fn(s.Field(i))
+	for field := range s.Fields() {
+		fn(field)
 	}
 }
 
@@ -638,8 +638,7 @@ func (w *Writer) constructStruct(n types.Type, s *types.Struct, vars []string) (
 	p := w.declare("p")
 	// maybe skip pointers from flattening to not allocate anyhing during trace.
 	w.line(`var `, p, ` `, w.typeString(n))
-	for i := 0; i < s.NumFields(); i++ {
-		v := s.Field(i)
+	for v := range s.Fields() {
 		if !v.Exported() {
 			continue
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,7 +18,7 @@ type Common struct {
 
 	disableSessionBalancer bool
 
-	panicCallback func(e interface{})
+	panicCallback func(e any)
 }
 
 // AutoRetry defines auto-retry flag
@@ -28,7 +28,7 @@ func (c *Common) AutoRetry() bool {
 
 // PanicCallback returns user-defined panic callback
 // If nil - panic callback not defined
-func (c *Common) PanicCallback() func(e interface{}) {
+func (c *Common) PanicCallback() func(e any) {
 	return c.panicCallback
 }
 
@@ -87,7 +87,7 @@ func SetOperationCancelAfter(c *Common, operationCancelAfter time.Duration) {
 }
 
 // SetPanicCallback applies panic callback to config
-func SetPanicCallback(c *Common, panicCallback func(e interface{})) {
+func SetPanicCallback(c *Common, panicCallback func(e any)) {
 	c.panicCallback = panicCallback
 }
 

--- a/internal/conn/conn.go
+++ b/internal/conn/conn.go
@@ -405,8 +405,8 @@ func invoke(
 func (c *conn) Invoke(
 	ctx context.Context,
 	method string,
-	req interface{},
-	res interface{},
+	req any,
+	res any,
 	opts ...grpc.CallOption,
 ) (err error) {
 	var (

--- a/internal/conn/grpc_client_stream.go
+++ b/internal/conn/grpc_client_stream.go
@@ -79,7 +79,7 @@ func (s *grpcClientStream) CloseSend() (err error) {
 	return nil
 }
 
-func (s *grpcClientStream) SendMsg(m interface{}) (err error) {
+func (s *grpcClientStream) SendMsg(m any) (err error) {
 	var (
 		ctx    = s.streamCtx
 		onDone = trace.DriverOnConnStreamSendMsg(s.parentConn.config.Trace(), &ctx,
@@ -127,7 +127,7 @@ func (s *grpcClientStream) finish(err error) {
 	s.streamCancel()
 }
 
-func (s *grpcClientStream) RecvMsg(m interface{}) (err error) {
+func (s *grpcClientStream) RecvMsg(m any) (err error) {
 	var (
 		ctx    = s.streamCtx
 		onDone = trace.DriverOnConnStreamRecvMsg(s.parentConn.config.Trace(), &ctx,

--- a/internal/conn/grpc_client_stream_test.go
+++ b/internal/conn/grpc_client_stream_test.go
@@ -376,7 +376,7 @@ func TestGrpcClientStream_RecvMsg(t *testing.T) {
 		mockStream := mock.NewMockClientStream(ctrl)
 
 		msg := &Ydb_Query.ExecuteQueryResponsePart{}
-		mockStream.EXPECT().RecvMsg(msg).DoAndReturn(func(m interface{}) error {
+		mockStream.EXPECT().RecvMsg(msg).DoAndReturn(func(m any) error {
 			resp := m.(*Ydb_Query.ExecuteQueryResponsePart)
 			resp.Status = Ydb.StatusIds_SUCCESS
 
@@ -554,7 +554,7 @@ func TestGrpcClientStream_RecvMsg(t *testing.T) {
 		mockStream := mock.NewMockClientStream(ctrl)
 
 		msg := &Ydb_Query.ExecuteQueryResponsePart{}
-		mockStream.EXPECT().RecvMsg(msg).DoAndReturn(func(m interface{}) error {
+		mockStream.EXPECT().RecvMsg(msg).DoAndReturn(func(m any) error {
 			resp := m.(*Ydb_Query.ExecuteQueryResponsePart)
 			resp.Status = Ydb.StatusIds_UNAVAILABLE
 
@@ -587,7 +587,7 @@ func TestGrpcClientStream_RecvMsg(t *testing.T) {
 		mockStream := mock.NewMockClientStream(ctrl)
 
 		msg := &Ydb_Query.ExecuteQueryResponsePart{}
-		mockStream.EXPECT().RecvMsg(msg).DoAndReturn(func(m interface{}) error {
+		mockStream.EXPECT().RecvMsg(msg).DoAndReturn(func(m any) error {
 			resp := m.(*Ydb_Query.ExecuteQueryResponsePart)
 			resp.Status = Ydb.StatusIds_UNAVAILABLE
 

--- a/internal/conn/middleware.go
+++ b/internal/conn/middleware.go
@@ -9,7 +9,7 @@ import (
 var _ grpc.ClientConnInterface = (*middleware)(nil)
 
 type (
-	invoker  func(context.Context, string, interface{}, interface{}, ...grpc.CallOption) error
+	invoker  func(context.Context, string, any, any, ...grpc.CallOption) error
 	streamer func(context.Context, *grpc.StreamDesc, string, ...grpc.CallOption) (grpc.ClientStream, error)
 )
 
@@ -19,7 +19,7 @@ type middleware struct {
 }
 
 func (m *middleware) Invoke(
-	ctx context.Context, method string, args interface{}, reply interface{}, opts ...grpc.CallOption,
+	ctx context.Context, method string, args any, reply any, opts ...grpc.CallOption,
 ) error {
 	return m.invoke(ctx, method, args, reply, opts...)
 }
@@ -35,7 +35,7 @@ func WithContextModifier(
 	modifyCtx func(ctx context.Context) context.Context,
 ) grpc.ClientConnInterface {
 	return &middleware{
-		invoke: func(ctx context.Context, method string, args interface{}, reply interface{}, opts ...grpc.CallOption) error {
+		invoke: func(ctx context.Context, method string, args any, reply any, opts ...grpc.CallOption) error {
 			ctx = modifyCtx(ctx)
 
 			return cc.Invoke(ctx, method, args, reply, opts...)
@@ -52,7 +52,7 @@ func WithContextModifier(
 
 func WithAppendOptions(cc grpc.ClientConnInterface, appendOpts ...grpc.CallOption) grpc.ClientConnInterface {
 	return &middleware{
-		invoke: func(ctx context.Context, method string, args interface{}, reply interface{}, opts ...grpc.CallOption) error {
+		invoke: func(ctx context.Context, method string, args any, reply any, opts ...grpc.CallOption) error {
 			opts = append(opts, appendOpts...)
 
 			return cc.Invoke(ctx, method, args, reply, opts...)
@@ -72,7 +72,7 @@ func WithBeforeFunc(
 	before func(),
 ) grpc.ClientConnInterface {
 	return &middleware{
-		invoke: func(ctx context.Context, method string, args interface{}, reply interface{}, opts ...grpc.CallOption) error {
+		invoke: func(ctx context.Context, method string, args any, reply any, opts ...grpc.CallOption) error {
 			before()
 
 			return cc.Invoke(ctx, method, args, reply, opts...)

--- a/internal/conn/pool_test.go
+++ b/internal/conn/pool_test.go
@@ -461,7 +461,7 @@ func TestPool_ConnParker(t *testing.T) {
 		go pool.connParker(ctx, ttl, interval)
 
 		// Advance clock multiple times and verify parker is running
-		for i := 0; i < 3; i++ {
+		for range 3 {
 			fakeClock.Advance(interval)
 			fakeClock.Advance(ttl)
 			time.Sleep(50 * time.Millisecond)

--- a/internal/credentials/oauth2.go
+++ b/internal/credentials/oauth2.go
@@ -516,17 +516,17 @@ type OAuth2TokenSourceConfig struct {
 }
 
 func signingMethodNotSupportedError(method string) error {
-	var supported string
+	var supported strings.Builder
 	for i, alg := range GetSupportedOauth2TokenExchangeJwtAlgorithms() {
 		if i != 0 {
-			supported += ", "
+			supported.WriteString(", ")
 		}
-		supported += "\""
-		supported += alg
-		supported += "\""
+		supported.WriteString("\"")
+		supported.WriteString(alg)
+		supported.WriteString("\"")
 	}
 
-	return fmt.Errorf("%w: %q. Supported signing methods are %s", errUnsupportedSigningMethod, method, supported)
+	return fmt.Errorf("%w: %q. Supported signing methods are %s", errUnsupportedSigningMethod, method, supported.String())
 }
 
 func (cfg *OAuth2TokenSourceConfig) applyConfigFixed(tokenSrcType int) (*tokenSourceOption, error) {
@@ -1242,7 +1242,7 @@ func WithKeyID(id string) keyIDOption {
 
 // PrivateKey
 type privateKeyOption struct {
-	key interface{}
+	key any
 }
 
 func (key *privateKeyOption) ApplyJWTTokenSourceOption(s *jwtTokenSource) error {
@@ -1251,7 +1251,7 @@ func (key *privateKeyOption) ApplyJWTTokenSourceOption(s *jwtTokenSource) error 
 	return nil
 }
 
-func WithPrivateKey(key interface{}) *privateKeyOption {
+func WithPrivateKey(key any) *privateKeyOption {
 	return &privateKeyOption{key}
 }
 
@@ -1436,7 +1436,7 @@ func NewJWTTokenSource(opts ...JWTTokenSourceOption) (*jwtTokenSource, error) {
 type jwtTokenSource struct {
 	signingMethod jwt.SigningMethod
 	keyID         string
-	privateKey    interface{} // symmetric key in case of symmetric algorithm
+	privateKey    any // symmetric key in case of symmetric algorithm
 
 	// JWT claims
 	issuer   string
@@ -1454,7 +1454,7 @@ func (s *jwtTokenSource) Token() (Token, error) {
 		err    error
 	)
 	t := jwt.Token{
-		Header: map[string]interface{}{
+		Header: map[string]any{
 			"typ": "JWT",
 			"alg": s.signingMethod.Alg(),
 			"kid": s.keyID,

--- a/internal/credentials/oauth2_test.go
+++ b/internal/credentials/oauth2_test.go
@@ -501,7 +501,7 @@ func TestJWTTokenSource(t *testing.T) {
 
 	for _, method := range methods {
 		for _, binary := range binaryOpts {
-			var publicKey interface{}
+			var publicKey any
 			var src TokenSource
 			var err error
 
@@ -563,7 +563,7 @@ func TestJWTTokenSource(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			getPublicKey := func(*jwt.Token) (interface{}, error) {
+			getPublicKey := func(*jwt.Token) (any, error) {
 				return publicKey, nil
 			}
 
@@ -626,7 +626,7 @@ func TestJWTTokenSourceReadPrivateKeyFromFile(t *testing.T) {
 			defer os.Remove(f.Name())
 			defer f.Close()
 
-			var publicKey interface{}
+			var publicKey any
 			var src TokenSource
 
 			//nolint:nestif
@@ -743,7 +743,7 @@ func TestJWTTokenSourceReadPrivateKeyFromFile(t *testing.T) {
 			require.NoError(t, err)
 
 			// parse token
-			getPublicKey := func(*jwt.Token) (interface{}, error) {
+			getPublicKey := func(*jwt.Token) (any, error) {
 				return publicKey, nil
 			}
 

--- a/internal/grpcwrapper/rawtopic/rawtopiccommon/codec.go
+++ b/internal/grpcwrapper/rawtopic/rawtopiccommon/codec.go
@@ -1,6 +1,8 @@
 package rawtopiccommon
 
 import (
+	"slices"
+
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Topic"
 )
 
@@ -8,7 +10,7 @@ import (
 type Codec int32
 
 const (
-	CodecUNSPECIFIED Codec = iota
+	CodecUNSPECIFIED Codec = Codec(Ydb_Topic.Codec_CODEC_UNSPECIFIED)
 	CodecRaw               = Codec(Ydb_Topic.Codec_CODEC_RAW)
 	CodecGzip              = Codec(Ydb_Topic.Codec_CODEC_GZIP)
 	CodecLzop              = Codec(Ydb_Topic.Codec_CODEC_LZOP)
@@ -48,13 +50,7 @@ func (c *SupportedCodecs) AllowedByCodecsList(need Codec) bool {
 }
 
 func (c *SupportedCodecs) Contains(need Codec) bool {
-	for _, v := range *c {
-		if v == need {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(*c, need)
 }
 
 func (c *SupportedCodecs) Clone() SupportedCodecs {

--- a/internal/grpcwrapper/rawtopic/rawtopicwriter/messages.go
+++ b/internal/grpcwrapper/rawtopic/rawtopicwriter/messages.go
@@ -344,7 +344,7 @@ type MessageWriteStatus struct {
 	SkippedReason WriteStatusSkipReason
 }
 
-func (s *MessageWriteStatus) fromProto(status interface{}) error {
+func (s *MessageWriteStatus) fromProto(status any) error {
 	switch v := status.(type) {
 	case *Ydb_Topic.StreamWriteMessage_WriteResponse_WriteAck_Written_:
 		s.Type = WriteStatusTypeWritten

--- a/internal/grpcwrapper/rawtopic/rawtopicwriter/streamwriter.go
+++ b/internal/grpcwrapper/rawtopic/rawtopicwriter/streamwriter.go
@@ -27,7 +27,7 @@ type GrpcStream interface {
 }
 
 type StreamWriter struct {
-	readCounter int32
+	readCounter atomic.Int32
 
 	sendCloseMtx sync.Mutex
 	Stream       GrpcStream
@@ -47,8 +47,8 @@ func (w *StreamWriter) Endpoint() endpoint.Endpoint { return w.PeerEndpoint }
 
 //nolint:funlen
 func (w *StreamWriter) Recv() (ServerMessage, error) {
-	readCnt := atomic.AddInt32(&w.readCounter, 1)
-	defer atomic.AddInt32(&w.readCounter, -1)
+	readCnt := w.readCounter.Add(1)
+	defer w.readCounter.Add(-1)
 
 	if readCnt != 1 {
 		return nil, xerrors.WithStackTrace(errConcurencyReadDenied)

--- a/internal/kv/field.go
+++ b/internal/kv/field.go
@@ -37,7 +37,7 @@ type KeyValue struct {
 
 	vint int64
 	vstr string
-	vany interface{}
+	vany any
 }
 
 func (f KeyValue) Type() FieldType {
@@ -112,7 +112,7 @@ func (f KeyValue) ErrorValue() error {
 }
 
 // AnyValue is a value getter for fields with AnyType type
-func (f KeyValue) AnyValue() interface{} {
+func (f KeyValue) AnyValue() any {
 	switch f.ftype {
 	case AnyType:
 		return f.vany
@@ -282,7 +282,7 @@ func Error(value error) KeyValue {
 }
 
 // Any constructs untyped KeyValue.
-func Any(key string, value interface{}) KeyValue {
+func Any(key string, value any) KeyValue {
 	return KeyValue{
 		ftype: AnyType,
 		key:   key,

--- a/internal/kv/field_test.go
+++ b/internal/kv/field_test.go
@@ -66,7 +66,7 @@ func TestField_AnyValue(t *testing.T) {
 	for _, tt := range []struct {
 		name string
 		f    KeyValue
-		want interface{}
+		want any
 	}{
 		{name: "int", f: Int("any", 1), want: 1},
 		{name: "int64", f: Int64("any", 9223372036854775807), want: int64(9223372036854775807)},

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -3,6 +3,7 @@ package meta
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"strconv"
 	"strings"
@@ -62,9 +63,7 @@ func WithBuildInfo(frameworkName string, frameworkVersion string) Option {
 
 		if frameworks := m.buildInfo.Load().frameworks; len(frameworks) > 0 {
 			buildInfo.frameworks = make(map[string]string, len(frameworks)+1)
-			for frameworkName, frameworkVersion := range frameworks {
-				buildInfo.frameworks[frameworkName] = frameworkVersion
-			}
+			maps.Copy(buildInfo.frameworks, frameworks)
 			buildInfo.frameworks[frameworkName] = frameworkVersion
 		} else {
 			buildInfo.frameworks = map[string]string{

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -379,9 +379,9 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 				}),
 			)
 			require.EqualValues(t, 1, p.config.limit)
-			var lambdaCounter int64
+			var lambdaCounter atomic.Int64
 			err := p.With(rootCtx, func(ctx context.Context, item *testItem) error {
-				if atomic.AddInt64(&lambdaCounter, 1) < 10 {
+				if lambdaCounter.Add(1) < 10 {
 					return xerrors.Retryable(errors.New("test"))
 				}
 
@@ -391,11 +391,11 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 			require.EqualValues(t, 2, newCounter)
 		})
 		t.Run("WithCreateItemFunc", func(t *testing.T) {
-			var newCounter int64
+			var newCounter atomic.Int64
 			p := New(rootCtx,
 				WithLimit[*testItem, testItem](1),
 				WithCreateItemFunc(func(context.Context) (*testItem, error) {
-					atomic.AddInt64(&newCounter, 1)
+					newCounter.Add(1)
 					var v testItem
 
 					return &v, nil
@@ -406,7 +406,7 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 				return nil
 			})
 			require.NoError(t, err)
-			require.EqualValues(t, p.config.limit, atomic.LoadInt64(&newCounter))
+			require.EqualValues(t, p.config.limit, newCounter.Load())
 		})
 	})
 	t.Run("Close", func(t *testing.T) {
@@ -666,14 +666,14 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 		t.Run("CreateItem", func(t *testing.T) {
 			t.Run("context", func(t *testing.T) {
 				t.Run("Cancelled", func(t *testing.T) {
-					var counter int64
+					var counter atomic.Int64
 					p := New(rootCtx,
 						WithCreateItemTimeout[*testItem, testItem](50*time.Millisecond),
 						WithCloseItemTimeout[*testItem, testItem](50*time.Millisecond),
 						WithCreateItemFunc(func(context.Context) (*testItem, error) {
-							atomic.AddInt64(&counter, 1)
+							counter.Add(1)
 
-							if atomic.LoadInt64(&counter) < 10 {
+							if counter.Load() < 10 {
 								return nil, context.Canceled
 							}
 
@@ -686,17 +686,17 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 						return nil
 					})
 					require.NoError(t, err)
-					require.GreaterOrEqual(t, atomic.LoadInt64(&counter), int64(10))
+					require.GreaterOrEqual(t, counter.Load(), int64(10))
 				})
 				t.Run("DeadlineExceeded", func(t *testing.T) {
-					var counter int64
+					var counter atomic.Int64
 					p := New(rootCtx,
 						WithCreateItemTimeout[*testItem, testItem](50*time.Millisecond),
 						WithCloseItemTimeout[*testItem, testItem](50*time.Millisecond),
 						WithCreateItemFunc(func(context.Context) (*testItem, error) {
-							atomic.AddInt64(&counter, 1)
+							counter.Add(1)
 
-							if atomic.LoadInt64(&counter) < 10 {
+							if counter.Load() < 10 {
 								return nil, context.DeadlineExceeded
 							}
 
@@ -709,18 +709,18 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 						return nil
 					})
 					require.NoError(t, err)
-					require.GreaterOrEqual(t, atomic.LoadInt64(&counter), int64(10))
+					require.GreaterOrEqual(t, counter.Load(), int64(10))
 				})
 			})
 			t.Run("OnTransportError", func(t *testing.T) {
-				var counter int64
+				var counter atomic.Int64
 				p := New(rootCtx,
 					WithCreateItemTimeout[*testItem, testItem](50*time.Millisecond),
 					WithCloseItemTimeout[*testItem, testItem](50*time.Millisecond),
 					WithCreateItemFunc(func(context.Context) (*testItem, error) {
-						atomic.AddInt64(&counter, 1)
+						counter.Add(1)
 
-						if atomic.LoadInt64(&counter) < 10 {
+						if counter.Load() < 10 {
 							return nil, xerrors.Transport(grpcStatus.Error(grpcCodes.Unavailable, ""))
 						}
 
@@ -733,17 +733,17 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 					return nil
 				})
 				require.NoError(t, err)
-				require.GreaterOrEqual(t, atomic.LoadInt64(&counter), int64(10))
+				require.GreaterOrEqual(t, counter.Load(), int64(10))
 			})
 			t.Run("OnOperationError", func(t *testing.T) {
-				var counter int64
+				var counter atomic.Int64
 				p := New(rootCtx,
 					WithCreateItemTimeout[*testItem, testItem](50*time.Millisecond),
 					WithCloseItemTimeout[*testItem, testItem](50*time.Millisecond),
 					WithCreateItemFunc(func(context.Context) (*testItem, error) {
-						atomic.AddInt64(&counter, 1)
+						counter.Add(1)
 
-						if atomic.LoadInt64(&counter) < 10 {
+						if counter.Load() < 10 {
 							return nil, xerrors.Operation(xerrors.WithStatusCode(Ydb.StatusIds_UNAVAILABLE))
 						}
 
@@ -756,7 +756,7 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 					return nil
 				})
 				require.NoError(t, err)
-				require.GreaterOrEqual(t, atomic.LoadInt64(&counter), int64(10))
+				require.GreaterOrEqual(t, counter.Load(), int64(10))
 			})
 			t.Run("NilNil", func(t *testing.T) {
 				xtest.TestManyTimes(t, func(t testing.TB) {
@@ -880,17 +880,17 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 		t.Run("Close", func(t *testing.T) {
 			xtest.TestManyTimes(t, func(t testing.TB) {
 				var (
-					createCounter int64
-					closeCounter  int64
+					createCounter atomic.Int64
+					closeCounter  atomic.Int64
 				)
 				p := New(rootCtx,
 					WithLimit[*testItem, testItem](1),
 					WithCreateItemFunc(func(context.Context) (*testItem, error) {
-						atomic.AddInt64(&createCounter, 1)
+						createCounter.Add(1)
 
 						v := &testItem{
 							onClose: func() error {
-								atomic.AddInt64(&closeCounter, 1)
+								closeCounter.Add(1)
 
 								return nil
 							},
@@ -903,10 +903,10 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 					return nil
 				})
 				require.NoError(t, err)
-				require.GreaterOrEqual(t, atomic.LoadInt64(&createCounter), atomic.LoadInt64(&closeCounter))
+				require.GreaterOrEqual(t, createCounter.Load(), closeCounter.Load())
 				err = p.Close(rootCtx)
 				require.NoError(t, err)
-				require.EqualValues(t, atomic.LoadInt64(&createCounter), atomic.LoadInt64(&closeCounter))
+				require.EqualValues(t, createCounter.Load(), closeCounter.Load())
 			})
 		})
 		t.Run("IsAlive", func(t *testing.T) {
@@ -1252,12 +1252,12 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 	})
 	t.Run("PreferredNodeID", func(t *testing.T) {
 		t.Run("AlwaysSatisfiedWhenIdleAvailable", func(t *testing.T) {
-			var createdCount int32
+			var createdCount atomic.Int32
 
 			p := New[*testItem, testItem](rootCtx,
 				WithLimit[*testItem, testItem](3),
 				WithCreateItemFunc(func(ctx context.Context) (*testItem, error) {
-					idx := atomic.AddInt32(&createdCount, 1) - 1
+					idx := createdCount.Add(1) - 1
 
 					return &testItem{
 						v: idx,

--- a/internal/query/config/options.go
+++ b/internal/query/config/options.go
@@ -52,11 +52,7 @@ func WithSessionPoolSessionUsageLimit[T interface{ uint64 | time.Duration }](lim
 // If sessionCreateTimeout is less than or equal to zero then no used timeout on create session request
 func WithSessionCreateTimeout(createSessionTimeout time.Duration) Option {
 	return func(c *Config) {
-		if createSessionTimeout > 0 {
-			c.sessionCreateTimeout = createSessionTimeout
-		} else {
-			c.sessionCreateTimeout = 0
-		}
+		c.sessionCreateTimeout = max(createSessionTimeout, 0)
 	}
 }
 

--- a/internal/query/result/result.go
+++ b/internal/query/result/result.go
@@ -37,8 +37,8 @@ type (
 	Row interface {
 		Values() []value.Value
 
-		Scan(dst ...interface{}) error
+		Scan(dst ...any) error
 		ScanNamed(dst ...scanner.NamedDestination) error
-		ScanStruct(dst interface{}, opts ...scanner.ScanStructOption) error
+		ScanStruct(dst any, opts ...scanner.ScanStructOption) error
 	}
 )

--- a/internal/query/row.go
+++ b/internal/query/row.go
@@ -18,13 +18,13 @@ type Row struct {
 	data *scanner.Data
 
 	indexedScanner interface {
-		Scan(dst ...interface{}) error
+		Scan(dst ...any) error
 	}
 	namedScanner interface {
 		ScanNamed(dst ...scanner.NamedDestination) error
 	}
 	structScanner interface {
-		ScanStruct(dst interface{}, opts ...scanner.ScanStructOption) error
+		ScanStruct(dst any, opts ...scanner.ScanStructOption) error
 	}
 }
 
@@ -43,7 +43,7 @@ func NewRow(columns []*Ydb.Column, v *Ydb.Value) *Row {
 	}
 }
 
-func (r Row) Scan(dst ...interface{}) error {
+func (r Row) Scan(dst ...any) error {
 	err := r.indexedScanner.Scan(dst...)
 	if err != nil {
 		return xerrors.WithStackTrace(
@@ -67,7 +67,7 @@ func (r Row) ScanNamed(dst ...scanner.NamedDestination) error {
 	return nil
 }
 
-func (r Row) ScanStruct(dst interface{}, opts ...scanner.ScanStructOption) error {
+func (r Row) ScanStruct(dst any, opts ...scanner.ScanStructOption) error {
 	err := r.structScanner.ScanStruct(dst, opts...)
 	if err != nil {
 		return xerrors.WithStackTrace(

--- a/internal/query/row_test.go
+++ b/internal/query/row_test.go
@@ -21,7 +21,7 @@ type testScanner struct {
 	err error
 }
 
-func (s testScanner) Scan(dst ...interface{}) error {
+func (s testScanner) Scan(dst ...any) error {
 	return s.err
 }
 
@@ -29,7 +29,7 @@ func (s testScanner) ScanNamed(dst ...scanner.NamedDestination) error {
 	return s.err
 }
 
-func (s testScanner) ScanStruct(dst interface{}, opts ...scanner.ScanStructOption) error {
+func (s testScanner) ScanStruct(dst any, opts ...scanner.ScanStructOption) error {
 	return s.err
 }
 
@@ -112,7 +112,7 @@ func generateData(count int) []*Row {
 		},
 	}}
 	rows := make([]*Row, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		rows[i] = NewRow(columns, &Ydb.Value{
 			Items: []*Ydb.Value{{
 				Value: &Ydb.Value_Uint64Value{

--- a/internal/query/scanner/indexed.go
+++ b/internal/query/scanner/indexed.go
@@ -17,7 +17,7 @@ func Indexed(data *Data) IndexedScanner {
 	}
 }
 
-func (s IndexedScanner) Scan(dst ...interface{}) (err error) {
+func (s IndexedScanner) Scan(dst ...any) (err error) {
 	if len(dst) != len(s.data.columns) {
 		return xerrors.WithStackTrace(
 			fmt.Errorf("%w: %d != %d",

--- a/internal/query/scanner/indexed_test.go
+++ b/internal/query/scanner/indexed_test.go
@@ -15,8 +15,8 @@ func TestIndexed(t *testing.T) {
 	for _, tt := range []struct {
 		name string
 		s    IndexedScanner
-		dst  [][]interface{}
-		exp  [][]interface{}
+		dst  [][]any
+		exp  [][]any
 	}{
 		{
 			name: "Ydb.Type_UTF8",
@@ -38,11 +38,11 @@ func TestIndexed(t *testing.T) {
 					},
 				},
 			)),
-			dst: [][]interface{}{
+			dst: [][]any{
 				{func(v string) *string { return &v }("")},
 				{func(v []byte) *[]byte { return &v }([]byte(""))},
 			},
-			exp: [][]interface{}{
+			exp: [][]any{
 				{func(v string) *string { return &v }("test")},
 				{func(v []byte) *[]byte { return &v }([]byte("test"))},
 			},
@@ -67,11 +67,11 @@ func TestIndexed(t *testing.T) {
 					},
 				},
 			)),
-			dst: [][]interface{}{
+			dst: [][]any{
 				{func(v string) *string { return &v }("")},
 				{func(v []byte) *[]byte { return &v }([]byte(""))},
 			},
-			exp: [][]interface{}{
+			exp: [][]any{
 				{func(v string) *string { return &v }("test")},
 				{func(v []byte) *[]byte { return &v }([]byte("test"))},
 			},
@@ -96,10 +96,10 @@ func TestIndexed(t *testing.T) {
 					},
 				},
 			)),
-			dst: [][]interface{}{
+			dst: [][]any{
 				{func(v uint64) *uint64 { return &v }(0)},
 			},
-			exp: [][]interface{}{
+			exp: [][]any{
 				{func(v uint64) *uint64 { return &v }(123)},
 			},
 		},
@@ -123,10 +123,10 @@ func TestIndexed(t *testing.T) {
 					},
 				},
 			)),
-			dst: [][]interface{}{
+			dst: [][]any{
 				{func(v int64) *int64 { return &v }(0)},
 			},
-			exp: [][]interface{}{
+			exp: [][]any{
 				{func(v int64) *int64 { return &v }(123)},
 			},
 		},
@@ -150,13 +150,13 @@ func TestIndexed(t *testing.T) {
 					},
 				},
 			)),
-			dst: [][]interface{}{
+			dst: [][]any{
 				{func(v uint64) *uint64 { return &v }(0)},
 				{func(v int64) *int64 { return &v }(0)},
 				{func(v uint32) *uint32 { return &v }(0)},
 				{func(v float64) *float64 { return &v }(0)},
 			},
-			exp: [][]interface{}{
+			exp: [][]any{
 				{func(v uint64) *uint64 { return &v }(123)},
 				{func(v int64) *int64 { return &v }(123)},
 				{func(v uint32) *uint32 { return &v }(123)},
@@ -183,14 +183,14 @@ func TestIndexed(t *testing.T) {
 					},
 				},
 			)),
-			dst: [][]interface{}{
+			dst: [][]any{
 				{func(v int64) *int64 { return &v }(0)},
 				{func(v int32) *int32 { return &v }(0)},
 				{func(v int) *int { return &v }(0)},
 				{func(v float32) *float32 { return &v }(0)},
 				{func(v float64) *float64 { return &v }(0)},
 			},
-			exp: [][]interface{}{
+			exp: [][]any{
 				{func(v int64) *int64 { return &v }(123)},
 				{func(v int32) *int32 { return &v }(123)},
 				{func(v int) *int { return &v }(123)},
@@ -218,7 +218,7 @@ func TestIndexed(t *testing.T) {
 					},
 				},
 			)),
-			dst: [][]interface{}{
+			dst: [][]any{
 				{func(v uint64) *uint64 { return &v }(0)},
 				{func(v int64) *int64 { return &v }(0)},
 				{func(v uint32) *uint32 { return &v }(0)},
@@ -226,7 +226,7 @@ func TestIndexed(t *testing.T) {
 				{func(v float32) *float32 { return &v }(0)},
 				{func(v float64) *float64 { return &v }(0)},
 			},
-			exp: [][]interface{}{
+			exp: [][]any{
 				{func(v uint64) *uint64 { return &v }(123)},
 				{func(v int64) *int64 { return &v }(123)},
 				{func(v uint32) *uint32 { return &v }(123)},
@@ -255,13 +255,13 @@ func TestIndexed(t *testing.T) {
 					},
 				},
 			)),
-			dst: [][]interface{}{
+			dst: [][]any{
 				{func(v int64) *int64 { return &v }(0)},
 				{func(v int32) *int32 { return &v }(0)},
 				{func(v float32) *float32 { return &v }(0)},
 				{func(v float64) *float64 { return &v }(0)},
 			},
-			exp: [][]interface{}{
+			exp: [][]any{
 				{func(v int64) *int64 { return &v }(123)},
 				{func(v int32) *int32 { return &v }(123)},
 				{func(v float32) *float32 { return &v }(123)},
@@ -288,7 +288,7 @@ func TestIndexed(t *testing.T) {
 					},
 				},
 			)),
-			dst: [][]interface{}{
+			dst: [][]any{
 				{func(v uint64) *uint64 { return &v }(0)},
 				{func(v int64) *int64 { return &v }(0)},
 				{func(v uint32) *uint32 { return &v }(0)},
@@ -297,7 +297,7 @@ func TestIndexed(t *testing.T) {
 				{func(v float32) *float32 { return &v }(0)},
 				{func(v float64) *float64 { return &v }(0)},
 			},
-			exp: [][]interface{}{
+			exp: [][]any{
 				{func(v uint64) *uint64 { return &v }(123)},
 				{func(v int64) *int64 { return &v }(123)},
 				{func(v uint32) *uint32 { return &v }(123)},
@@ -327,14 +327,14 @@ func TestIndexed(t *testing.T) {
 					},
 				},
 			)),
-			dst: [][]interface{}{
+			dst: [][]any{
 				{func(v int64) *int64 { return &v }(0)},
 				{func(v int32) *int32 { return &v }(0)},
 				{func(v int8) *int8 { return &v }(0)},
 				{func(v float32) *float32 { return &v }(0)},
 				{func(v float64) *float64 { return &v }(0)},
 			},
-			exp: [][]interface{}{
+			exp: [][]any{
 				{func(v int64) *int64 { return &v }(123)},
 				{func(v int32) *int32 { return &v }(123)},
 				{func(v int8) *int8 { return &v }(123)},
@@ -362,10 +362,10 @@ func TestIndexed(t *testing.T) {
 					},
 				},
 			)),
-			dst: [][]interface{}{
+			dst: [][]any{
 				{func(v bool) *bool { return &v }(false)},
 			},
-			exp: [][]interface{}{
+			exp: [][]any{
 				{func(v bool) *bool { return &v }(true)},
 			},
 		},
@@ -389,13 +389,13 @@ func TestIndexed(t *testing.T) {
 					},
 				},
 			)),
-			dst: [][]interface{}{
+			dst: [][]any{
 				{func(v uint64) *uint64 { return &v }(0)},
 				{func(v int64) *int64 { return &v }(0)},
 				{func(v int32) *int32 { return &v }(0)},
 				{func(v time.Time) *time.Time { return &v }(time.Unix(0, 0))},
 			},
-			exp: [][]interface{}{
+			exp: [][]any{
 				{func(v uint64) *uint64 { return &v }(100500)},
 				{func(v int64) *int64 { return &v }(100500)},
 				{func(v int32) *int32 { return &v }(100500)},
@@ -422,13 +422,13 @@ func TestIndexed(t *testing.T) {
 					},
 				},
 			)),
-			dst: [][]interface{}{
+			dst: [][]any{
 				{func(v uint64) *uint64 { return &v }(0)},
 				{func(v int64) *int64 { return &v }(0)},
 				{func(v uint32) *uint32 { return &v }(0)},
 				{func(v time.Time) *time.Time { return &v }(time.Unix(0, 0))},
 			},
-			exp: [][]interface{}{
+			exp: [][]any{
 				{func(v uint64) *uint64 { return &v }(100500)},
 				{func(v int64) *int64 { return &v }(100500)},
 				{func(v uint32) *uint32 { return &v }(100500)},
@@ -455,11 +455,11 @@ func TestIndexed(t *testing.T) {
 					},
 				},
 			)),
-			dst: [][]interface{}{
+			dst: [][]any{
 				{func(v uint64) *uint64 { return &v }(0)},
 				{func(v time.Time) *time.Time { return &v }(time.Unix(0, 0))},
 			},
-			exp: [][]interface{}{
+			exp: [][]any{
 				{func(v uint64) *uint64 { return &v }(12345678987654321)},
 				{func(v time.Time) *time.Time { return &v }(time.Unix(12345678987, 654321000))},
 			},
@@ -484,11 +484,11 @@ func TestIndexed(t *testing.T) {
 					},
 				},
 			)),
-			dst: [][]interface{}{
+			dst: [][]any{
 				{func(v int64) *int64 { return &v }(0)},
 				{func(v time.Duration) *time.Duration { return &v }(time.Duration(0))},
 			},
-			exp: [][]interface{}{
+			exp: [][]any{
 				{func(v int64) *int64 { return &v }(100500)},
 				{func(v time.Duration) *time.Duration { return &v }(time.Duration(100500000))},
 			},

--- a/internal/query/scanner/named.go
+++ b/internal/query/scanner/named.go
@@ -14,11 +14,11 @@ type (
 	}
 	namedDestination struct {
 		name string
-		ref  interface{}
+		ref  any
 	}
 	NamedDestination interface {
 		Name() string
-		Ref() interface{}
+		Ref() any
 	}
 )
 
@@ -26,11 +26,11 @@ func (dst namedDestination) Name() string {
 	return dst.name
 }
 
-func (dst namedDestination) Ref() interface{} {
+func (dst namedDestination) Ref() any {
 	return dst.ref
 }
 
-func NamedRef(columnName string, destinationValueReference interface{}) (dst namedDestination) {
+func NamedRef(columnName string, destinationValueReference any) (dst namedDestination) {
 	if columnName == "" {
 		panic("columnName must be not empty")
 	}

--- a/internal/query/scanner/named_test.go
+++ b/internal/query/scanner/named_test.go
@@ -15,8 +15,8 @@ func TestNamed(t *testing.T) {
 	for _, tt := range []struct {
 		name string
 		s    NamedScanner
-		dst  [][]interface{}
-		exp  [][]interface{}
+		dst  [][]any
+		exp  [][]any
 	}{
 		{
 			name: "Ydb.Type_UTF8",
@@ -39,11 +39,11 @@ func TestNamed(t *testing.T) {
 					},
 				},
 			)),
-			dst: [][]interface{}{
+			dst: [][]any{
 				{func(v string) *string { return &v }("")},
 				{func(v []byte) *[]byte { return &v }([]byte(""))},
 			},
-			exp: [][]interface{}{
+			exp: [][]any{
 				{func(v string) *string { return &v }("test")},
 				{func(v []byte) *[]byte { return &v }([]byte("test"))},
 			},
@@ -69,11 +69,11 @@ func TestNamed(t *testing.T) {
 					},
 				},
 			)),
-			dst: [][]interface{}{
+			dst: [][]any{
 				{func(v string) *string { return &v }("")},
 				{func(v []byte) *[]byte { return &v }([]byte(""))},
 			},
-			exp: [][]interface{}{
+			exp: [][]any{
 				{func(v string) *string { return &v }("test")},
 				{func(v []byte) *[]byte { return &v }([]byte("test"))},
 			},
@@ -99,10 +99,10 @@ func TestNamed(t *testing.T) {
 					},
 				},
 			)),
-			dst: [][]interface{}{
+			dst: [][]any{
 				{func(v uint64) *uint64 { return &v }(0)},
 			},
-			exp: [][]interface{}{
+			exp: [][]any{
 				{func(v uint64) *uint64 { return &v }(123)},
 			},
 		},
@@ -127,10 +127,10 @@ func TestNamed(t *testing.T) {
 					},
 				},
 			)),
-			dst: [][]interface{}{
+			dst: [][]any{
 				{func(v int64) *int64 { return &v }(0)},
 			},
-			exp: [][]interface{}{
+			exp: [][]any{
 				{func(v int64) *int64 { return &v }(123)},
 			},
 		},
@@ -155,13 +155,13 @@ func TestNamed(t *testing.T) {
 					},
 				},
 			)),
-			dst: [][]interface{}{
+			dst: [][]any{
 				{func(v uint64) *uint64 { return &v }(0)},
 				{func(v int64) *int64 { return &v }(0)},
 				{func(v uint32) *uint32 { return &v }(0)},
 				{func(v float64) *float64 { return &v }(0)},
 			},
-			exp: [][]interface{}{
+			exp: [][]any{
 				{func(v uint64) *uint64 { return &v }(123)},
 				{func(v int64) *int64 { return &v }(123)},
 				{func(v uint32) *uint32 { return &v }(123)},
@@ -189,14 +189,14 @@ func TestNamed(t *testing.T) {
 					},
 				},
 			)),
-			dst: [][]interface{}{
+			dst: [][]any{
 				{func(v int64) *int64 { return &v }(0)},
 				{func(v int32) *int32 { return &v }(0)},
 				{func(v int) *int { return &v }(0)},
 				{func(v float32) *float32 { return &v }(0)},
 				{func(v float64) *float64 { return &v }(0)},
 			},
-			exp: [][]interface{}{
+			exp: [][]any{
 				{func(v int64) *int64 { return &v }(123)},
 				{func(v int32) *int32 { return &v }(123)},
 				{func(v int) *int { return &v }(123)},
@@ -225,7 +225,7 @@ func TestNamed(t *testing.T) {
 					},
 				},
 			)),
-			dst: [][]interface{}{
+			dst: [][]any{
 				{func(v uint64) *uint64 { return &v }(0)},
 				{func(v int64) *int64 { return &v }(0)},
 				{func(v uint32) *uint32 { return &v }(0)},
@@ -233,7 +233,7 @@ func TestNamed(t *testing.T) {
 				{func(v float32) *float32 { return &v }(0)},
 				{func(v float64) *float64 { return &v }(0)},
 			},
-			exp: [][]interface{}{
+			exp: [][]any{
 				{func(v uint64) *uint64 { return &v }(123)},
 				{func(v int64) *int64 { return &v }(123)},
 				{func(v uint32) *uint32 { return &v }(123)},
@@ -263,13 +263,13 @@ func TestNamed(t *testing.T) {
 					},
 				},
 			)),
-			dst: [][]interface{}{
+			dst: [][]any{
 				{func(v int64) *int64 { return &v }(0)},
 				{func(v int32) *int32 { return &v }(0)},
 				{func(v float32) *float32 { return &v }(0)},
 				{func(v float64) *float64 { return &v }(0)},
 			},
-			exp: [][]interface{}{
+			exp: [][]any{
 				{func(v int64) *int64 { return &v }(123)},
 				{func(v int32) *int32 { return &v }(123)},
 				{func(v float32) *float32 { return &v }(123)},
@@ -297,7 +297,7 @@ func TestNamed(t *testing.T) {
 					},
 				},
 			)),
-			dst: [][]interface{}{
+			dst: [][]any{
 				{func(v uint64) *uint64 { return &v }(0)},
 				{func(v int64) *int64 { return &v }(0)},
 				{func(v uint32) *uint32 { return &v }(0)},
@@ -306,7 +306,7 @@ func TestNamed(t *testing.T) {
 				{func(v float32) *float32 { return &v }(0)},
 				{func(v float64) *float64 { return &v }(0)},
 			},
-			exp: [][]interface{}{
+			exp: [][]any{
 				{func(v uint64) *uint64 { return &v }(123)},
 				{func(v int64) *int64 { return &v }(123)},
 				{func(v uint32) *uint32 { return &v }(123)},
@@ -337,14 +337,14 @@ func TestNamed(t *testing.T) {
 					},
 				},
 			)),
-			dst: [][]interface{}{
+			dst: [][]any{
 				{func(v int64) *int64 { return &v }(0)},
 				{func(v int32) *int32 { return &v }(0)},
 				{func(v int8) *int8 { return &v }(0)},
 				{func(v float32) *float32 { return &v }(0)},
 				{func(v float64) *float64 { return &v }(0)},
 			},
-			exp: [][]interface{}{
+			exp: [][]any{
 				{func(v int64) *int64 { return &v }(123)},
 				{func(v int32) *int32 { return &v }(123)},
 				{func(v int8) *int8 { return &v }(123)},
@@ -373,10 +373,10 @@ func TestNamed(t *testing.T) {
 					},
 				},
 			)),
-			dst: [][]interface{}{
+			dst: [][]any{
 				{func(v bool) *bool { return &v }(false)},
 			},
-			exp: [][]interface{}{
+			exp: [][]any{
 				{func(v bool) *bool { return &v }(true)},
 			},
 		},
@@ -401,13 +401,13 @@ func TestNamed(t *testing.T) {
 					},
 				},
 			)),
-			dst: [][]interface{}{
+			dst: [][]any{
 				{func(v uint64) *uint64 { return &v }(0)},
 				{func(v int64) *int64 { return &v }(0)},
 				{func(v int32) *int32 { return &v }(0)},
 				{func(v time.Time) *time.Time { return &v }(time.Unix(0, 0))},
 			},
-			exp: [][]interface{}{
+			exp: [][]any{
 				{func(v uint64) *uint64 { return &v }(100500)},
 				{func(v int64) *int64 { return &v }(100500)},
 				{func(v int32) *int32 { return &v }(100500)},
@@ -435,13 +435,13 @@ func TestNamed(t *testing.T) {
 					},
 				},
 			)),
-			dst: [][]interface{}{
+			dst: [][]any{
 				{func(v uint64) *uint64 { return &v }(0)},
 				{func(v int64) *int64 { return &v }(0)},
 				{func(v uint32) *uint32 { return &v }(0)},
 				{func(v time.Time) *time.Time { return &v }(time.Unix(0, 0))},
 			},
-			exp: [][]interface{}{
+			exp: [][]any{
 				{func(v uint64) *uint64 { return &v }(100500)},
 				{func(v int64) *int64 { return &v }(100500)},
 				{func(v uint32) *uint32 { return &v }(100500)},
@@ -469,11 +469,11 @@ func TestNamed(t *testing.T) {
 					},
 				},
 			)),
-			dst: [][]interface{}{
+			dst: [][]any{
 				{func(v uint64) *uint64 { return &v }(0)},
 				{func(v time.Time) *time.Time { return &v }(time.Unix(0, 0))},
 			},
-			exp: [][]interface{}{
+			exp: [][]any{
 				{func(v uint64) *uint64 { return &v }(12345678987654321)},
 				{func(v time.Time) *time.Time { return &v }(time.Unix(12345678987, 654321000))},
 			},
@@ -499,11 +499,11 @@ func TestNamed(t *testing.T) {
 					},
 				},
 			)),
-			dst: [][]interface{}{
+			dst: [][]any{
 				{func(v int64) *int64 { return &v }(0)},
 				{func(v time.Duration) *time.Duration { return &v }(time.Duration(0))},
 			},
-			exp: [][]interface{}{
+			exp: [][]any{
 				{func(v int64) *int64 { return &v }(100500)},
 				{func(v time.Duration) *time.Duration { return &v }(time.Duration(100500000))},
 			},
@@ -611,7 +611,7 @@ func TestScannerNamedOrdering(t *testing.T) {
 func TestNamedRef(t *testing.T) {
 	for _, tt := range []struct {
 		name  string
-		ref   interface{}
+		ref   any
 		dst   NamedDestination
 		panic bool
 	}{

--- a/internal/query/scanner/struct.go
+++ b/internal/query/scanner/struct.go
@@ -33,7 +33,7 @@ func fieldName(f reflect.StructField, tagName string) string { //nolint:gocritic
 	return f.Name
 }
 
-func (s StructScanner) ScanStruct(dst interface{}, opts ...ScanStructOption) (err error) {
+func (s StructScanner) ScanStruct(dst any, opts ...ScanStructOption) (err error) {
 	settings := scanStructSettings{
 		TagName:                       "sql",
 		AllowMissingColumnsFromSelect: false,

--- a/internal/query/scanner/struct_test.go
+++ b/internal/query/scanner/struct_test.go
@@ -18,7 +18,7 @@ import (
 func TestFieldName(t *testing.T) {
 	for _, tt := range []struct {
 		name string
-		in   interface{}
+		in   any
 		out  string
 	}{
 		{

--- a/internal/query/session_core_test.go
+++ b/internal/query/session_core_test.go
@@ -162,11 +162,8 @@ func TestSessionCoreClose(t *testing.T) {
 		<-stopRecv
 
 		var wg sync.WaitGroup
-		parallel := runtime.GOMAXPROCS(0)
-		if parallel > 10 {
-			parallel = 10
-		}
-		for i := 0; i < parallel; i++ {
+		parallel := min(runtime.GOMAXPROCS(0), 10)
+		for i := range parallel {
 			wg.Add(1)
 			go func(i int) {
 				defer wg.Done()

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -64,7 +64,7 @@ type RawValue interface {
 	//   [16]byte
 	//   uuid
 	//
-	Any() interface{}
+	Any() any
 
 	// Unwrap unwraps current item under scan interpreting it as Optional<Type> types.
 	Unwrap()

--- a/internal/scheme/helpers/check_exists.go
+++ b/internal/scheme/helpers/check_exists.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"slices"
 	"strings"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
@@ -89,10 +90,8 @@ func IsEntryExists(ctx context.Context, c schemeClient, absPath string, entryTyp
 			continue
 		}
 		childrenType := d.Children[i].Type
-		for _, entryType := range entryTypes {
-			if childrenType == entryType {
-				return true, nil
-			}
+		if slices.Contains(entryTypes, childrenType) {
+			return true, nil
 		}
 
 		return false, xerrors.WithStackTrace(fmt.Errorf(

--- a/internal/secret/token.go
+++ b/internal/secret/token.go
@@ -17,7 +17,7 @@ func Token(token string) string {
 	} else {
 		mask.WriteString("****")
 	}
-	mask.WriteString(fmt.Sprintf("(CRC-32c: %08X)", crc32.Checksum([]byte(token), crc32.IEEETable)))
+	fmt.Fprintf(&mask, "(CRC-32c: %08X)", crc32.Checksum([]byte(token), crc32.IEEETable))
 
 	return mask.String()
 }

--- a/internal/table/client_test.go
+++ b/internal/table/client_test.go
@@ -54,7 +54,7 @@ func TestRaceWgClosed(t *testing.T) {
 		wg := sync.WaitGroup{}
 		p := New(ctx,
 			testutil.NewBalancer(testutil.WithInvokeHandlers(testutil.InvokeHandlers{
-				testutil.TableCreateSession: func(interface{}) (proto.Message, error) {
+				testutil.TableCreateSession: func(any) (proto.Message, error) {
 					return &Ydb_Table.CreateSessionResult{
 						SessionId: testutil.SessionID(),
 					}, nil
@@ -131,48 +131,48 @@ func newTestBulkRequest(t *testing.T, itemsLen int) *Ydb_Table.BulkUpsertRequest
 	return req
 }
 
-var okHandler = func(interface{}) (proto.Message, error) {
+var okHandler = func(any) (proto.Message, error) {
 	return &emptypb.Empty{}, nil
 }
 
 var simpleCluster = testutil.NewBalancer(
 	testutil.WithInvokeHandlers(
 		testutil.InvokeHandlers{
-			testutil.TableExecuteDataQuery: func(interface{}) (proto.Message, error) {
+			testutil.TableExecuteDataQuery: func(any) (proto.Message, error) {
 				return &Ydb_Table.ExecuteQueryResult{
 					TxMeta: &Ydb_Table.TransactionMeta{
 						Id: "",
 					},
 				}, nil
 			},
-			testutil.TableBeginTransaction: func(interface{}) (proto.Message, error) {
+			testutil.TableBeginTransaction: func(any) (proto.Message, error) {
 				return &Ydb_Table.BeginTransactionResult{
 					TxMeta: &Ydb_Table.TransactionMeta{
 						Id: "",
 					},
 				}, nil
 			},
-			testutil.TableExplainDataQuery: func(interface{}) (proto.Message, error) {
+			testutil.TableExplainDataQuery: func(any) (proto.Message, error) {
 				return &Ydb_Table.ExecuteQueryResult{}, nil
 			},
-			testutil.TablePrepareDataQuery: func(interface{}) (proto.Message, error) {
+			testutil.TablePrepareDataQuery: func(any) (proto.Message, error) {
 				return &Ydb_Table.PrepareQueryResult{}, nil
 			},
-			testutil.TableCreateSession: func(interface{}) (proto.Message, error) {
+			testutil.TableCreateSession: func(any) (proto.Message, error) {
 				return &Ydb_Table.CreateSessionResult{
 					SessionId: testutil.SessionID(),
 				}, nil
 			},
-			testutil.TableDeleteSession: func(interface{}) (proto.Message, error) {
+			testutil.TableDeleteSession: func(any) (proto.Message, error) {
 				return &Ydb_Table.DeleteSessionResponse{}, nil
 			},
-			testutil.TableCommitTransaction: func(interface{}) (proto.Message, error) {
+			testutil.TableCommitTransaction: func(any) (proto.Message, error) {
 				return &Ydb_Table.CommitTransactionResponse{}, nil
 			},
-			testutil.TableRollbackTransaction: func(interface{}) (proto.Message, error) {
+			testutil.TableRollbackTransaction: func(any) (proto.Message, error) {
 				return &Ydb_Table.RollbackTransactionResponse{}, nil
 			},
-			testutil.TableKeepAlive: func(interface{}) (proto.Message, error) {
+			testutil.TableKeepAlive: func(any) (proto.Message, error) {
 				return &Ydb_Table.KeepAliveResult{}, nil
 			},
 		},

--- a/internal/table/config/config.go
+++ b/internal/table/config/config.go
@@ -130,11 +130,7 @@ func WithKeepAliveTimeout(keepAliveTimeout time.Duration) Option {
 // If createSessionTimeout is less than or equal to zero then no used timeout on create session request
 func WithCreateSessionTimeout(createSessionTimeout time.Duration) Option {
 	return func(c *Config) {
-		if createSessionTimeout > 0 {
-			c.createSessionTimeout = createSessionTimeout
-		} else {
-			c.createSessionTimeout = 0
-		}
+		c.createSessionTimeout = max(createSessionTimeout, 0)
 	}
 }
 

--- a/internal/table/scanner/perfomance_test.go
+++ b/internal/table/scanner/perfomance_test.go
@@ -103,7 +103,7 @@ func TestOverallSliceApproaches(t *testing.T) {
 
 func BenchmarkTestSliceIncrement(b *testing.B) {
 	slice := make([]*column, testSize)
-	for j := 0; j < testSize; j++ {
+	for j := range testSize {
 		slice[j] = &column{}
 	}
 	var cnt int
@@ -111,7 +111,7 @@ func BenchmarkTestSliceIncrement(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		cnt = 0
-		for i := 0; i < testSize; i++ {
+		for range testSize {
 			row = *slice[cnt]
 			cnt++
 		}
@@ -121,12 +121,12 @@ func BenchmarkTestSliceIncrement(b *testing.B) {
 
 func BenchmarkTestTempValue(b *testing.B) {
 	slice := make([]*column, testSize)
-	for j := 0; j < testSize; j++ {
+	for j := range testSize {
 		slice[j] = &column{}
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		for i := 0; i < testSize; i++ {
+		for i := range testSize {
 			col := slice[i]
 			col.name = "test1"
 			col.typeID = 1
@@ -136,12 +136,12 @@ func BenchmarkTestTempValue(b *testing.B) {
 
 func BenchmarkTestDoubleIndex(b *testing.B) {
 	slice := make([]*column, testSize)
-	for j := 0; j < testSize; j++ {
+	for j := range testSize {
 		slice[j] = &column{}
 	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		for i := 0; i < testSize; i++ {
+		for i := range testSize {
 			slice[i].name = "test2"
 			slice[i].typeID = 1
 		}

--- a/internal/table/scanner/result_test.go
+++ b/internal/table/scanner/result_test.go
@@ -22,7 +22,7 @@ func TestResultAny(t *testing.T) {
 		name    string
 		columns []options.Column
 		values  []value.Value
-		exp     []interface{}
+		exp     []any
 	}{
 		{
 			columns: []options.Column{
@@ -36,7 +36,7 @@ func TestResultAny(t *testing.T) {
 				value.OptionalValue(value.Uint32Value(43)),
 				value.NullValue(types.Uint32),
 			},
-			exp: []interface{}{
+			exp: []any{
 				uint32(43),
 				nil,
 			},
@@ -53,7 +53,7 @@ func TestResultAny(t *testing.T) {
 				nil,
 			)
 			var i int
-			var act interface{}
+			var act any
 			for res.NextResultSet(context.Background()) {
 				for res.NextRow() {
 					err := res.ScanWithDefaults(&act)

--- a/internal/table/scanner/scan_raw.go
+++ b/internal/table/scanner/scan_raw.go
@@ -295,7 +295,7 @@ func (s *rawConverter) DyNumber() (v string) {
 	return s.text()
 }
 
-func (s *rawConverter) Any() interface{} {
+func (s *rawConverter) Any() any {
 	return s.any()
 }
 
@@ -824,7 +824,7 @@ func (s *rawConverter) decimalTypeError(t types.Type) {
 	)
 }
 
-func nameIface(v interface{}) string {
+func nameIface(v any) string {
 	if v == nil {
 		return "nil"
 	}

--- a/internal/table/scanner/scanner.go
+++ b/internal/table/scanner/scanner.go
@@ -373,7 +373,7 @@ func (s *valueScanner) setColumnIndexes(columns []string) {
 //	    uuid
 //
 //nolint:gocyclo,funlen
-func (s *valueScanner) any() interface{} {
+func (s *valueScanner) any() any {
 	x := s.stack.current()
 	if s.Err() != nil || x.isEmpty() {
 		return nil
@@ -816,7 +816,7 @@ func (s *valueScanner) setByte(dst *[]byte) {
 	}
 }
 
-func (s *valueScanner) trySetByteArray(v interface{}, optional, def bool) bool {
+func (s *valueScanner) trySetByteArray(v any, optional, def bool) bool {
 	rv := reflect.ValueOf(v)
 	if rv.Kind() == reflect.Ptr {
 		rv = rv.Elem()
@@ -858,7 +858,7 @@ func (s *valueScanner) trySetByteArray(v interface{}, optional, def bool) bool {
 }
 
 //nolint:gocyclo,funlen
-func (s *valueScanner) scanRequired(v interface{}) {
+func (s *valueScanner) scanRequired(v any) {
 	switch v := v.(type) {
 	case *bool:
 		*v = s.bool()
@@ -900,7 +900,7 @@ func (s *valueScanner) scanRequired(v interface{}) {
 		*v = s.uuidBytesWithIssue1501()
 	case *uuid.UUID:
 		*v = s.uuid()
-	case *interface{}:
+	case *any:
 		*v = s.any()
 	case *value.Value:
 		*v = s.value()
@@ -938,7 +938,7 @@ func (s *valueScanner) scanRequired(v interface{}) {
 }
 
 //nolint:gocyclo, funlen
-func (s *valueScanner) scanOptional(v interface{}, defaultValueForOptional bool) {
+func (s *valueScanner) scanOptional(v any, defaultValueForOptional bool) {
 	if defaultValueForOptional {
 		if s.isNull() {
 			s.setDefaultValue(v)
@@ -1097,7 +1097,7 @@ func (s *valueScanner) scanOptional(v interface{}, defaultValueForOptional bool)
 			src := s.uuid()
 			*v = &src
 		}
-	case **interface{}:
+	case **any:
 		if s.isNull() {
 			*v = nil
 		} else {
@@ -1160,7 +1160,7 @@ func (s *valueScanner) scanOptional(v interface{}, defaultValueForOptional bool)
 }
 
 //nolint:funlen
-func (s *valueScanner) setDefaultValue(dst interface{}) {
+func (s *valueScanner) setDefaultValue(dst any) {
 	switch v := dst.(type) {
 	case *bool:
 		*v = false
@@ -1194,7 +1194,7 @@ func (s *valueScanner) setDefaultValue(dst interface{}) {
 		*v = nil
 	case *[16]byte:
 		*v = [16]byte{}
-	case *interface{}:
+	case *any:
 		*v = nil
 	case *value.Value:
 		*v = s.value()
@@ -1229,7 +1229,7 @@ func (r *baseResult) SetErr(err error) {
 	})
 }
 
-func (s *valueScanner) errorf(depth int, f string, args ...interface{}) error {
+func (s *valueScanner) errorf(depth int, f string, args ...any) error {
 	s.errMtx.Lock()
 	defer s.errMtx.Unlock()
 	if s.err != nil {
@@ -1240,7 +1240,7 @@ func (s *valueScanner) errorf(depth int, f string, args ...interface{}) error {
 	return s.err
 }
 
-func (s *valueScanner) typeError(act, exp interface{}) {
+func (s *valueScanner) typeError(act, exp any) {
 	_ = s.errorf(
 		2, //nolint:mnd
 		"unexpected types during scan at %q %s: %s; want %s",
@@ -1251,7 +1251,7 @@ func (s *valueScanner) typeError(act, exp interface{}) {
 	)
 }
 
-func (s *valueScanner) valueTypeError(act, exp interface{}) {
+func (s *valueScanner) valueTypeError(act, exp any) {
 	// unexpected value during scan at \"migration_status\" Int64: NullFlag; want Int64
 	_ = s.errorf(
 		2, //nolint:mnd
@@ -1287,7 +1287,7 @@ func (s *valueScanner) noColumnError(name string) error {
 	)
 }
 
-func (s *valueScanner) overflowError(i, n interface{}) error {
+func (s *valueScanner) overflowError(i, n any) error {
 	return s.errorf(
 		2, //nolint:mnd
 		"overflow error: %d overflows capacity of %t",
@@ -1375,7 +1375,7 @@ func (s *scanStack) current() item {
 	return s.v[s.p]
 }
 
-func (s *scanStack) currentValue() interface{} {
+func (s *scanStack) currentValue() any {
 	if v := s.current().v; v != nil {
 		return v.GetValue()
 	}
@@ -1383,7 +1383,7 @@ func (s *scanStack) currentValue() interface{} {
 	return nil
 }
 
-func (s *scanStack) currentType() interface{} {
+func (s *scanStack) currentType() any {
 	if t := s.current().t; t != nil {
 		return t.GetType()
 	}

--- a/internal/table/scanner/scanner_data_test.go
+++ b/internal/table/scanner/scanner_data_test.go
@@ -24,7 +24,7 @@ type column struct {
 
 type intIncScanner int64
 
-func (s *intIncScanner) Scan(src interface{}) error {
+func (s *intIncScanner) Scan(src any) error {
 	v, ok := src.(int64)
 	if !ok {
 		return fmt.Errorf("wrong type: %T, exp: int64", src)
@@ -36,7 +36,7 @@ func (s *intIncScanner) Scan(src interface{}) error {
 
 type dateScanner time.Time
 
-func (s *dateScanner) Scan(src interface{}) error {
+func (s *dateScanner) Scan(src any) error {
 	v, ok := src.(time.Time)
 	if !ok {
 		return fmt.Errorf("wrong type: %T, exp: time.Time", src)
@@ -529,7 +529,7 @@ func generateScannerData(count int) *valueScanner {
 		},
 	}}
 	res.set.Rows = []*Ydb.Value{}
-	for i := 0; i < count; i++ {
+	for i := range count {
 		res.set.Rows = append(res.set.GetRows(), &Ydb.Value{
 			Items: []*Ydb.Value{{
 				Value: &Ydb.Value_Uint64Value{

--- a/internal/table/scanner/scanner_test.go
+++ b/internal/table/scanner/scanner_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 //nolint:gocyclo
-func valueFromPrimitiveTypeID(c *column, r xrand.Rand) (*Ydb.Value, interface{}) {
+func valueFromPrimitiveTypeID(c *column, r xrand.Rand) (*Ydb.Value, any) {
 	rv := r.Int64(math.MaxInt16)
 	switch c.typeID {
 	case Ydb.Type_BOOL:
@@ -544,7 +544,7 @@ func getResultSet(count int, col []*column) (result *Ydb.ResultSet, testValues [
 
 	r := xrand.New(xrand.WithLock())
 	testValues = make([][]indexed.RequiredOrOptional, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		var items []*Ydb.Value
 		var vals []indexed.RequiredOrOptional
 		for j := range result.GetColumns() {

--- a/internal/table/session.go
+++ b/internal/table/session.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"maps"
 	"net/url"
 	"strconv"
 	"sync"
@@ -697,9 +698,7 @@ func processColumnFamilies(families []*Ydb_Table.ColumnFamily) []options.ColumnF
 
 func processAttributes(attrs map[string]string) map[string]string {
 	attributes := make(map[string]string, len(attrs))
-	for k, v := range attrs {
-		attributes[k] = v
-	}
+	maps.Copy(attributes, attrs)
 
 	return attributes
 }

--- a/internal/table/session_test.go
+++ b/internal/table/session_test.go
@@ -44,10 +44,10 @@ func TestSessionKeepAlive(t *testing.T) {
 		cc: testutil.NewBalancer(
 			testutil.WithInvokeHandlers(
 				testutil.InvokeHandlers{
-					testutil.TableKeepAlive: func(interface{}) (proto.Message, error) {
+					testutil.TableKeepAlive: func(any) (proto.Message, error) {
 						return &Ydb_Table.KeepAliveResult{SessionStatus: status}, e
 					},
-					testutil.TableCreateSession: func(interface{}) (proto.Message, error) {
+					testutil.TableCreateSession: func(any) (proto.Message, error) {
 						return &Ydb_Table.CreateSessionResult{
 							SessionId: testutil.SessionID(),
 						}, nil
@@ -98,12 +98,12 @@ func TestSessionDescribeTable(t *testing.T) {
 		cc: testutil.NewBalancer(
 			testutil.WithInvokeHandlers(
 				testutil.InvokeHandlers{
-					testutil.TableCreateSession: func(interface{}) (proto.Message, error) {
+					testutil.TableCreateSession: func(any) (proto.Message, error) {
 						return &Ydb_Table.CreateSessionResult{
 							SessionId: testutil.SessionID(),
 						}, nil
 					},
-					testutil.TableDescribeTable: func(interface{}) (proto.Message, error) {
+					testutil.TableDescribeTable: func(any) (proto.Message, error) {
 						r := &Ydb_Table.DescribeTableResult{}
 						proto.Merge(r, result)
 
@@ -373,41 +373,41 @@ func TestSessionOperationModeOnExecuteDataQuery(t *testing.T) {
 						client := New(context.Background(), testutil.NewBalancer(
 							testutil.WithInvokeHandlers(
 								testutil.InvokeHandlers{
-									testutil.TableExecuteDataQuery: func(interface{}) (proto.Message, error) {
+									testutil.TableExecuteDataQuery: func(any) (proto.Message, error) {
 										return &Ydb_Table.ExecuteQueryResult{
 											TxMeta: &Ydb_Table.TransactionMeta{
 												Id: "",
 											},
 										}, nil
 									},
-									testutil.TableBeginTransaction: func(interface{}) (proto.Message, error) {
+									testutil.TableBeginTransaction: func(any) (proto.Message, error) {
 										return &Ydb_Table.BeginTransactionResult{
 											TxMeta: &Ydb_Table.TransactionMeta{
 												Id: "",
 											},
 										}, nil
 									},
-									testutil.TableExplainDataQuery: func(request interface{}) (result proto.Message, err error) {
+									testutil.TableExplainDataQuery: func(request any) (result proto.Message, err error) {
 										return &Ydb_Table.ExplainQueryResult{}, nil
 									},
-									testutil.TablePrepareDataQuery: func(request interface{}) (result proto.Message, err error) {
+									testutil.TablePrepareDataQuery: func(request any) (result proto.Message, err error) {
 										return &Ydb_Table.PrepareQueryResult{}, nil
 									},
-									testutil.TableCreateSession: func(interface{}) (proto.Message, error) {
+									testutil.TableCreateSession: func(any) (proto.Message, error) {
 										return &Ydb_Table.CreateSessionResult{
 											SessionId: testutil.SessionID(),
 										}, nil
 									},
-									testutil.TableDeleteSession: func(request interface{}) (result proto.Message, err error) {
+									testutil.TableDeleteSession: func(request any) (result proto.Message, err error) {
 										return &Ydb_Table.DeleteSessionResponse{}, nil
 									},
-									testutil.TableCommitTransaction: func(request interface{}) (result proto.Message, err error) {
+									testutil.TableCommitTransaction: func(request any) (result proto.Message, err error) {
 										return &Ydb_Table.CommitTransactionResult{}, nil
 									},
-									testutil.TableRollbackTransaction: func(request interface{}) (result proto.Message, err error) {
+									testutil.TableRollbackTransaction: func(request any) (result proto.Message, err error) {
 										return &Ydb_Table.RollbackTransactionResponse{}, nil
 									},
-									testutil.TableKeepAlive: func(request interface{}) (result proto.Message, err error) {
+									testutil.TableKeepAlive: func(request any) (result proto.Message, err error) {
 										return &Ydb_Table.KeepAliveResult{}, nil
 									},
 								},
@@ -430,12 +430,12 @@ func TestCreateTableRegression(t *testing.T) {
 	client := New(context.Background(), testutil.NewBalancer(
 		testutil.WithInvokeHandlers(
 			testutil.InvokeHandlers{
-				testutil.TableCreateSession: func(request interface{}) (proto.Message, error) {
+				testutil.TableCreateSession: func(request any) (proto.Message, error) {
 					return &Ydb_Table.CreateSessionResult{
 						SessionId: "",
 					}, nil
 				},
-				testutil.TableCreateTable: func(act interface{}) (proto.Message, error) {
+				testutil.TableCreateTable: func(act any) (proto.Message, error) {
 					exp := &Ydb_Table.CreateTableRequest{
 						SessionId: "",
 						Path:      "episodes",
@@ -529,12 +529,12 @@ func TestDescribeTableRegression(t *testing.T) {
 	client := New(context.Background(), testutil.NewBalancer(
 		testutil.WithInvokeHandlers(
 			testutil.InvokeHandlers{
-				testutil.TableCreateSession: func(request interface{}) (proto.Message, error) {
+				testutil.TableCreateSession: func(request any) (proto.Message, error) {
 					return &Ydb_Table.CreateSessionResult{
 						SessionId: "",
 					}, nil
 				},
-				testutil.TableDescribeTable: func(act interface{}) (proto.Message, error) {
+				testutil.TableDescribeTable: func(act any) (proto.Message, error) {
 					return &Ydb_Table.DescribeTableResult{
 						Self: &Ydb_Scheme.Entry{
 							Name: "episodes",

--- a/internal/table/transaction_test.go
+++ b/internal/table/transaction_test.go
@@ -25,7 +25,7 @@ func TestTxSkipRollbackForCommitted(t *testing.T) {
 		cc: testutil.NewBalancer(
 			testutil.WithInvokeHandlers(
 				testutil.InvokeHandlers{
-					testutil.TableBeginTransaction: func(request interface{}) (proto.Message, error) {
+					testutil.TableBeginTransaction: func(request any) (proto.Message, error) {
 						_, ok := request.(*Ydb_Table.BeginTransactionRequest)
 						if !ok {
 							t.Fatalf("cannot cast request '%T' to *Ydb_Table.BeginTransactionRequest", request)
@@ -38,7 +38,7 @@ func TestTxSkipRollbackForCommitted(t *testing.T) {
 							},
 						}, nil
 					},
-					testutil.TableCommitTransaction: func(request interface{}) (proto.Message, error) {
+					testutil.TableCommitTransaction: func(request any) (proto.Message, error) {
 						_, ok := request.(*Ydb_Table.CommitTransactionRequest)
 						if !ok {
 							t.Fatalf("cannot cast request '%T' to *Ydb_Table.CommitTransactionRequest", request)
@@ -47,7 +47,7 @@ func TestTxSkipRollbackForCommitted(t *testing.T) {
 
 						return &Ydb_Table.CommitTransactionResult{}, nil
 					},
-					testutil.TableRollbackTransaction: func(request interface{}) (proto.Message, error) {
+					testutil.TableRollbackTransaction: func(request any) (proto.Message, error) {
 						_, ok := request.(*Ydb_Table.RollbackTransactionRequest)
 						if !ok {
 							t.Fatalf("cannot cast request '%T' to *Ydb_Table.RollbackTransactionRequest", request)
@@ -61,7 +61,7 @@ func TestTxSkipRollbackForCommitted(t *testing.T) {
 							},
 						}, nil
 					},
-					testutil.TableCreateSession: func(interface{}) (proto.Message, error) {
+					testutil.TableCreateSession: func(any) (proto.Message, error) {
 						return &Ydb_Table.CreateSessionResult{
 							SessionId: testutil.SessionID(),
 						}, nil

--- a/internal/topic/topiclistenerinternal/partition_worker_test.go
+++ b/internal/topic/topiclistenerinternal/partition_worker_test.go
@@ -60,7 +60,7 @@ func (s *syncMessageSender) waitForMessage(ctx context.Context) error {
 
 // waitForMessages waits for at least n messages to be sent
 func (s *syncMessageSender) waitForMessages(ctx context.Context, n int) error {
-	for i := 0; i < n; i++ {
+	for range n {
 		if err := s.waitForMessage(ctx); err != nil {
 			return err
 		}

--- a/internal/topic/topicreadercommon/batch.go
+++ b/internal/topic/topicreadercommon/batch.go
@@ -24,7 +24,7 @@ type PublicBatch struct {
 }
 
 func NewBatch(session *PartitionSession, messages []*PublicMessage) (*PublicBatch, error) {
-	for i := 0; i < len(messages); i++ {
+	for i := range messages {
 		msg := messages[i]
 
 		if msg.commitRange.PartitionSession == nil {

--- a/internal/topic/topicreadercommon/committer.go
+++ b/internal/topic/topicreadercommon/committer.go
@@ -278,10 +278,10 @@ func (w *commitWaiter) checkCondition(
 	return session == w.Session && offset >= w.EndOffset
 }
 
-var commitWaiterLastID int64
+var commitWaiterLastID atomic.Int64
 
 func newCommitWaiter(session *PartitionSession, endOffset rawtopiccommon.Offset) commitWaiter {
-	id := atomic.AddInt64(&commitWaiterLastID, 1)
+	id := commitWaiterLastID.Add(1)
 
 	return commitWaiter{
 		ID:        id,

--- a/internal/topic/topicreadercommon/committer_test.go
+++ b/internal/topic/topicreadercommon/committer_test.go
@@ -307,7 +307,7 @@ func TestCommitterBuffer(t *testing.T) {
 			return nil
 		}
 
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			_, err := c.pushCommit(
 				CommitRange{
 					PartitionSession: newTestPartitionSession(

--- a/internal/topic/topicreadercommon/decoders_test.go
+++ b/internal/topic/topicreadercommon/decoders_test.go
@@ -83,7 +83,7 @@ func TestMultiDecoder(t *testing.T) {
 	t.Run("ResettableReaderManyMessages", func(t *testing.T) {
 		testMultiDecoder := NewMultiDecoder()
 
-		for i := 0; i < 50; i++ {
+		for i := range 50 {
 			testMsg := fmt.Sprintf("test_data_%d", i)
 			encodedReader := compressGzip(testMsg)
 

--- a/internal/topic/topicreadercommon/message_content_pool.go
+++ b/internal/topic/topicreadercommon/message_content_pool.go
@@ -13,8 +13,8 @@ import (
 //
 //go:generate mockgen -destination=pool_interface_mock_test.go --typed -write_package_comment=false -package=topicreadercommon github.com/ydb-platform/ydb-go-sdk/v3/internal/topic/topicreadercommon Pool
 type Pool interface {
-	Get() interface{}
-	Put(x interface{})
+	Get() any
+	Put(x any)
 }
 
 // CallbackWithMessageContentFunc is callback function for work with message content

--- a/internal/topic/topicreadercommon/reader_id.go
+++ b/internal/topic/topicreadercommon/reader_id.go
@@ -2,8 +2,8 @@ package topicreadercommon
 
 import "sync/atomic"
 
-var globalReaderCounter int64
+var globalReaderCounter atomic.Int64
 
 func NextReaderID() int64 {
-	return atomic.AddInt64(&globalReaderCounter, 1)
+	return globalReaderCounter.Add(1)
 }

--- a/internal/topic/topicreaderinternal/batcher.go
+++ b/internal/topic/topicreaderinternal/batcher.go
@@ -17,7 +17,7 @@ import (
 var errBatcherPopConcurency = xerrors.Wrap(errors.New("ydb: batch pop concurency, internal state error"))
 
 type batcher struct {
-	popInFlight    int64
+	popInFlight    atomic.Int64
 	closeErr       error
 	hasNewMessages empty.Chan
 
@@ -176,8 +176,8 @@ func (o batcherGetOptions) splitBatch(batch *topicreadercommon.PublicBatch) (
 }
 
 func (b *batcher) Pop(ctx context.Context, opts batcherGetOptions) (_ batcherMessageOrderItem, err error) {
-	counter := atomic.AddInt64(&b.popInFlight, 1)
-	defer atomic.AddInt64(&b.popInFlight, -1)
+	counter := b.popInFlight.Add(1)
+	defer b.popInFlight.Add(-1)
 
 	if counter != 1 {
 		return batcherMessageOrderItem{}, xerrors.WithStackTrace(errBatcherPopConcurency)

--- a/internal/topic/topicreaderinternal/batcher_test.go
+++ b/internal/topic/topicreaderinternal/batcher_test.go
@@ -395,7 +395,7 @@ func TestBatcherConcurency(t *testing.T) {
 		session := &topicreadercommon.PartitionSession{}
 
 		go func() {
-			for i := 0; i < count; i++ {
+			for i := range count {
 				_ = b.PushRawMessage(session, &rawtopicreader.StartPartitionSessionRequest{
 					CommittedOffset:  rawtopiccommon.NewOffset(int64(i)),
 					PartitionOffsets: rawtopiccommon.OffsetRange{},
@@ -406,7 +406,7 @@ func TestBatcherConcurency(t *testing.T) {
 		ctx, cancel := xcontext.WithTimeout(context.Background(), time.Second)
 		defer cancel()
 
-		for i := 0; i < count; i++ {
+		for i := range count {
 			res, err := b.Pop(ctx, batcherGetOptions{MinCount: 1})
 			require.NoError(tb, err)
 			require.Equal(

--- a/internal/topic/topicreaderinternal/stream_reconnector_test.go
+++ b/internal/topic/topicreaderinternal/stream_reconnector_test.go
@@ -131,7 +131,7 @@ func TestTopicReaderReconnectorReadMessageBatch(t *testing.T) {
 		cancelledCtx, cancelledCtxCancel := xcontext.WithCancel(context.Background())
 		cancelledCtxCancel()
 
-		for i := 0; i < 100; i++ {
+		for range 100 {
 			reconnector := &readerReconnector{tracer: &trace.Topic{}}
 			reconnector.initChannelsAndClock()
 

--- a/internal/value/cast_test.go
+++ b/internal/value/cast_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ydb-platform/ydb-go-sdk/v3/pkg/xtest"
 )
 
-func ptr[T any]() interface{} {
+func ptr[T any]() any {
 	var zeroValue T
 
 	return &zeroValue
@@ -23,7 +23,7 @@ func value2ptr[T any](v T) *T {
 	return &v
 }
 
-func unwrapPtr(v interface{}) interface{} {
+func unwrapPtr(v any) any {
 	return reflect.ValueOf(v).Elem().Interface()
 }
 
@@ -60,14 +60,14 @@ func TestCastTo(t *testing.T) {
 	testsCases := []struct {
 		name  string
 		value Value
-		dst   interface{}
-		exp   interface{}
+		dst   any
+		exp   any
 		err   error
 	}{
 		{
 			name:  xtest.CurrentFileLine(),
 			value: TextValue("test"),
-			dst:   (interface{})(nil),
+			dst:   (any)(nil),
 			err:   errNilDestination,
 		},
 
@@ -712,7 +712,7 @@ func TestCastToDriverValue(t *testing.T) {
 	testsCases := []struct {
 		name  string
 		value Value
-		exp   interface{}
+		exp   any
 		err   error
 	}{
 		{

--- a/internal/value/nullable.go
+++ b/internal/value/nullable.go
@@ -427,7 +427,7 @@ func NullableDyNumberValue(v *string) Value {
 // Warning: type interface will be replaced in the future with typed parameters pattern from go1.18
 //
 //nolint:gocyclo, funlen
-func Nullable(t types.Type, v interface{}) Value {
+func Nullable(t types.Type, v any) Value {
 	switch t {
 	case types.Bool:
 		tt, ok := v.(*bool)

--- a/internal/value/value.go
+++ b/internal/value/value.go
@@ -1548,7 +1548,7 @@ func (v *listValue) castTo(dst any) error {
 		*dstValue = v
 
 		return nil
-	case interface{}:
+	case any:
 		ptr := reflect.ValueOf(dstValue)
 
 		inner := reflect.Indirect(ptr)
@@ -1679,7 +1679,7 @@ func (v *setValue) castTo(dst any) error {
 		*dstValue = v
 
 		return nil
-	case interface{}:
+	case any:
 		ptr := reflect.ValueOf(dstValue)
 
 		inner := reflect.Indirect(ptr)
@@ -1889,7 +1889,7 @@ func (v *structValue) castTo(dst any) error {
 		*dstValue = v
 
 		return nil
-	case interface{}:
+	case any:
 		ptr := reflect.ValueOf(dst)
 
 		inner := reflect.Indirect(ptr)

--- a/internal/value/value_test.go
+++ b/internal/value/value_test.go
@@ -633,7 +633,7 @@ func TestOptionalValueCastTo(t *testing.T) {
 		name string
 		v    *optionalValue
 		dst  **string
-		exp  interface{}
+		exp  any
 		err  error
 	}{
 		{
@@ -681,7 +681,7 @@ func TestNullable(t *testing.T) {
 	for _, test := range []struct {
 		name string
 		t    types.Type
-		v    interface{}
+		v    any
 		exp  Value
 	}{
 		{
@@ -1126,7 +1126,7 @@ func TestCastNumbers(t *testing.T) {
 		},
 	}
 	numberDestinations := []struct {
-		destination interface{}
+		destination any
 		signed      bool
 		len         int
 	}{
@@ -1221,8 +1221,8 @@ func TestCastNumbers(t *testing.T) {
 	}
 	for _, tt := range []struct {
 		v      Value
-		dst    interface{}
-		result interface{}
+		dst    any
+		result any
 		error  bool
 	}{
 		{
@@ -1365,8 +1365,8 @@ func TestCastNumbers(t *testing.T) {
 func TestCastList(t *testing.T) {
 	for _, tt := range []struct {
 		v      Value
-		dst    interface{}
-		result interface{}
+		dst    any
+		result any
 		error  bool
 	}{
 		{
@@ -1412,8 +1412,8 @@ func TestCastList(t *testing.T) {
 func TestCastSet(t *testing.T) {
 	for _, tt := range []struct {
 		v      Value
-		dst    interface{}
-		result interface{}
+		dst    any
+		result any
 		error  bool
 	}{
 		{
@@ -1463,8 +1463,8 @@ func TestCastStruct(t *testing.T) {
 	}
 	for _, tt := range []struct {
 		v      Value
-		dst    interface{}
-		result interface{}
+		dst    any
+		result any
 		error  bool
 	}{
 		{
@@ -1504,8 +1504,8 @@ func TestCastStruct(t *testing.T) {
 func TestCastOtherTypes(t *testing.T) {
 	for _, tt := range []struct {
 		v      Value
-		dst    interface{}
-		result interface{}
+		dst    any
+		result any
 		error  bool
 	}{
 		{

--- a/internal/xcontext/context_with_cancel.go
+++ b/internal/xcontext/context_with_cancel.go
@@ -45,7 +45,7 @@ func (ctx *cancelCtx) Err() error {
 	return ctx.err
 }
 
-func (ctx *cancelCtx) Value(key interface{}) interface{} {
+func (ctx *cancelCtx) Value(key any) any {
 	return ctx.ctx.Value(key)
 }
 

--- a/internal/xcontext/context_with_timeout.go
+++ b/internal/xcontext/context_with_timeout.go
@@ -60,7 +60,7 @@ func (ctx *timeoutCtx) Err() error {
 	return nil
 }
 
-func (ctx *timeoutCtx) Value(key interface{}) interface{} {
+func (ctx *timeoutCtx) Value(key any) any {
 	return ctx.ctx.Value(key)
 }
 

--- a/internal/xcontext/done_test.go
+++ b/internal/xcontext/done_test.go
@@ -17,8 +17,7 @@ func TestWithDone(t *testing.T) {
 		require.Error(t, ctx1.Err())
 	})
 	t.Run("WithExplicitCancel", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 		done := make(chan struct{})
 		ctx1, cancel1 := WithDone(ctx, done)
 		require.NoError(t, ctx1.Err())

--- a/internal/xcontext/merge_contexts.go
+++ b/internal/xcontext/merge_contexts.go
@@ -24,7 +24,7 @@ func (ctx *MergedContexts) Err() error {
 	return ctx.deadlineContext.Err()
 }
 
-func (ctx *MergedContexts) Value(key interface{}) interface{} {
+func (ctx *MergedContexts) Value(key any) any {
 	if ctx.deadlineContext.Value(key) != nil {
 		return ctx.deadlineContext.Value(key)
 	}

--- a/internal/xerrors/issues.go
+++ b/internal/xerrors/issues.go
@@ -100,7 +100,7 @@ func (e *withIssuesError) Error() string {
 	return b.String()
 }
 
-func (e *withIssuesError) As(target interface{}) bool {
+func (e *withIssuesError) As(target any) bool {
 	for _, err := range e.issues {
 		if As(err, target) {
 			return true

--- a/internal/xerrors/join.go
+++ b/internal/xerrors/join.go
@@ -43,7 +43,7 @@ func (e *joinError) Error() string {
 	return b.String()
 }
 
-func (e *joinError) As(target interface{}) bool {
+func (e *joinError) As(target any) bool {
 	for _, err := range e.errs {
 		if As(err, target) {
 			return true

--- a/internal/xerrors/join_test.go
+++ b/internal/xerrors/join_test.go
@@ -12,7 +12,7 @@ func TestJoin(t *testing.T) {
 	for _, tt := range []struct {
 		join error
 		iss  []error
-		ass  []interface{}
+		ass  []any
 		s    string
 	}{
 		{
@@ -24,7 +24,7 @@ func TestJoin(t *testing.T) {
 		{
 			join: Join(context.Canceled, context.DeadlineExceeded, Operation()),
 			iss:  []error{context.Canceled, context.DeadlineExceeded},
-			ass: []interface{}{func() interface{} {
+			ass: []any{func() any {
 				var i isYdbError
 
 				return &i

--- a/internal/xerrors/operation.go
+++ b/internal/xerrors/operation.go
@@ -152,13 +152,8 @@ func IsOperationError(err error, codes ...Ydb.StatusIds_StatusCode) bool {
 	if len(codes) == 0 {
 		return true
 	}
-	for _, code := range codes {
-		if op.code == code {
-			return true
-		}
-	}
 
-	return false
+	return slices.Contains(codes, op.code)
 }
 
 func IsOperationErrorTransactionLocksInvalidated(err error) (isTLI bool) {

--- a/internal/xerrors/transport.go
+++ b/internal/xerrors/transport.go
@@ -3,6 +3,7 @@ package xerrors
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 
 	grpcCodes "google.golang.org/grpc/codes"
@@ -130,10 +131,8 @@ func IsTransportError(err error, codes ...grpcCodes.Code) bool {
 		if len(codes) == 0 {
 			return true
 		}
-		for _, code := range codes {
-			if status.Code() == code {
-				return true
-			}
+		if slices.Contains(codes, status.Code()) {
+			return true
 		}
 	}
 

--- a/internal/xerrors/tx.go
+++ b/internal/xerrors/tx.go
@@ -8,7 +8,7 @@ func (err *alreadyHasTxError) Error() string {
 	return "сonn already has an open currentTx: " + err.currentTx
 }
 
-func (err *alreadyHasTxError) As(target interface{}) bool {
+func (err *alreadyHasTxError) As(target any) bool {
 	switch t := target.(type) {
 	case *alreadyHasTxError:
 		t.currentTx = err.currentTx

--- a/internal/xerrors/xerrors.go
+++ b/internal/xerrors/xerrors.go
@@ -62,7 +62,7 @@ func HideEOF(err error) error {
 
 // As is a proxy to errors.As
 // This need to single import errors
-func As(err error, targets ...interface{}) bool {
+func As(err error, targets ...any) bool {
 	if err == nil {
 		panic("nil err")
 	}

--- a/internal/xsql/badconn/badconn.go
+++ b/internal/xsql/badconn/badconn.go
@@ -21,7 +21,7 @@ func New(msg string) error {
 	return &Error{xerrors.IsTarget(errors.New(msg), driver.ErrBadConn)}
 }
 
-func Errorf(format string, args ...interface{}) error {
+func Errorf(format string, args ...any) error {
 	return &Error{xerrors.IsTarget(fmt.Errorf(format, args...), driver.ErrBadConn)}
 }
 

--- a/internal/xsql/common/sqlvalue.go
+++ b/internal/xsql/common/sqlvalue.go
@@ -10,7 +10,7 @@ import (
 
 // ToDatabaseSQLValue convert native go values to subset of types for use
 // with database/sql.Scanner interface
-func ToDatabaseSQLValue(v interface{}) driver.Value {
+func ToDatabaseSQLValue(v any) driver.Value {
 	// convert types to one of safe database sql types for scan it by scanners
 	// https://pkg.go.dev/database/sql@go1.25.5#Scanner
 	switch val := v.(type) {

--- a/internal/xsql/conn_helpers.go
+++ b/internal/xsql/conn_helpers.go
@@ -5,6 +5,7 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"path"
+	"slices"
 	"strings"
 	"time"
 
@@ -122,10 +123,8 @@ func (c *Conn) IsPrimaryKey(ctx context.Context, tableName, columnName string) (
 		return false, xerrors.WithStackTrace(err)
 	}
 
-	for _, pkCol := range d.PrimaryKey {
-		if pkCol == columnName {
-			return true, nil
-		}
+	if slices.Contains(d.PrimaryKey, columnName) {
+		return true, nil
 	}
 
 	return false, nil

--- a/internal/xsql/unwrap.go
+++ b/internal/xsql/unwrap.go
@@ -17,7 +17,7 @@ func Unwrap[T *sql.DB | *sql.Conn](v T) (connector *Connector, _ error) {
 
 		return nil, xerrors.WithStackTrace(fmt.Errorf("%T is not a *driverWrapper", v))
 	case *sql.Conn:
-		if err := vv.Raw(func(driverConn interface{}) error {
+		if err := vv.Raw(func(driverConn any) error {
 			if cc, ok := driverConn.(*Conn); ok {
 				connector = cc.connector
 

--- a/internal/xsql/xtable/valuer.go
+++ b/internal/xsql/xtable/valuer.go
@@ -6,7 +6,7 @@ import (
 )
 
 type valuer struct {
-	v interface{}
+	v any
 }
 
 func (v *valuer) UnmarshalYDB(raw scanner.RawValue) error {
@@ -15,6 +15,6 @@ func (v *valuer) UnmarshalYDB(raw scanner.RawValue) error {
 	return nil
 }
 
-func (v *valuer) Value() interface{} {
+func (v *valuer) Value() any {
 	return common.ToDatabaseSQLValue(v.v)
 }

--- a/internal/xsync/mutex_test.go
+++ b/internal/xsync/mutex_test.go
@@ -68,12 +68,12 @@ func TestRWMutex(t *testing.T) {
 		var badSummCount int64
 		var wg sync.WaitGroup
 
-		for reader := 0; reader < 100; reader++ {
+		for range 100 {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
 
-				for i := 0; i < 1000; i++ {
+				for range 1000 {
 					m.WithRLock(func() {
 						if a+b != 2 {
 							atomic.AddInt64(&badSummCount, 1)
@@ -88,7 +88,7 @@ func TestRWMutex(t *testing.T) {
 		go func() {
 			defer wg.Done()
 
-			for i := 0; i < 100; i++ {
+			for range 100 {
 				m.WithLock(func() {
 					a++
 					b--

--- a/internal/xsync/soft_semaphore_test.go
+++ b/internal/xsync/soft_semaphore_test.go
@@ -213,14 +213,14 @@ func TestSoftWeightedSemaphore(t *testing.T) {
 			done := make(chan struct{})
 
 			// Launch multiple goroutines
-			for i := 0; i < goroutines; i++ {
+			for range goroutines {
 				go func() {
 					defer func() {
 						done <- struct{}{}
 					}()
 
 					// Each goroutine tries to acquire and release semaphore multiple times
-					for j := 0; j < 10; j++ {
+					for range 10 {
 						if sem.TryAcquire(3) {
 							time.Sleep(time.Millisecond)
 							sem.Release(3)
@@ -235,7 +235,7 @@ func TestSoftWeightedSemaphore(t *testing.T) {
 			}
 
 			// Wait for all goroutines to complete
-			for i := 0; i < goroutines; i++ {
+			for range goroutines {
 				<-done
 			}
 		})

--- a/internal/xsync/unbounded_chan_test.go
+++ b/internal/xsync/unbounded_chan_test.go
@@ -132,12 +132,12 @@ func TestUnboundedChanMultipleMessages(t *testing.T) {
 	const count = 1000
 
 	// Send many messages
-	for i := 0; i < count; i++ {
+	for i := range count {
 		ch.Send(i)
 	}
 
 	// Receive them all
-	for i := 0; i < count; i++ {
+	for i := range count {
 		msg, ok, err := ch.Receive(ctx)
 		if err != nil || !ok || msg != i {
 			t.Errorf("Receive() = (%v, %v, %v), want (%d, true, nil)", msg, ok, err, i)
@@ -150,12 +150,12 @@ func TestUnboundedChanSignalChannelBehavior(t *testing.T) {
 	ch := NewUnboundedChan[int]()
 
 	// Send multiple messages rapidly
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		ch.Send(i)
 	}
 
 	// Should receive all messages despite signal channel being buffered
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		msg, ok, err := ch.Receive(ctx)
 		if err != nil || !ok || msg != i {
 			t.Errorf("Receive() = (%v, %v, %v), want (%d, true, nil)", msg, ok, err, i)
@@ -231,7 +231,7 @@ func TestUnboundedChanConcurrentSendReceive(t *testing.T) {
 		// Start sender goroutine
 		go func() {
 			defer close(senderDone)
-			for i := 0; i < count; i++ {
+			for i := range count {
 				ch.Send(i)
 			}
 		}()
@@ -271,7 +271,7 @@ func TestUnboundedChanConcurrentSendReceive(t *testing.T) {
 			}
 
 			// Verify we received the correct messages
-			for i := 0; i < count; i++ {
+			for i := range count {
 				if !received[i] {
 					t.Errorf("Missing message: %d", i)
 
@@ -294,9 +294,9 @@ func TestUnboundedChanConcurrentMerge(t *testing.T) {
 		done := make(empty.Chan)
 
 		// Start multiple sender goroutines
-		for i := 0; i < numSenders; i++ {
+		for i := range numSenders {
 			go func(id int) {
-				for j := 0; j < count; j++ {
+				for range count {
 					ch.SendWithMerge(TestMessage{ID: id, Data: "test"}, mergeTestMessages)
 				}
 			}(i)
@@ -341,7 +341,7 @@ func TestUnboundedChanConcurrentMerge(t *testing.T) {
 
 // allSendersHaveMessages checks if all sender IDs have sent at least one message
 func allSendersHaveMessages(received map[int]int, numSenders int) bool {
-	for i := 0; i < numSenders; i++ {
+	for i := range numSenders {
 		if received[i] == 0 {
 			return false
 		}

--- a/log/context_test.go
+++ b/log/context_test.go
@@ -69,7 +69,7 @@ func TestWithNamesRaceRegression(t *testing.T) {
 
 		start := make(chan bool)
 		finished := make(chan bool)
-		for i := 0; i < count; i++ {
+		for i := range count {
 			go func(index int) {
 				<-start
 				res[index] = WithNames(ctx, strconv.Itoa(index))
@@ -80,11 +80,11 @@ func TestWithNamesRaceRegression(t *testing.T) {
 		time.Sleep(time.Microsecond)
 		close(start)
 
-		for i := 0; i < count; i++ {
+		for range count {
 			<-finished
 		}
 
-		for i := 0; i < count; i++ {
+		for i := range count {
 			expected := []string{"test", "test", "test", strconv.Itoa(i)}
 			require.Equal(t, expected, NamesFromContext(res[i]))
 		}

--- a/options.go
+++ b/options.go
@@ -657,7 +657,7 @@ func WithIgnoreTruncated() Option {
 // Warning: WithPanicCallback must be defined on start of all options
 // (before `WithTrace{Driver,Table,Scheme,Scripting,Coordination,Ratelimiter}` and other options)
 // If not defined - panic would not intercept with driver
-func WithPanicCallback(panicCallback func(e interface{})) Option {
+func WithPanicCallback(panicCallback func(e any)) Option {
 	return func(ctx context.Context, d *Driver) error {
 		d.panicCallback = panicCallback
 		d.options = append(d.options, config.WithPanicCallback(panicCallback))

--- a/pkg/decimal/decimal.go
+++ b/pkg/decimal/decimal.go
@@ -38,8 +38,8 @@ const (
 // ParseDecimal parses a decimal string into a big.Int and exponent.
 // Returns (n, e) such that n * 10^(-e) equals the original number.
 func ParseDecimal(s string) (_ *big.Int, exp uint32, _ error) {
-	dotIndex := strings.Index(s, ".")
-	if dotIndex == -1 {
+	integerPart, fractionalPart, ok := strings.Cut(s, ".")
+	if !ok {
 		n := &big.Int{}
 		if _, ok := n.SetString(s, 10); !ok {
 			return nil, 0, xerrors.WithStackTrace(fmt.Errorf("invalid integer: %s", s))
@@ -47,9 +47,6 @@ func ParseDecimal(s string) (_ *big.Int, exp uint32, _ error) {
 
 		return n, 0, nil
 	}
-
-	integerPart := s[:dotIndex]
-	fractionalPart := s[dotIndex+1:]
 
 	combined := integerPart + fractionalPart
 	n := &big.Int{}
@@ -368,7 +365,7 @@ func put(x *big.Int, p []byte) {
 	}
 	i := len(p)
 	for _, d := range x.Bits() {
-		for j := 0; j < wordSize; j++ {
+		for range wordSize {
 			i--
 			p[i] = byte(d)
 			d >>= 8

--- a/pkg/xslices/filter.go
+++ b/pkg/xslices/filter.go
@@ -3,7 +3,7 @@ package xslices
 func Filter[T any](in []T, filter func(t T) bool) (out []T) {
 	out = make([]T, 0, len(in))
 
-	for i := 0; i < len(in); i++ {
+	for i := range in {
 		if filter(in[i]) {
 			out = append(out, in[i])
 		}

--- a/pkg/xslices/split.go
+++ b/pkg/xslices/split.go
@@ -4,7 +4,7 @@ func Split[T any](x []T, isOk func(t T) bool) (good, bad []T) {
 	good = make([]T, 0, len(x))
 	bad = make([]T, 0, len(x))
 
-	for i := 0; i < len(x); i++ {
+	for i := range x {
 		if isOk(x[i]) {
 			good = append(good, x[i])
 		} else {

--- a/pkg/xslices/uniq.go
+++ b/pkg/xslices/uniq.go
@@ -2,13 +2,11 @@ package xslices
 
 import (
 	"cmp"
-	"sort"
+	"slices"
 )
 
 func Uniq[T cmp.Ordered](in []T) (out []T) {
-	sort.Slice(in, func(i, j int) bool {
-		return in[i] < in[j]
-	})
+	slices.Sort(in)
 
 	out = make([]T, 0, len(in))
 	out = append(out, in[0])

--- a/pkg/xstring/buffer.go
+++ b/pkg/xstring/buffer.go
@@ -10,7 +10,7 @@ type buffer struct {
 	bytes.Buffer
 }
 
-var buffersPool = sync.Pool{New: func() interface{} {
+var buffersPool = sync.Pool{New: func() any {
 	return &buffer{}
 }}
 

--- a/pkg/xtest/grpclogger.go
+++ b/pkg/xtest/grpclogger.go
@@ -29,7 +29,7 @@ func NewGrpcLogger(t testing.TB) GrpcLogger {
 func (l GrpcLogger) UnaryClientInterceptor(
 	ctx context.Context,
 	method string,
-	req, reply interface{},
+	req, reply any,
 	cc *grpc.ClientConn,
 	invoker grpc.UnaryInvoker,
 	opts ...grpc.CallOption,
@@ -88,7 +88,7 @@ func (g grpcLoggerStream) CloseSend() error {
 	return err
 }
 
-func (g grpcLoggerStream) SendMsg(m interface{}) error {
+func (g grpcLoggerStream) SendMsg(m any) error {
 	err := g.ClientStream.SendMsg(m)
 	if err != nil {
 		g.t.Logf("SendMsg (streamID: %v) with err '%v':\n%v ", g.streamID, err, m)
@@ -99,7 +99,7 @@ func (g grpcLoggerStream) SendMsg(m interface{}) error {
 	return err
 }
 
-func (g grpcLoggerStream) RecvMsg(m interface{}) error {
+func (g grpcLoggerStream) RecvMsg(m any) error {
 	err := g.ClientStream.RecvMsg(m)
 	if err != nil {
 		g.t.Logf("RecvMsg (streamID: %v) with err '%v':\n%v ", g.streamID, err, m)

--- a/pkg/xtest/logger.go
+++ b/pkg/xtest/logger.go
@@ -25,7 +25,7 @@ func (s *SyncedTest) Cleanup(f func()) {
 	s.T.Cleanup(f)
 }
 
-func (s *SyncedTest) Error(args ...interface{}) {
+func (s *SyncedTest) Error(args ...any) {
 	s.m.Lock()
 	defer s.m.Unlock()
 	s.T.Helper()
@@ -33,7 +33,7 @@ func (s *SyncedTest) Error(args ...interface{}) {
 	s.T.Error(args...)
 }
 
-func (s *SyncedTest) Errorf(format string, args ...interface{}) {
+func (s *SyncedTest) Errorf(format string, args ...any) {
 	s.m.Lock()
 	defer s.m.Unlock()
 	s.T.Helper()
@@ -65,7 +65,7 @@ func (s *SyncedTest) Failed() bool {
 	return s.T.Failed()
 }
 
-func (s *SyncedTest) Fatal(args ...interface{}) {
+func (s *SyncedTest) Fatal(args ...any) {
 	s.m.Lock()
 	defer s.m.Unlock()
 	s.T.Helper()
@@ -73,7 +73,7 @@ func (s *SyncedTest) Fatal(args ...interface{}) {
 	s.T.Fatal(args...)
 }
 
-func (s *SyncedTest) Fatalf(format string, args ...interface{}) {
+func (s *SyncedTest) Fatalf(format string, args ...any) {
 	s.m.Lock()
 	defer s.m.Unlock()
 	s.T.Helper()
@@ -88,7 +88,7 @@ func (s *SyncedTest) Fatalf(format string, args ...interface{}) {
 //	s.T.Helper()
 //}
 
-func (s *SyncedTest) Log(args ...interface{}) {
+func (s *SyncedTest) Log(args ...any) {
 	s.m.Lock()
 	defer s.m.Unlock()
 	s.T.Helper()
@@ -96,7 +96,7 @@ func (s *SyncedTest) Log(args ...interface{}) {
 	s.T.Log(args...)
 }
 
-func (s *SyncedTest) Logf(format string, args ...interface{}) {
+func (s *SyncedTest) Logf(format string, args ...any) {
 	s.m.Lock()
 	defer s.m.Unlock()
 	s.T.Helper()
@@ -135,7 +135,7 @@ func (s *SyncedTest) Setenv(key, value string) {
 	panic("not implemented")
 }
 
-func (s *SyncedTest) Skip(args ...interface{}) {
+func (s *SyncedTest) Skip(args ...any) {
 	s.m.Lock()
 	defer s.m.Unlock()
 	s.T.Helper()
@@ -151,7 +151,7 @@ func (s *SyncedTest) SkipNow() {
 	s.T.SkipNow()
 }
 
-func (s *SyncedTest) Skipf(format string, args ...interface{}) {
+func (s *SyncedTest) Skipf(format string, args ...any) {
 	s.m.Lock()
 	defer s.m.Unlock()
 	s.T.Helper()

--- a/pkg/xtest/manytimes.go
+++ b/pkg/xtest/manytimes.go
@@ -95,28 +95,28 @@ func (tw *testWrapper) Cleanup(f func()) {
 	tw.cleanup = append(tw.cleanup, f)
 }
 
-func (tw *testWrapper) Error(args ...interface{}) {
+func (tw *testWrapper) Error(args ...any) {
 	tw.TB.Helper()
 
 	tw.flushLogs()
 	tw.TB.Error(args...)
 }
 
-func (tw *testWrapper) Errorf(format string, args ...interface{}) {
+func (tw *testWrapper) Errorf(format string, args ...any) {
 	tw.TB.Helper()
 
 	tw.flushLogs()
 	tw.TB.Errorf(format, args...)
 }
 
-func (tw *testWrapper) Fatal(args ...interface{}) {
+func (tw *testWrapper) Fatal(args ...any) {
 	tw.TB.Helper()
 
 	tw.flushLogs()
 	tw.TB.Fatal(args...)
 }
 
-func (tw *testWrapper) Fatalf(format string, args ...interface{}) {
+func (tw *testWrapper) Fatalf(format string, args ...any) {
 	tw.TB.Helper()
 
 	tw.flushLogs()
@@ -137,7 +137,7 @@ func (tw *testWrapper) FailNow() {
 	tw.TB.FailNow()
 }
 
-func (tw *testWrapper) Log(args ...interface{}) {
+func (tw *testWrapper) Log(args ...any) {
 	tw.TB.Helper()
 
 	tw.m.Lock()
@@ -153,7 +153,7 @@ func (tw *testWrapper) Log(args ...interface{}) {
 	}
 }
 
-func (tw *testWrapper) Logf(format string, args ...interface{}) {
+func (tw *testWrapper) Logf(format string, args ...any) {
 	tw.TB.Helper()
 
 	tw.m.Lock()
@@ -199,5 +199,5 @@ func (tw *testWrapper) doCleanup() {
 
 type logRecord struct {
 	format string
-	args   []interface{}
+	args   []any
 }

--- a/pkg/xtest/to_json.go
+++ b/pkg/xtest/to_json.go
@@ -2,7 +2,7 @@ package xtest
 
 import "encoding/json"
 
-func ToJSON(v interface{}) string {
+func ToJSON(v any) string {
 	b, _ := json.MarshalIndent(v, "", "\t") //nolint:errchkjson
 
 	return string(b)

--- a/pkg/xtest/to_json_test.go
+++ b/pkg/xtest/to_json_test.go
@@ -9,7 +9,7 @@ import (
 func TestToJSON(t *testing.T) {
 	for _, tt := range []struct {
 		name string
-		v    interface{}
+		v    any
 		s    string
 	}{
 		{

--- a/pkg/xtest/waiters.go
+++ b/pkg/xtest/waiters.go
@@ -83,7 +83,7 @@ func SpinWaitConditionWithTimeout(tb testing.TB, l sync.Locker, condWaitTimeout 
 }
 
 // SpinWaitProgress failed if result of progress func no changes without timeout
-func SpinWaitProgress(tb testing.TB, progress func() (progressValue interface{}, finished bool)) {
+func SpinWaitProgress(tb testing.TB, progress func() (progressValue any, finished bool)) {
 	tb.Helper()
 	SpinWaitProgressWithTimeout(tb, commonWaitTimeout, progress)
 }
@@ -91,7 +91,7 @@ func SpinWaitProgress(tb testing.TB, progress func() (progressValue interface{},
 func SpinWaitProgressWithTimeout(
 	tb testing.TB,
 	timeout time.Duration,
-	progress func() (progressValue interface{}, finished bool),
+	progress func() (progressValue any, finished bool),
 ) {
 	tb.Helper()
 

--- a/query/result.go
+++ b/query/result.go
@@ -16,7 +16,7 @@ type (
 	ScanStructOption  = scanner.ScanStructOption
 )
 
-func Named(columnName string, destinationValueReference interface{}) (dst NamedDestination) {
+func Named(columnName string, destinationValueReference any) (dst NamedDestination) {
 	return scanner.NamedRef(columnName, destinationValueReference)
 }
 

--- a/query_bind_test.go
+++ b/query_bind_test.go
@@ -20,7 +20,7 @@ func TestQueryBind(t *testing.T) {
 	for _, tt := range []struct {
 		b      testutil.QueryBindings
 		sql    string
-		args   []interface{}
+		args   []any
 		yql    string
 		params *table.QueryParameters
 		err    error
@@ -34,7 +34,7 @@ func TestQueryBind(t *testing.T) {
 			sql: `$cnt = (SELECT 2 * COUNT(*) FROM my_table);
 
 UPDATE my_table SET data = CAST($cnt AS Optional<Uint64>) WHERE id = ?;`,
-			args: []interface{}{uint64(6)},
+			args: []any{uint64(6)},
 			yql: `-- bind TablePathPrefix
 PRAGMA TablePathPrefix("/local/test");
 
@@ -58,7 +58,7 @@ UPDATE my_table SET data = CAST($cnt AS Optional<Uint64>) WHERE id = $p0;`,
 			sql: `$cnt = (SELECT 2 * COUNT(*) FROM my_table);
 
 UPDATE my_table SET data = CAST($cnt AS Uint64) WHERE id = $1;`,
-			args: []interface{}{uint64(6)},
+			args: []any{uint64(6)},
 			yql: `-- bind TablePathPrefix
 PRAGMA TablePathPrefix("/local/test");
 
@@ -101,7 +101,7 @@ SELECT ?, $1, $p0`,
 				ydb.WithAutoDeclare(),
 			),
 			sql: "SELECT $p0, $p1, $p2, $p0, $p1",
-			args: []interface{}{
+			args: []any{
 				1,
 				"test",
 				[]string{
@@ -132,7 +132,7 @@ SELECT $p0, $p1, $p2, $p0, $p1`,
 				ydb.WithPositionalArgs(),
 			),
 			sql: "SELECT ?, ?, ?",
-			args: []interface{}{
+			args: []any{
 				1,
 				"test",
 				[]string{
@@ -165,7 +165,7 @@ SELECT $p0, $p1, $p2`,
 				ydb.WithNumericArgs(),
 			),
 			sql: "SELECT ?, ?, ?",
-			args: []interface{}{
+			args: []any{
 				1,
 				"test",
 				[]string{
@@ -198,7 +198,7 @@ SELECT $p0, $p1, $p2`,
 				ydb.WithPositionalArgs(),
 			),
 			sql: "SELECT ?, ?, ?",
-			args: []interface{}{
+			args: []any{
 				1,
 				"test",
 				[]string{
@@ -231,7 +231,7 @@ SELECT $p0, $p1, $p2`,
 				ydb.WithNumericArgs(),
 			),
 			sql: "SELECT $1, $2, $3",
-			args: []interface{}{
+			args: []any{
 				1,
 				"test",
 				[]string{
@@ -264,7 +264,7 @@ SELECT $p0, $p1, $p2`,
 				ydb.WithPositionalArgs(),
 			),
 			sql: "SELECT $1, $2, $3",
-			args: []interface{}{
+			args: []any{
 				1,
 				"test",
 				[]string{
@@ -296,7 +296,7 @@ SELECT $p0, $p1, $p2`,
 				ydb.WithNumericArgs(),
 			),
 			sql: "SELECT $1, $2, $3, $1, $2",
-			args: []interface{}{
+			args: []any{
 				1,
 				"test",
 				[]string{
@@ -329,7 +329,7 @@ SELECT $p0, $p1, $p2, $p0, $p1`,
 				ydb.WithPositionalArgs(),
 			),
 			sql: "SELECT a, b, c WHERE id = ? AND date < ? AND value IN (?)",
-			args: []interface{}{
+			args: []any{
 				1, now, []string{"3"},
 			},
 			yql: `-- bind TablePathPrefix
@@ -371,7 +371,7 @@ SELECT 1`,
 DECLARE $param1 AS Text; -- some comment
 DECLARE $param2 AS Text;
 SELECT $param1, $param2`,
-			args: []interface{}{
+			args: []any{
 				sql.Named("param1", 100),
 				sql.Named("$param2", 200),
 			},
@@ -399,7 +399,7 @@ SELECT $param1, $param2`,
 			sql: `
 DECLARE $param2 AS Text; -- some comment
 SELECT $param1, $param2`,
-			args: []interface{}{
+			args: []any{
 				sql.Named("param1", 100),
 				sql.Named("$param2", 200),
 			},
@@ -433,7 +433,7 @@ SELECT 1`,
 		{
 			b:   testutil.QueryBind(ydb.WithPositionalArgs()),
 			sql: "SELECT ?, ?",
-			args: []interface{}{
+			args: []any{
 				1,
 			},
 			err: bind.ErrInconsistentArgs,
@@ -441,7 +441,7 @@ SELECT 1`,
 		{
 			b:   testutil.QueryBind(ydb.WithNumericArgs()),
 			sql: "SELECT $0, $1",
-			args: []interface{}{
+			args: []any{
 				1, 1,
 			},
 			err: bind.ErrUnexpectedNumericArgZero,
@@ -449,7 +449,7 @@ SELECT 1`,
 		{
 			b:   testutil.QueryBind(ydb.WithPositionalArgs()),
 			sql: "SELECT ?, ? -- some comment",
-			args: []interface{}{
+			args: []any{
 				100,
 				200,
 			},
@@ -463,7 +463,7 @@ SELECT $p0, $p1 -- some comment`,
 		{
 			b:   testutil.QueryBind(ydb.WithPositionalArgs()),
 			sql: "SELECT ?, ? -- some comment",
-			args: []interface{}{
+			args: []any{
 				100,
 			},
 			yql: `-- origin query with positional args replacement
@@ -476,7 +476,7 @@ SELECT $p0, $p1 -- some comment`,
 		{
 			b:   testutil.QueryBind(ydb.WithPositionalArgs()),
 			sql: "SELECT ?, ?, ?",
-			args: []interface{}{
+			args: []any{
 				100,
 				200,
 			},
@@ -492,7 +492,7 @@ SELECT $p0, $p1`,
 			b: testutil.QueryBind(ydb.WithPositionalArgs()),
 			sql: `
 SELECT ? /* some comment with ? */, ?`,
-			args: []interface{}{
+			args: []any{
 				100,
 				200,
 			},
@@ -510,7 +510,7 @@ SELECT $p0 /* some comment with ? */, $p1`,
 				ydb.WithPositionalArgs(),
 			),
 			sql: "SELECT ?, ?",
-			args: []interface{}{
+			args: []any{
 				100,
 				200,
 			},
@@ -531,7 +531,7 @@ SELECT $p0, $p1`,
 				ydb.WithPositionalArgs(),
 			),
 			sql: "SELECT ?, ?",
-			args: []interface{}{
+			args: []any{
 				100,
 				200,
 			},
@@ -552,7 +552,7 @@ SELECT $p0, $p1`,
 		{
 			b:   testutil.QueryBind(ydb.WithNumericArgs()),
 			sql: "SELECT $1 /* some comment with $3 */, $2",
-			args: []interface{}{
+			args: []any{
 				1,
 			},
 			err: bind.ErrInconsistentArgs,
@@ -560,7 +560,7 @@ SELECT $p0, $p1`,
 		{
 			b:   testutil.QueryBind(ydb.WithNumericArgs()),
 			sql: "SELECT $1 /* some comment with $3 */, $2",
-			args: []interface{}{
+			args: []any{
 				100,
 				200,
 			},
@@ -577,7 +577,7 @@ SELECT $p0 /* some comment with $3 */, $p1`,
 				ydb.WithNumericArgs(),
 			),
 			sql: "SELECT $1, $2",
-			args: []interface{}{
+			args: []any{
 				100,
 				200,
 			},
@@ -596,7 +596,7 @@ SELECT $p0, $p1`,
 			b: testutil.QueryBind(ydb.WithNumericArgs()),
 			sql: `
 SELECT $1, $2`,
-			args: []interface{}{
+			args: []any{
 				100,
 				200,
 			},
@@ -614,7 +614,7 @@ SELECT $p0, $p1`,
 				ydb.WithNumericArgs(),
 			),
 			sql: "SELECT $1 /* some comment with $3 */, $2",
-			args: []interface{}{
+			args: []any{
 				100,
 				200,
 			},
@@ -635,7 +635,7 @@ SELECT $p0 /* some comment with $3 */, $p1`,
 				ydb.WithNumericArgs(),
 			),
 			sql: "SELECT $1, $2",
-			args: []interface{}{
+			args: []any{
 				100,
 				200,
 			},
@@ -680,7 +680,7 @@ SELECT 1`,
 				ydb.WithAutoDeclare(),
 			),
 			sql: "SELECT $param1, $param2",
-			args: []interface{}{
+			args: []any{
 				sql.Named("param1", 100),
 				sql.Named("$param2", 200),
 			},
@@ -703,7 +703,7 @@ SELECT $param1, $param2`,
 				ydb.WithPositionalArgs(),
 			),
 			sql:  `SELECT ?;`,
-			args: []interface{}{time.Unix(123, 456)},
+			args: []any{time.Unix(123, 456)},
 			yql: `-- bind declares
 DECLARE $p0 AS Timestamp;
 
@@ -718,7 +718,7 @@ SELECT $p0;`,
 				ydb.WithWideTimeTypes(true),
 			),
 			sql:  `SELECT ?;`,
-			args: []interface{}{time.Unix(123, 456)},
+			args: []any{time.Unix(123, 456)},
 			yql: `-- bind declares
 DECLARE $p0 AS Timestamp64;
 

--- a/retry/budget/budget_test.go
+++ b/retry/budget/budget_test.go
@@ -61,7 +61,7 @@ func TestPercent(t *testing.T) {
 			b       = Percent(int(percent * 100))
 			success int
 		)
-		for i := 0; i < total; i++ {
+		for range total {
 			if b.Acquire(ctx) == nil {
 				success++
 			}

--- a/retry/retry.go
+++ b/retry/retry.go
@@ -28,7 +28,7 @@ type retryOptions struct {
 	slowBackoff backoff.Backoff
 	budget      budget.Budget
 
-	panicCallback func(e interface{})
+	panicCallback func(e any)
 }
 
 type Option interface {
@@ -225,7 +225,7 @@ func WithSlowBackoff(b backoff.Backoff) slowBackoffOption {
 var _ Option = panicCallbackOption{}
 
 type panicCallbackOption struct {
-	callback func(e interface{})
+	callback func(e any)
 }
 
 func (o panicCallbackOption) ApplyRetryOption(opts *retryOptions) {
@@ -242,7 +242,7 @@ func (o panicCallbackOption) ApplyDoTxOption(opts *doTxOptions) {
 
 // WithPanicCallback returns panic callback option
 // If not defined - panic would not intercept with driver
-func WithPanicCallback(panicCallback func(e interface{})) panicCallbackOption {
+func WithPanicCallback(panicCallback func(e any)) panicCallbackOption {
 	return panicCallbackOption{callback: panicCallback}
 }
 

--- a/retry/retry_test.go
+++ b/retry/retry_test.go
@@ -189,10 +189,10 @@ func TestRetryWithBudget(t *testing.T) {
 
 type MockPanicCallback struct {
 	called   bool
-	received interface{}
+	received any
 }
 
-func (m *MockPanicCallback) Call(e interface{}) {
+func (m *MockPanicCallback) Call(e any) {
 	m.called = true
 	m.received = e
 }

--- a/scripting/scripting.go
+++ b/scripting/scripting.go
@@ -14,7 +14,9 @@ const (
 	ExplainModeUnknown ExplainMode = iota
 	ExplainModeValidate
 	ExplainModePlan
+)
 
+const (
 	ExplainModeDefault = ExplainModePlan
 )
 

--- a/spans/driver.go
+++ b/spans/driver.go
@@ -374,7 +374,7 @@ func driver(adapter Adapter) trace.Driver { //nolint:gocyclo,funlen
 					} else {
 						mask.WriteString("****")
 					}
-					mask.WriteString(fmt.Sprintf("(CRC-32c: %08X)", crc32.Checksum([]byte(info.Token), crc32.IEEETable)))
+					fmt.Fprintf(&mask, "(CRC-32c: %08X)", crc32.Checksum([]byte(info.Token), crc32.IEEETable))
 					parent.Log(functionID,
 						kv.String("token", mask.String()),
 					)

--- a/sugar/params.go
+++ b/sugar/params.go
@@ -86,7 +86,7 @@ func parameterOptionsToDeclares(v []table.ParameterOption) string {
 }
 
 func namedArgsToDeclares(v []sql.NamedArg) (string, error) {
-	vv, err := bind.Params(func() (newArgs []interface{}) {
+	vv, err := bind.Params(func() (newArgs []any) {
 		for i := range v {
 			newArgs = append(newArgs, v[i])
 		}

--- a/sugar/params_test.go
+++ b/sugar/params_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestGenerateDeclareSection(t *testing.T) {
 	splitDeclares := func(declaresSection string) (declares []string) {
-		for _, s := range strings.Split(declaresSection, ";") {
+		for s := range strings.SplitSeq(declaresSection, ";") {
 			s = strings.TrimSpace(s)
 			if s != "" {
 				declares = append(declares, s)
@@ -118,7 +118,7 @@ func TestGenerateDeclareSection(t *testing.T) {
 func TestGenerateDeclareSection_ParameterOption(t *testing.T) {
 	b := testutil.QueryBind(bind.AutoDeclare{})
 	getDeclares := func(declaresSection string) (declares []string) {
-		for _, s := range strings.Split(declaresSection, "\n") {
+		for s := range strings.SplitSeq(declaresSection, "\n") {
 			s = strings.TrimSpace(s)
 			if s != "" && !strings.HasPrefix(s, "--") {
 				declares = append(declares, strings.TrimRight(s, ";"))
@@ -129,11 +129,11 @@ func TestGenerateDeclareSection_ParameterOption(t *testing.T) {
 		return declares
 	}
 	for _, tt := range []struct {
-		params   []interface{}
+		params   []any
 		declares []string
 	}{
 		{
-			params: []interface{}{
+			params: []any{
 				table.ValueParam(
 					"$values",
 					types.ListValue(
@@ -150,7 +150,7 @@ func TestGenerateDeclareSection_ParameterOption(t *testing.T) {
 			},
 		},
 		{
-			params: []interface{}{
+			params: []any{
 				table.ValueParam(
 					"$delta",
 					types.IntervalValueFromDuration(time.Hour),
@@ -161,7 +161,7 @@ func TestGenerateDeclareSection_ParameterOption(t *testing.T) {
 			},
 		},
 		{
-			params: []interface{}{
+			params: []any{
 				table.ValueParam(
 					"$ts",
 					types.TimestampValueFromTime(time.Now()),
@@ -172,7 +172,7 @@ func TestGenerateDeclareSection_ParameterOption(t *testing.T) {
 			},
 		},
 		{
-			params: []interface{}{
+			params: []any{
 				table.ValueParam(
 					"$a",
 					types.BoolValue(true),
@@ -193,7 +193,7 @@ func TestGenerateDeclareSection_ParameterOption(t *testing.T) {
 			},
 		},
 		{
-			params: []interface{}{
+			params: []any{
 				table.ValueParam(
 					"$a",
 					types.BoolValue(true),
@@ -225,7 +225,7 @@ func TestGenerateDeclareSection_ParameterOption(t *testing.T) {
 func TestGenerateDeclareSection_NamedArg(t *testing.T) {
 	b := testutil.QueryBind(bind.AutoDeclare{})
 	getDeclares := func(declaresSection string) (declares []string) {
-		for _, s := range strings.Split(declaresSection, "\n") {
+		for s := range strings.SplitSeq(declaresSection, "\n") {
 			s = strings.TrimSpace(s)
 			if s != "" && !strings.HasPrefix(s, "--") {
 				declares = append(declares, strings.TrimRight(s, ";"))
@@ -236,11 +236,11 @@ func TestGenerateDeclareSection_NamedArg(t *testing.T) {
 		return declares
 	}
 	for _, tt := range []struct {
-		params   []interface{}
+		params   []any
 		declares []string
 	}{
 		{
-			params: []interface{}{
+			params: []any{
 				sql.Named(
 					"values",
 					types.ListValue(
@@ -257,7 +257,7 @@ func TestGenerateDeclareSection_NamedArg(t *testing.T) {
 			},
 		},
 		{
-			params: []interface{}{
+			params: []any{
 				sql.Named(
 					"delta",
 					types.IntervalValueFromDuration(time.Hour),
@@ -268,7 +268,7 @@ func TestGenerateDeclareSection_NamedArg(t *testing.T) {
 			},
 		},
 		{
-			params: []interface{}{
+			params: []any{
 				sql.Named(
 					"ts",
 					types.TimestampValueFromTime(time.Now()),
@@ -279,7 +279,7 @@ func TestGenerateDeclareSection_NamedArg(t *testing.T) {
 			},
 		},
 		{
-			params: []interface{}{
+			params: []any{
 				sql.Named(
 					"a",
 					types.BoolValue(true),
@@ -300,7 +300,7 @@ func TestGenerateDeclareSection_NamedArg(t *testing.T) {
 			},
 		},
 		{
-			params: []interface{}{
+			params: []any{
 				sql.Named(
 					"a",
 					types.BoolValue(true),
@@ -322,7 +322,7 @@ func TestGenerateDeclareSection_NamedArg(t *testing.T) {
 		},
 
 		{
-			params: []interface{}{
+			params: []any{
 				sql.Named("delta", time.Hour),
 			},
 			declares: []string{
@@ -330,7 +330,7 @@ func TestGenerateDeclareSection_NamedArg(t *testing.T) {
 			},
 		},
 		{
-			params: []interface{}{
+			params: []any{
 				sql.Named("ts", time.Now()),
 			},
 			declares: []string{
@@ -338,7 +338,7 @@ func TestGenerateDeclareSection_NamedArg(t *testing.T) {
 			},
 		},
 		{
-			params: []interface{}{
+			params: []any{
 				sql.Named("$a", true),
 				sql.Named("$b", int64(123)),
 				sql.Named("$c", func(s string) *string { return &s }("test")),
@@ -350,7 +350,7 @@ func TestGenerateDeclareSection_NamedArg(t *testing.T) {
 			},
 		},
 		{
-			params: []interface{}{
+			params: []any{
 				sql.Named("$a", func(b bool) *bool { return &b }(true)),
 				sql.Named("b", func(i int64) *int64 { return &i }(123)),
 				sql.Named("c", func(s string) *string { return &s }("test")),

--- a/sugar/result.go
+++ b/sugar/result.go
@@ -42,7 +42,7 @@ func (r *result) NextRow() bool {
 }
 
 func (r *result) Scan(indexedValues ...indexed.RequiredOrOptional) error {
-	values := make([]interface{}, 0, len(indexedValues))
+	values := make([]any, 0, len(indexedValues))
 	for _, value := range indexedValues {
 		values = append(values, value)
 	}
@@ -59,7 +59,7 @@ func (r *result) ScanNamed(namedValues ...named.Value) error {
 	return r.row.ScanNamed(values...)
 }
 
-func (r *result) ScanStruct(dst interface{}) error {
+func (r *result) ScanStruct(dst any) error {
 	return r.row.ScanStruct(dst)
 }
 

--- a/table/example_test.go
+++ b/table/example_test.go
@@ -153,7 +153,7 @@ func Example_bulkUpsert() {
 	// prepare native go data
 	const batchSize = 10000
 	logs := make([]logMessage, 0, batchSize)
-	for i := 0; i < batchSize; i++ {
+	for i := range batchSize {
 		logs = append(logs, logMessage{
 			App:       fmt.Sprintf("App_%d", i/256),
 			Host:      fmt.Sprintf("192.168.0.%d", i%256),
@@ -313,7 +313,7 @@ func Example_bulkUpsertWithCompression() {
 	// prepare native go data
 	const batchSize = 10000
 	logs := make([]logMessage, 0, batchSize)
-	for i := 0; i < batchSize; i++ {
+	for i := range batchSize {
 		logs = append(logs, logMessage{
 			App:       fmt.Sprintf("App_%d", i/256),
 			Host:      fmt.Sprintf("192.168.0.%d", i%256),

--- a/table/result/indexed/indexed.go
+++ b/table/result/indexed/indexed.go
@@ -8,7 +8,7 @@ package indexed
 //	type Required interface {
 //	  *int8 | *int64 | *string | types.Scanner | json.Unmarshaler
 //	}
-type Required interface{}
+type Required any
 
 // Optional is a type scan destination of optional ydb values
 // Optional must be a double pointer value destination
@@ -22,7 +22,7 @@ type Required interface{}
 // or alias such as
 //
 //	type Optional *Required
-type Optional interface{}
+type Optional any
 
 // RequiredOrOptional is a type scan destination of ydb values
 // This is a proxy type for preparing go1.18 type set constrains such as
@@ -30,4 +30,4 @@ type Optional interface{}
 //	type valueType interface {
 //	  Required | Optional
 //	}
-type RequiredOrOptional interface{}
+type RequiredOrOptional any

--- a/table/result/named/named.go
+++ b/table/result/named/named.go
@@ -11,7 +11,7 @@ const (
 
 type Value struct {
 	Name  string
-	Value interface{}
+	Value any
 	Type  Type
 }
 
@@ -20,7 +20,7 @@ type Value struct {
 // # If column value is NULL, then ScanNamed will write a nil into destination
 //
 // Warning: value must double-pointed data destination
-func Optional(columnName string, destination interface{}) Value {
+func Optional(columnName string, destination any) Value {
 	if columnName == "" {
 		panic("columnName must be not empty")
 	}
@@ -35,7 +35,7 @@ func Optional(columnName string, destination interface{}) Value {
 // Required makes an object with destination address for column value with name columnName
 //
 // Warning: value must single-pointed data destination
-func Required(columnName string, destinationValueReference interface{}) Value {
+func Required(columnName string, destinationValueReference any) Value {
 	if columnName == "" {
 		panic("columnName must be not empty")
 	}
@@ -51,7 +51,7 @@ func Required(columnName string, destinationValueReference interface{}) Value {
 //
 // If scanned YDB value is NULL - default type value will be applied to value destination
 // Warning: value must single-pointed data destination
-func OptionalWithDefault(columnName string, destinationValueReference interface{}) Value {
+func OptionalWithDefault(columnName string, destinationValueReference any) Value {
 	if columnName == "" {
 		panic("columnName must be not empty")
 	}

--- a/table/types/cast.go
+++ b/table/types/cast.go
@@ -12,7 +12,7 @@ import (
 var errNilValue = errors.New("nil value")
 
 // CastTo try cast value to destination type value
-func CastTo(v Value, dst interface{}) error {
+func CastTo(v Value, dst any) error {
 	if v == nil {
 		return xerrors.WithStackTrace(errNilValue)
 	}

--- a/table/types/value.go
+++ b/table/types/value.go
@@ -512,6 +512,6 @@ func NullableDyNumberValue(v *string) Value {
 	return value.NullableDyNumberValue(v)
 }
 
-func Nullable(t Type, v interface{}) Value {
+func Nullable(t Type, v any) Value {
 	return value.Nullable(t, v)
 }

--- a/testutil/compare.go
+++ b/testutil/compare.go
@@ -94,7 +94,7 @@ func expandTuple(v *Ydb.TypedValue) []*Ydb.TypedValue {
 	return values
 }
 
-func notComparableError(lhs, rhs interface{}) error {
+func notComparableError(lhs, rhs any) error {
 	return xerrors.WithStackTrace(fmt.Errorf("%w: %v and %v", ErrNotComparable, lhs, rhs), xerrors.WithSkipDepth(1))
 }
 

--- a/testutil/driver.go
+++ b/testutil/driver.go
@@ -102,7 +102,7 @@ var codeToString = map[MethodCode]string{
 	TableStreamExecuteScanQuery: lastSegment("/Ydb.Table.V1.TableService/StreamExecuteScanQuery"),
 }
 
-func setField(name string, dst, value interface{}) {
+func setField(name string, dst, value any) {
 	x := reflect.ValueOf(dst).Elem()
 	t := x.Type()
 	f, ok := t.FieldByName(name)
@@ -126,8 +126,8 @@ type balancerStub struct {
 	onInvoke func(
 		ctx context.Context,
 		method string,
-		args interface{},
-		reply interface{},
+		args any,
+		reply any,
 		opts ...grpc.CallOption,
 	) error
 	onNewStream func(
@@ -141,8 +141,8 @@ type balancerStub struct {
 func (b *balancerStub) Invoke(
 	ctx context.Context,
 	method string,
-	args interface{},
-	reply interface{},
+	args any,
+	reply any,
 	opts ...grpc.CallOption,
 ) (err error) {
 	if b.onInvoke == nil {
@@ -183,7 +183,7 @@ func (b *balancerStub) Close(ctx context.Context) error {
 }
 
 type (
-	InvokeHandlers    map[MethodCode]func(request interface{}) (result proto.Message, err error)
+	InvokeHandlers    map[MethodCode]func(request any) (result proto.Message, err error)
 	NewStreamHandlers map[MethodCode]func(desc *grpc.StreamDesc) (grpc.ClientStream, error)
 )
 
@@ -194,8 +194,8 @@ func WithInvokeHandlers(invokeHandlers InvokeHandlers) balancerOption {
 		r.onInvoke = func(
 			ctx context.Context,
 			method string,
-			args interface{},
-			reply interface{},
+			args any,
+			reply any,
 			opts ...grpc.CallOption,
 		) (err error) {
 			if handler, ok := invokeHandlers[Method(method).Code()]; ok {
@@ -260,8 +260,8 @@ type clientConn struct {
 	onInvoke func(
 		ctx context.Context,
 		method string,
-		args interface{},
-		reply interface{},
+		args any,
+		reply any,
 		opts ...grpc.CallOption,
 	) error
 	onNewStream func(
@@ -284,8 +284,8 @@ func (c *clientConn) Address() string {
 func (c *clientConn) Invoke(
 	ctx context.Context,
 	method string,
-	args interface{},
-	reply interface{},
+	args any,
+	reply any,
 	opts ...grpc.CallOption,
 ) error {
 	if c.onInvoke == nil {
@@ -313,8 +313,8 @@ type ClientStream struct {
 	OnTrailer   func() metadata.MD
 	OnCloseSend func() error
 	OnContext   func() context.Context
-	OnSendMsg   func(m interface{}) error
-	OnRecvMsg   func(m interface{}) error
+	OnSendMsg   func(m any) error
+	OnRecvMsg   func(m any) error
 }
 
 func (s *ClientStream) Header() (metadata.MD, error) {
@@ -349,7 +349,7 @@ func (s *ClientStream) Context() context.Context {
 	return s.OnContext()
 }
 
-func (s *ClientStream) SendMsg(m interface{}) error {
+func (s *ClientStream) SendMsg(m any) error {
 	if s.OnSendMsg == nil {
 		return xerrors.WithStackTrace(ErrNotImplemented)
 	}
@@ -357,7 +357,7 @@ func (s *ClientStream) SendMsg(m interface{}) error {
 	return s.OnSendMsg(m)
 }
 
-func (s *ClientStream) RecvMsg(m interface{}) error {
+func (s *ClientStream) RecvMsg(m any) error {
 	if s.OnRecvMsg == nil {
 		return xerrors.WithStackTrace(ErrNotImplemented)
 	}

--- a/topic/topicoptions/topicoptions_alter.go
+++ b/topic/topicoptions/topicoptions_alter.go
@@ -1,6 +1,7 @@
 package topicoptions
 
 import (
+	"slices"
 	"sort"
 	"time"
 
@@ -40,9 +41,7 @@ func AlterWithRetentionStorageMB(retentionStorageMB int64) AlterOption {
 
 // AlterWithSupportedCodecs change set of codec, allowed for the topic
 func AlterWithSupportedCodecs(codecs ...topictypes.Codec) AlterOption {
-	sort.Slice(codecs, func(i, j int) bool {
-		return codecs[i] < codecs[j]
-	})
+	slices.Sort(codecs)
 
 	return withSupportedCodecs(codecs)
 }
@@ -96,9 +95,7 @@ func AlterConsumerWithReadFrom(name string, readFrom time.Time) AlterOption {
 
 // AlterConsumerWithSupportedCodecs change codecs, supported by the consumer
 func AlterConsumerWithSupportedCodecs(name string, codecs []topictypes.Codec) AlterOption {
-	sort.Slice(codecs, func(i, j int) bool {
-		return codecs[i] < codecs[j]
-	})
+	slices.Sort(codecs)
 
 	return withConsumerWithSupportedCodecs{
 		name:   name,

--- a/topic/topicoptions/topicoptions_create.go
+++ b/topic/topicoptions/topicoptions_create.go
@@ -1,6 +1,7 @@
 package topicoptions
 
 import (
+	"slices"
 	"sort"
 	"time"
 
@@ -43,9 +44,7 @@ func CreateWithRetentionStorageMB(retentionStorageMB int64) CreateOption {
 
 // CreateWithSupportedCodecs set supported codecs for the topic
 func CreateWithSupportedCodecs(codecs ...topictypes.Codec) CreateOption {
-	sort.Slice(codecs, func(i, j int) bool {
-		return codecs[i] < codecs[j]
-	})
+	slices.Sort(codecs)
 
 	return withSupportedCodecs(codecs)
 }

--- a/topic/topicsugar/topicreader.go
+++ b/topic/topicsugar/topicreader.go
@@ -14,13 +14,13 @@ func ProtoUnmarshal(msg *topicreader.Message, dst proto.Message) error {
 }
 
 // JSONUnmarshal unmarshal json message content to dst must by pointer to struct
-func JSONUnmarshal(msg *topicreader.Message, dst interface{}) error {
+func JSONUnmarshal(msg *topicreader.Message, dst any) error {
 	return UnmarshalMessageWith(msg, json.Unmarshal, dst)
 }
 
 // UnmarshalMessageWith call unmarshaller func with message content
 // unmarshaller func must not use received byte slice after return.
-func UnmarshalMessageWith(msg *topicreader.Message, unmarshaler UnmarshalFunc, v interface{}) error {
+func UnmarshalMessageWith(msg *topicreader.Message, unmarshaler UnmarshalFunc, v any) error {
 	return msg.UnmarshalTo(messageUnmarshaler{unmarshaler: unmarshaler, dst: v})
 }
 
@@ -40,7 +40,7 @@ func (c messageUnmarhalerToCallback) UnmarshalYDBTopicMessage(data []byte) error
 
 // UnmarshalFunc is func to unmarshal data to interface, for example
 // json.Unmarshal from standard library
-type UnmarshalFunc func(data []byte, dst interface{}) error
+type UnmarshalFunc func(data []byte, dst any) error
 
 type protobufUnmarshaler struct {
 	dst proto.Message
@@ -53,7 +53,7 @@ func (m protobufUnmarshaler) UnmarshalYDBTopicMessage(data []byte) error {
 
 type messageUnmarshaler struct {
 	unmarshaler UnmarshalFunc
-	dst         interface{}
+	dst         any
 }
 
 // UnmarshalYDBTopicMessage implement unmarshaller

--- a/topic/topictypes/topictypes.go
+++ b/topic/topictypes/topictypes.go
@@ -1,6 +1,7 @@
 package topictypes
 
 import (
+	"maps"
 	"time"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/clone"
@@ -230,9 +231,7 @@ func (d *TopicDescription) FromRaw(raw *rawtopic.DescribeTopicResult) {
 	d.RetentionStorageMB = raw.RetentionStorageMB
 
 	d.Attributes = make(map[string]string)
-	for k, v := range raw.Attributes {
-		d.Attributes[k] = v
-	}
+	maps.Copy(d.Attributes, raw.Attributes)
 
 	d.Consumers = make([]Consumer, len(raw.Consumers))
 	for i := 0; i < len(raw.Consumers); i++ {

--- a/trace/trace_test.go
+++ b/trace/trace_test.go
@@ -7,13 +7,13 @@ import (
 )
 
 // Stub is a helper function that stubs all functional fields of x with given f.
-func Stub(x interface{}, f func(name string, args ...interface{})) {
+func Stub(x any, f func(name string, args ...any)) {
 	(FieldStubber{
 		OnCall: f,
 	}).Stub(reflect.ValueOf(x))
 }
 
-func ClearContext(x interface{}) interface{} {
+func ClearContext(x any) any {
 	p := reflect.ValueOf(x).Index(0)
 	t := p.Elem().Type()
 	f, has := t.FieldByName("Context")
@@ -39,7 +39,7 @@ type FieldStubber struct {
 	// OnCall is an optional callback that will be called for each stubbed
 	// field getting called.
 	// Internals: https://github.com/ydb-platform/ydb-go-sdk/blob/master/VERSIONING.md#internals
-	OnCall func(name string, args ...interface{})
+	OnCall func(name string, args ...any)
 }
 
 // Stub fills in given x struct.
@@ -70,7 +70,7 @@ func (f FieldStubber) Stub(x reflect.Value) {
 			if f.OnCall == nil {
 				return out
 			}
-			params := make([]interface{}, len(args))
+			params := make([]any, len(args))
 			for i, arg := range args {
 				params[i] = arg.Interface()
 			}
@@ -114,7 +114,7 @@ func TestDatabaseSQL(t *testing.T) {
 	testSingleTrace(t, &DatabaseSQL{}, "DatabaseSQL")
 }
 
-func testSingleTrace(t *testing.T, x interface{}, traceName string) {
+func testSingleTrace(t *testing.T, x any, traceName string) {
 	t.Helper()
 	v := reflect.ValueOf(x)
 	m := v.MethodByName("Compose")
@@ -141,7 +141,7 @@ func stubEachFunc(x reflect.Value) map[string]bool {
 		OnStub: func(name string) {
 			fs[name] = false
 		},
-		OnCall: func(name string, _ ...interface{}) {
+		OnCall: func(name string, _ ...any) {
 			fs[name] = true
 		},
 	}).Stub(x)

--- a/with_test.go
+++ b/with_test.go
@@ -139,7 +139,7 @@ func TestWithCertificatesCached(t *testing.T) {
 
 			hitCounter, missCounter = 0, 0
 
-			for i := 0; i < n; i++ {
+			for range n {
 				_, _, err := db.with(ctx,
 					func(ctx context.Context, c *Driver) error {
 						return nil // nothing to do


### PR DESCRIPTION
## Summary
- Upgraded CI to Go 1.26 and golangci-lint v2.11.4, updated YDB test matrix (added `edge`, removed `25.2`)
- Disabled new linters in golangci config: `prealloc`, `godoclint`, `unqueryvet`
- Modernized Go code across 127 files:
  - `interface{}` → `any`
  - `for i := 0; i < N; i++` → `for range N`
  - Manual contains/sort loops → `slices.Contains` / `slices.Sort`
  - `strings.Split` + for → `strings.SplitSeq`
  - `reflect.TypeOf(T{})` → `reflect.TypeFor[T]()`
  - `s.NumFields()` loop → `s.Fields()` range iterator
  - Removed custom `min`/`max` in favor of builtins
  - Split unrelated iota const blocks

## Test plan
- [ ] CI lint passes with golangci-lint v2.11.4
- [ ] Unit tests pass on Go 1.21.x and 1.26.x
- [ ] Integration tests pass against YDB 24.4, latest, edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)