### PR TITLE
Fix multiwriter Write to wait for background init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed multiwriter `Write` to wait for background initialization before touching partition chooser or sequence numbers, preventing races and errors when writing immediately after `StartWriter`
+
 ## v3.134.0
 * Fixed `sugar.RemoveRecursive()` for directories containing external data sources or external tables
 * Added `table.DescribeExternalDataSource()` and `table.DescribeExternalTable()` methods for describing external data sources and external tables

--- a/internal/topic/topicmultiwriter/orchestrator.go
+++ b/internal/topic/topicmultiwriter/orchestrator.go
@@ -197,6 +197,10 @@ func (o *orchestrator) pushMessage(ctx context.Context, msg message) (err error)
 		}
 	}()
 
+	if err := o.waitInitDone(ctx); err != nil {
+		return err
+	}
+
 	var autoSetSeqNo bool
 	o.mu.WithLock(func() {
 		autoSetSeqNo = o.writerCfg.AutoSetSeqNo

--- a/internal/topic/topicmultiwriter/topicmultiwriter_test.go
+++ b/internal/topic/topicmultiwriter/topicmultiwriter_test.go
@@ -379,6 +379,28 @@ func TestMultiWriter_DescribeError(t *testing.T) {
 	require.True(t, errors.Is(err, describeErr) || errors.Is(err, context.DeadlineExceeded))
 }
 
+func TestMultiWriter_Write_WaitsForInit(t *testing.T) {
+	t.Parallel()
+
+	ctx := xtest.Context(t)
+	stubClient := stubs.NewStubTopicClient(t, stubs.DefaultStubTopicDescription(t))
+	multiWriter := newTestMultiWriterWithInitDelay(
+		t,
+		func(ctx context.Context, path string) (topictypes.TopicDescription, error) {
+			return stubClient.Describe(ctx, path)
+		},
+		200*time.Millisecond,
+	)
+
+	err := multiWriter.Write(ctx, []topicwriterinternal.PublicMessage{{
+		Data:  bytes.NewReader([]byte("hello")),
+		SeqNo: 1,
+		Key:   "partition-key-1",
+	}})
+	require.NoError(t, err)
+	require.NoError(t, multiWriter.Close(ctx))
+}
+
 func TestMultiWriter_Write_WithBasicWriter(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Pull request type                                            

  - [x] Bugfix                                                                                                                                                                                                                                                     
  - [ ] Feature
  - [ ] Code style update (formatting, renaming)                                                                                                                                                                                                                   
  - [ ] Refactoring (no functional changes, no api changes)       
  - [ ] Build related changes                                                                                                                                                                                                                                      
  - [ ] Documentation content changes
  - [ ] Other (please describe):                                                                                                                                                                                                                                   
                                                                  
  ## What is the current behavior?

  `MultiWriter.Write`, called immediately after `StartWriter`, reads the                                                                                                                                                                                           
  orchestrator's partition chooser and `currentSeqNo` without waiting for
  the background `init()` (describe topic, `initSeqNo`, partition chooser                                                                                                                                                                                          
  setup) to finish. This leads to three classes of races:                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                   
  - nil partition chooser panic when no chooser is passed via options                                                                                                                                                                                              
    (the default chooser is assigned inside `init()`)                                                                                                                                                                                                              
  - `"no partitions configured"` from Hash/Bound choosers when                                                                                                                                                                                                     
    `AddNewPartitions` has not yet run at the end of `init()`                                                                                                                                                                                                      
  - `SeqNo` values that collide with server-side deduplication because                                                                                                                                                                                             
    `initSeqNo` has not yet set `currentSeqNo` to the server's `maxSeqNo`                                                                                                                                                                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                   
  ## What is the new behavior?                                    

  - `pushMessage` now calls the existing `waitInitDone(ctx)` helper at                                                                                                                                                                                             
    the top, so `Write` blocks until orchestrator init has completed
    before touching the partition chooser or sequence state.                                                                                                                                                                                                       
  - Mirrors the `waitFirstInitResponse` guard already used in                                                                                                                                                                                                      
    `WriterReconnector.writePrepared`.                                                                                                                                                                                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                                                                                                                                                           