### PR TITLE
feat(topic): add WithWriterErrOnQueueFull for fail-fast when the writer queue is full

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* Added `topicoptions.WithWriterErrOnQueueFull(bool)` option for topic writer to make `Write` return `topicwriter.ErrQueueLimitExceed` immediately when the internal queue is full, instead of blocking. Useful for preventing OOM when the writer cannot keep up with produced messages.
+* Un-deprecated `topicwriter.ErrQueueLimitExceed`: it is returned by `Write` when a writer is created with `topicoptions.WithWriterErrOnQueueFull(true)` and the internal queue is full.
+
 ## v3.134.1
 * Changed multi-partition topic writer (`topicoptions.WithWriteToManyPartitions`) so `Write` and `Flush` block until internal initialization completes, consistent with single-partition writers
 

--- a/internal/topic/topicwriterinternal/writer_options.go
+++ b/internal/topic/topicwriterinternal/writer_options.go
@@ -127,6 +127,16 @@ func WithMaxQueueLen(num int) PublicWriterOption {
 	}
 }
 
+// WithErrOnQueueFull controls WriterReconnector.Write when the internal message queue
+// is full. When enable is false (default), the call blocks until space is available
+// or ctx is cancelled. When enable is true, the call returns ErrPublicQueueIsFull
+// immediately without blocking.
+func WithErrOnQueueFull(enable bool) PublicWriterOption {
+	return func(cfg *WriterReconnectorConfig) {
+		cfg.ErrOnQueueFull = enable
+	}
+}
+
 func WithPartitioning(partitioning PublicFuturePartitioning) PublicWriterOption {
 	return func(cfg *WriterReconnectorConfig) {
 		cfg.defaultPartitioning = partitioning.ToRaw()

--- a/internal/topic/topicwriterinternal/writer_reconnector.go
+++ b/internal/topic/topicwriterinternal/writer_reconnector.go
@@ -31,12 +31,14 @@ import (
 )
 
 var (
-	errConnTimeout                                 = xerrors.Wrap(errors.New("ydb: connection timeout"))
-	errStopWriterReconnector                       = xerrors.Wrap(errors.New("ydb: stop writer reconnector"))
-	ErrNonZeroSeqNo                                = xerrors.Wrap(errors.New("ydb: non zero seqno for auto set seqno mode")) //nolint:lll
-	errNoAllowedCodecs                             = xerrors.Wrap(errors.New("ydb: no allowed codecs for write to topic"))
-	errLargeMessage                                = xerrors.Wrap(errors.New("ydb: message uncompressed size more, then limit"))                                                                                                                                                                                             //nolint:lll
-	ErrPublicQueueIsFull                           = xerrors.Wrap(errors.New("ydb: queue is full"))                                                                                                                                                                                                                          //nolint:lll
+	errConnTimeout           = xerrors.Wrap(errors.New("ydb: connection timeout"))
+	errStopWriterReconnector = xerrors.Wrap(errors.New("ydb: stop writer reconnector"))
+	ErrNonZeroSeqNo          = xerrors.Wrap(errors.New("ydb: non zero seqno for auto set seqno mode"))
+	errNoAllowedCodecs       = xerrors.Wrap(errors.New("ydb: no allowed codecs for write to topic"))
+	errLargeMessage          = xerrors.Wrap(errors.New("ydb: message uncompressed size more, then limit"))
+	ErrPublicQueueIsFull     = xerrors.Wrap(
+		errors.New("ydb: queue is full"),
+	)
 	ErrPublicMessagesPutToInternalQueueBeforeError = xerrors.Wrap(errors.New("ydb: the messages was put to internal buffer before the error happened. It mean about the messages can be delivered to the server"))                                                                                                           //nolint:lll
 	errDiffetentTransactions                       = xerrors.Wrap(errors.New("ydb: internal writer has messages from different trasactions. It is internal logic error, write issue please: https://github.com/ydb-platform/ydb-go-sdk/issues/new?assignees=&labels=bug&projects=&template=01_BUG_REPORT.md&title=bug%3A+")) //nolint:lll
 	errWritingByKeyNotSupported                    = xerrors.Wrap(errors.New("ydb: writing by key is not supported for single writer, use WithWriterPartitionByKey or WithPartitionByPartitionID options"))                                                                                                                  //nolint:lll

--- a/internal/topic/topicwriterinternal/writer_reconnector.go
+++ b/internal/topic/topicwriterinternal/writer_reconnector.go
@@ -36,7 +36,7 @@ var (
 	ErrNonZeroSeqNo                                = xerrors.Wrap(errors.New("ydb: non zero seqno for auto set seqno mode")) //nolint:lll
 	errNoAllowedCodecs                             = xerrors.Wrap(errors.New("ydb: no allowed codecs for write to topic"))
 	errLargeMessage                                = xerrors.Wrap(errors.New("ydb: message uncompressed size more, then limit"))                                                                                                                                                                                             //nolint:lll
-	ErrPublicQueueIsFull                           = xerrors.Wrap(errors.New("ydb: queue is full"))                                                                                                                                                                                                                          // Deprecated.
+	ErrPublicQueueIsFull                           = xerrors.Wrap(errors.New("ydb: queue is full"))                                                                                                                                                                                                                          //nolint:lll
 	ErrPublicMessagesPutToInternalQueueBeforeError = xerrors.Wrap(errors.New("ydb: the messages was put to internal buffer before the error happened. It mean about the messages can be delivered to the server"))                                                                                                           //nolint:lll
 	errDiffetentTransactions                       = xerrors.Wrap(errors.New("ydb: internal writer has messages from different trasactions. It is internal logic error, write issue please: https://github.com/ydb-platform/ydb-go-sdk/issues/new?assignees=&labels=bug&projects=&template=01_BUG_REPORT.md&title=bug%3A+")) //nolint:lll
 	errWritingByKeyNotSupported                    = xerrors.Wrap(errors.New("ydb: writing by key is not supported for single writer, use WithWriterPartitionByKey or WithPartitionByPartitionID options"))                                                                                                                  //nolint:lll
@@ -63,6 +63,12 @@ type WriterReconnectorConfig struct {
 	OnWriterInitResponseCallback PublicOnWriterInitResponseCallback
 	OnAckReceivedCallback        func(seqNo int64)
 	MultiMode                    bool
+
+	// ErrOnQueueFull controls Write behavior when the internal message queue is full.
+	// false (default): Write blocks until queue space becomes available or ctx is cancelled.
+	// true: Write returns ErrPublicQueueIsFull immediately without blocking,
+	// allowing callers to implement back-pressure and avoid unbounded memory growth.
+	ErrOnQueueFull bool
 
 	MultiWriterConfig any
 	RetrySettings     topic.RetrySettings
@@ -255,6 +261,28 @@ func (w *WriterReconnector) validateWriteMessages(messages []PublicMessage) erro
 	return nil
 }
 
+// acquireQueueSpaceForWrite reserves capacity in the internal message queue for weight messages.
+// On success the caller must release the same weight with w.semaphore.Release (typically in defer).
+func (w *WriterReconnector) acquireQueueSpaceForWrite(ctx context.Context, weight int64) error {
+	if w.cfg.ErrOnQueueFull {
+		// Non-blocking path: fail fast with ErrPublicQueueIsFull when the queue has no room.
+		// This lets callers avoid unbounded memory growth and implement their own back-pressure.
+		if !w.semaphore.TryAcquire(weight) {
+			return xerrors.WithStackTrace(ErrPublicQueueIsFull)
+		}
+
+		return nil
+	}
+
+	if err := w.semaphore.Acquire(ctx, weight); err != nil {
+		return xerrors.WithStackTrace(
+			fmt.Errorf("ydb: timeout waiting for queue space to become available: %w", err),
+		)
+	}
+
+	return nil
+}
+
 func (w *WriterReconnector) writePrepared(
 	ctx context.Context,
 	messageCount int,
@@ -272,10 +300,8 @@ func (w *WriterReconnector) writePrepared(
 	}
 
 	semaphoreWeight := int64(messageCount)
-	if err := w.semaphore.Acquire(ctx, semaphoreWeight); err != nil {
-		return xerrors.WithStackTrace(
-			fmt.Errorf("ydb: timeout waiting for queue space to become available: %w", err),
-		)
+	if err := w.acquireQueueSpaceForWrite(ctx, semaphoreWeight); err != nil {
+		return err
 	}
 	defer func() {
 		w.semaphore.Release(semaphoreWeight)

--- a/internal/topic/topicwriterinternal/writer_reconnector_err_on_queue_full_test.go
+++ b/internal/topic/topicwriterinternal/writer_reconnector_err_on_queue_full_test.go
@@ -1,0 +1,87 @@
+//go:build go1.25
+
+package topicwriterinternal
+
+import (
+	"context"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawtopic/rawtopicwriter"
+)
+
+// TestWriterReconnector_Write_ErrOnQueueFull uses testing/synctest for deterministic,
+// fast tests (no xtest.TestManyTimes hot loop). Use t.Context so contexts and timers
+// are created in the same synctest bubble as the test.
+//
+// This file is built only on Go 1.25+ (see go1.25 build tag) where testing/synctest exists.
+func TestWriterReconnector_Write_ErrOnQueueFull(t *testing.T) {
+	t.Run("ReturnsErrWhenQueueFull", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			const maxQueueLen = int64(2)
+			w := newWriterReconnectorStopped(NewWriterReconnectorConfig(
+				WithAutoSetSeqNo(false),
+				WithMaxQueueLen(int(maxQueueLen)),
+				WithErrOnQueueFull(true),
+			))
+			w.firstConnectionHandled.Store(true)
+
+			err := w.Write(t.Context(), newTestMessages(1, 2, 3)) //nolint:mnd // 3 > maxQueueLen(2) soft first batch
+			require.NoError(t, err)
+
+			err = w.Write(t.Context(), newTestMessages(4))
+			require.ErrorIs(t, err, ErrPublicQueueIsFull)
+			require.NotErrorIs(t, err, ErrPublicMessagesPutToInternalQueueBeforeError)
+
+			ackErr := w.queue.AcksReceived([]rawtopicwriter.WriteAck{
+				{SeqNo: 1},
+				{SeqNo: 2},
+				{SeqNo: 3},
+			})
+			require.NoError(t, ackErr)
+
+			err = w.Write(t.Context(), newTestMessages(4, 5))
+			require.NoError(t, err)
+		})
+	})
+
+	t.Run("DoesNotBlockOnCtx", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			w := newWriterReconnectorStopped(NewWriterReconnectorConfig(
+				WithAutoSetSeqNo(false),
+				WithMaxQueueLen(1), //nolint:mnd
+				WithErrOnQueueFull(true),
+			))
+			w.firstConnectionHandled.Store(true)
+
+			err := w.Write(t.Context(), newTestMessages(1))
+			require.NoError(t, err)
+
+			err = w.Write(t.Context(), newTestMessages(2))
+			require.ErrorIs(t, err, ErrPublicQueueIsFull)
+		})
+	})
+
+	t.Run("DefaultBehaviorStillBlocks", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			w := newWriterReconnectorStopped(NewWriterReconnectorConfig(
+				WithAutoSetSeqNo(false),
+				WithMaxQueueLen(1), //nolint:mnd
+			))
+			w.firstConnectionHandled.Store(true)
+
+			err := w.Write(t.Context(), newTestMessages(1))
+			require.NoError(t, err)
+
+			const timeout = 50 * time.Millisecond //nolint:mnd
+			ctxTimeout, cancel := context.WithTimeout(t.Context(), timeout)
+			defer cancel()
+			err = w.Write(ctxTimeout, newTestMessages(2))
+			require.ErrorIs(t, err, context.DeadlineExceeded)
+			require.NotErrorIs(t, err, ErrPublicQueueIsFull)
+		})
+	})
+}

