### PR TITLE
log/driver.go: log YQL issues from DriverConnInvokeDoneInfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Added logging for YQL compiler warnings returned via `trace.DriverConnInvokeDoneInfo.Issues` so they become visible in SDK logs (including when `trace.DetailsAll` is enabled), instead of being silently dropped.
+
 ## v3.135.5
 * Fixed transactional topic writers with lazy query transactions (`query.WithLazyTx(true)`)
 

--- a/log/driver.go
+++ b/log/driver.go
@@ -211,6 +211,14 @@ func internalDriver(l Logger, d trace.Detailer) trace.Driver {
 						kv.Version(),
 					)
 				}
+				for _, issue := range info.Issues {
+					l.Log(WithLevel(ctx, WARN), "YQL issue",
+						kv.String("method", method),
+						kv.Stringer("endpoint", endpoint),
+						kv.String("message", issue.GetMessage()),
+						kv.Int("code", int(issue.GetIssueCode())),
+					)
+				}
 			}
 		},
 		OnConnNewStream: func(


### PR DESCRIPTION
## Problem

`DriverConnInvokeDoneInfo.Issues` contains YQL compiler warnings returned by the server (e.g. `CORE_IMPLICIT_BITCAST`, `CORE_TYPE_ANN`). The `OnConnInvoke` done handler logs errors and successes but silently discards these issues — they never appear in logs even when `trace.DetailsAll` is enabled.

This makes it impossible to observe YQL warnings through the SDK logger, forcing users to rely on response parsing or other workarounds.

## Fix

After the error/success branch, iterate over `info.Issues` and log each one at `WARN` level, consistent with how other warnings are handled in the logger.

```go
for _, issue := range info.Issues {
    l.Log(WithLevel(ctx, WARN), "YQL issue",
        kv.String("method", method),
        kv.Stringer("endpoint", endpoint),
        kv.String("message", issue.GetMessage()),
        kv.Int("code", int(issue.GetIssueCode())),
    )
}
```