### PR TITLE
Fix table.Session.Execute ignoring options.WithCommit()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed `table.Session.Execute` ignoring `options.WithCommit()` so transactions were not committed when the option was passed
+
 ## v3.134.1
 * Changed multi-partition topic writer (`topicoptions.WithWriteToManyPartitions`) so `Write` and `Flush` block until internal initialization completes, consistent with single-partition writers
 

--- a/internal/table/session.go
+++ b/internal/table/session.go
@@ -168,12 +168,10 @@ func (e queryClientExecutor) execute(
 
 func (e tableClientExecutor) execute(
 	ctx context.Context,
-	txControl *tx.Control,
+	_ *tx.Control,
 	request *Ydb_Table.ExecuteDataQueryRequest,
 	callOptions ...grpc.CallOption,
 ) (*transaction, result.Result, error) {
-	request.TxControl = txControl.ToYdbTableTransactionControl()
-
 	r, err := executeDataQuery(ctx, e.client, request, callOptions...)
 	if err != nil {
 		return nil, nil, xerrors.WithStackTrace(err)

--- a/tests/integration/table_tx_control_test.go
+++ b/tests/integration/table_tx_control_test.go
@@ -5,14 +5,20 @@ package integration
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3"
+	"github.com/ydb-platform/ydb-go-sdk/v3/balancers"
 	"github.com/ydb-platform/ydb-go-sdk/v3/table"
+	"github.com/ydb-platform/ydb-go-sdk/v3/table/options"
 )
 
 func TestTableTxControl(t *testing.T) {
 	scope := newScope(t)
-	driver := scope.Driver()
+	driver := scope.Driver(ydb.WithBalancer(balancers.SingleConn()))
 
 	t.Run("rw-auto-commit", func(t *testing.T) {
 		txControl := table.TxControl(
@@ -55,6 +61,58 @@ func TestTableTxControl(t *testing.T) {
 		err := driver.Table().Do(scope.Ctx, func(ctx context.Context, s table.Session) error {
 			_, _, err := s.Execute(ctx, txControl, "SELECT 1", nil)
 			return err
+		})
+		scope.Require.NoError(err)
+	})
+	t.Run("write-with-commit", func(t *testing.T) {
+		tablePath := scope.TablePath()
+		const id = 1
+		const value = "committed-value"
+
+		txControl := table.TxControl(
+			table.BeginTx(table.WithSerializableReadWrite()),
+		)
+
+		err := driver.Table().Do(scope.Ctx, func(ctx context.Context, s table.Session) error {
+			tx, res, err := s.Execute(ctx, txControl, "SELECT 1", nil)
+			scope.Require.NoError(err)
+			scope.Require.NoError(res.Err())
+			defer res.Close()
+
+			query := fmt.Sprintf(
+				"UPSERT INTO `%s` (id, val) VALUES (%d, \"%s\")",
+				tablePath,
+				id,
+				value,
+			)
+			res, err = tx.Execute(ctx, query, nil, options.WithCommit())
+			scope.Require.NoError(err)
+			defer res.Close()
+
+			return res.Err()
+		})
+		scope.Require.NoError(err)
+
+		err = driver.Table().Do(scope.Ctx, func(ctx context.Context, s table.Session) error {
+			_, res, err := s.Execute(
+				ctx,
+				table.DefaultTxControl(),
+				fmt.Sprintf("SELECT val FROM `%s` WHERE id = %d", tablePath, id),
+				nil,
+			)
+			scope.Require.NoError(err)
+			defer res.Close()
+			if err = res.NextResultSetErr(ctx); err != nil {
+				return err
+			}
+			scope.Require.True(res.NextRow(), "no rows")
+
+			var actual *string
+			err = res.Scan(&actual)
+			require.NoError(t, err)
+			scope.Require.Equal(value, *actual)
+
+			return res.Err()
 		})
 		scope.Require.NoError(err)
 	})

--- a/tests/integration/table_tx_control_test.go
+++ b/tests/integration/table_tx_control_test.go
@@ -10,15 +10,13 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/ydb-platform/ydb-go-sdk/v3"
-	"github.com/ydb-platform/ydb-go-sdk/v3/balancers"
 	"github.com/ydb-platform/ydb-go-sdk/v3/table"
 	"github.com/ydb-platform/ydb-go-sdk/v3/table/options"
 )
 
 func TestTableTxControl(t *testing.T) {
 	scope := newScope(t)
-	driver := scope.Driver(ydb.WithBalancer(balancers.SingleConn()))
+	driver := scope.Driver()
 
 	t.Run("rw-auto-commit", func(t *testing.T) {
 		txControl := table.TxControl(

--- a/tests/integration/table_tx_control_test.go
+++ b/tests/integration/table_tx_control_test.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/ydb-platform/ydb-go-sdk/v3/table"
 	"github.com/ydb-platform/ydb-go-sdk/v3/table/options"
 )
@@ -107,7 +105,7 @@ func TestTableTxControl(t *testing.T) {
 
 			var actual *string
 			err = res.Scan(&actual)
-			require.NoError(t, err)
+			scope.Require.NoError(err)
 			scope.Require.Equal(value, *actual)
 
 			return res.Err()


### PR DESCRIPTION
## Pull request type

- [x] Bugfix

## What is the current behavior?

`tableClientExecutor.execute` unconditionally overwrote `request.TxControl` with the `txControl` argument **after** `ExecuteDataQueryOption`s had already been applied to the request. This silently dropped the `CommitTx=true` flag that `options.WithCommit()` sets on the request, so transactions opened via `table.BeginTx(...)` remained uncommitted when `WithCommit` was passed to `Execute`.

Issue: repro added in #2089.

## What is the new behavior?

- Removed the stray `request.TxControl = txControl.ToYdbTableTransactionControl()` assignment in `tableClientExecutor.execute` so the `TxControl` built by `Session.Execute` (including `ExecuteDataQueryOption` mutations such as `options.WithCommit()`) is sent to the server as-is.
- Renamed the now-unused `txControl` parameter to `_` — it is still required by the `dataQueryExecutor` interface used by the query-service executor.
- Extended `TestTableTxControl` with a `write-with-commit` subtest that opens a transaction with `BeginTx`, upserts a row using `options.WithCommit()`, then re-reads the row in an independent `DefaultTxControl` transaction to verify it was actually committed. 

## Other information

Git-bisect traced the regression to commit `afdce85` ("replaced table transaction control types to internal/tx control").

Made with [Cursor](https://cursor.com)