--- a/topic/topicoptions/topicoptions_writer.go
+++ b/topic/topicoptions/topicoptions_writer.go
@@ -59,6 +59,32 @@ func WithWriterMaxQueueLen(num int) WriterOption {
 	return topicwriterinternal.WithMaxQueueLen(num)
 }
 
+// WithWriterErrOnQueueFull configures topic writer Write behavior when the internal
+// message queue is full.
+//
+// When enable is false (default), the call blocks until queue space becomes
+// available or the call context is cancelled. This preserves the pre-existing
+// behavior.
+//
+// When enable is true, the call returns with ErrQueueLimitExceed
+// (see package topic/topicwriter) immediately, without blocking. This is useful for
+// preventing unbounded memory growth (OOM) when
+// messages are produced faster than the writer can flush them to the server, for
+// example during connection problems or when the consumer is slow. In this mode the
+// caller is responsible for implementing back-pressure (e.g. dropping messages,
+// logging, retrying with its own budget).
+//
+// Note: when the queue is completely empty, the implementation may still accept
+// a single request larger than the queue size (soft limit), in order not to
+// break large batches on otherwise idle writers. Later calls may fail with the same
+// ErrQueueLimitExceed as soon
+// as the queue is non-full but cannot fit the new batch.
+//
+// Experimental: https://github.com/ydb-platform/ydb-go-sdk/blob/master/VERSIONING.md#experimental
+func WithWriterErrOnQueueFull(enable bool) WriterOption {
+	return topicwriterinternal.WithErrOnQueueFull(enable)
+}
+
 // WithWriterMessageMaxBytesSize set max body size of one message in bytes.
 // Writer will return error in message will be more than the size.
 func WithWriterMessageMaxBytesSize(size int) WriterOption {

--- a/topic/topicoptions/topicoptions_writer.go
+++ b/topic/topicoptions/topicoptions_writer.go
@@ -79,8 +79,6 @@ func WithWriterMaxQueueLen(num int) WriterOption {
 // break large batches on otherwise idle writers. Later calls may fail with the same
 // ErrQueueLimitExceed as soon
 // as the queue is non-full but cannot fit the new batch.
-//
-// Experimental: https://github.com/ydb-platform/ydb-go-sdk/blob/master/VERSIONING.md#experimental
 func WithWriterErrOnQueueFull(enable bool) WriterOption {
 	return topicwriterinternal.WithErrOnQueueFull(enable)
 }

--- a/topic/topicwriter/topicwriter.go
+++ b/topic/topicwriter/topicwriter.go
@@ -13,9 +13,11 @@ type (
 )
 
 var (
-	// Deprecated: the error will not be returned. Topic writer allow overflow queue for single call.
-	// Will be removed after October 2025.
-	// Read about versioning policy: https://github.com/ydb-platform/ydb-go-sdk/blob/master/VERSIONING.md#deprecated
+	// ErrQueueLimitExceed is what Writer.Write returns when the internal message
+	// queue is full, if the writer was created with
+	// WithWriterErrOnQueueFull from the topicoptions package
+	// with enable set to true. Otherwise the call blocks on a full queue until
+	// space is available. Must be checked with errors.Is.
 	ErrQueueLimitExceed                      = topicwriterinternal.ErrPublicQueueIsFull
 	ErrMessagesPutToInternalQueueBeforeError = topicwriterinternal.ErrPublicMessagesPutToInternalQueueBeforeError
 	ErrUnimplemented                         = errors.New("unimplemented")
@@ -53,10 +55,16 @@ func NewWriterWrapper(inner innerWriter) *Writer {
 // The method will wait first initial connection even for async mode, that mean first write may be slower.
 // especially when connection has problems.
 //
-// It returns ErrQueueLimitExceed (must be checked by errors.Is)
-// if ctx cancelled before messages put to internal buffer or try to add more messages, that can be put to queue.
-// If err != nil you can check errors.Is(err, ErrMessagesPutToInternalQueueBeforeError) for check if the messages
-// put to buffer before error. It means that it is messages can be delivered to the server.
+// By default, when the internal queue is full, the call blocks until queue space
+// becomes available or ctx is cancelled. If the writer was created with
+// WithWriterErrOnQueueFull from the topicoptions package
+// and enable is true, the error is ErrQueueLimitExceed instead of blocking; use
+// errors.Is to test. This helps limit memory use
+// when the application produces messages faster than the writer can flush.
+//
+// If err != nil you can check errors.Is with ErrMessagesPutToInternalQueueBeforeError
+// to see if the messages were put in the buffer before the error. If so, they can still
+// be delivered to the server.
 func (w *Writer) Write(ctx context.Context, messages ...Message) error {
 	return w.inner.Write(ctx, messages)
 }


### PR DESCRIPTION
### Summary

Adds `topicoptions.WithWriterErrOnQueueFull(enable bool)` so `topicwriter.Writer.Write` can return `topicwriter.ErrQueueLimitExceed` **immediately** when the internal message queue is full, instead of blocking until space appears or the context is cancelled. This gives callers explicit back-pressure and helps avoid unbounded memory growth (OOM) when production outpaces the connection or the server.

Default behavior is unchanged: `enable` is `false` by default, so `Write` still waits on the existing soft semaphore.

### API

- **New:** `topicoptions.WithWriterErrOnQueueFull(enable bool)` (experimental; see `VERSIONING.md`)
- **Internal:** `topicwriterinternal.WithErrOnQueueFull`, `WriterReconnectorConfig.ErrOnQueueFull`
- **`topicwriter.ErrQueueLimitExceed`:** documentation updated; the error is returned when the option is enabled and the queue has no room (use `errors.Is`).

### Implementation notes

- Queue reservation is factored into `acquireQueueSpaceForWrite` (blocking `Acquire` vs non-blocking `TryAcquire` on the soft weighted semaphore).
- The existing soft overflow behavior (one oversized batch when the queue is empty) is unchanged.

### Tests

- `TestWriterReconnector_Write_ErrOnQueueFull` in `writer_reconnector_err_on_queue_full_test.go` using `testing/synctest` (build tag `go1.25`; skipped on older toolchains).

### Changelog

- User-facing entries added at the top of `CHANGELOG.md`.

Made with [Cursor](https://cursor.com)