### PR TITLE
fix(xsql): map query transaction errors through badconn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 * Fixed `database/sql` query service transactions to map connection-related errors to `driver.ErrBadConn` (begin, commit, rollback, exec, and query) so the pool can discard bad connections
 
 ## v3.135.0
-* Fixed `database/sql` query service transactions to map connection-related errors to `driver.ErrBadConn` (begin, commit, rollback, exec, and query) so the pool can discard bad connections
 * Added `topicoptions.WithWriterErrOnQueueFull(bool)` option for topic writer to make `Write` return `topicwriter.ErrQueueLimitExceed` immediately when the internal queue is full, instead of blocking. Useful for preventing OOM when the writer cannot keep up with produced messages.
 * Un-deprecated `topicwriter.ErrQueueLimitExceed`: it is returned by `Write` when a writer is created with `topicoptions.WithWriterErrOnQueueFull(true)` and the internal queue is full.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## v3.135.0
+* Fixed `database/sql` query service transactions to map connection-related errors to `driver.ErrBadConn` (begin, commit, rollback, exec, and query) so the pool can discard bad connections
 * Added `topicoptions.WithWriterErrOnQueueFull(bool)` option for topic writer to make `Write` return `topicwriter.ErrQueueLimitExceed` immediately when the internal queue is full, instead of blocking. Useful for preventing OOM when the writer cannot keep up with produced messages.
 * Un-deprecated `topicwriter.ErrQueueLimitExceed`: it is returned by `Write` when a writer is created with `topicoptions.WithWriterErrOnQueueFull(true)` and the internal queue is full.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed `database/sql` query service transactions to map connection-related errors to `driver.ErrBadConn` (begin, commit, rollback, exec, and query) so the pool can discard bad connections
+
 ## v3.135.0
 * Added `topicoptions.WithWriterErrOnQueueFull(bool)` option for topic writer to make `Write` return `topicwriter.ErrQueueLimitExceed` immediately when the internal queue is full, instead of blocking. Useful for preventing OOM when the writer cannot keep up with produced messages.
 * Un-deprecated `topicwriter.ErrQueueLimitExceed`: it is returned by `Write` when a writer is created with `topicoptions.WithWriterErrOnQueueFull(true)` and the internal queue is full.

--- a/internal/xsql/xquery/tx.go
+++ b/internal/xsql/xquery/tx.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/stats"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/tx"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xsql/badconn"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xsql/common"
 	"github.com/ydb-platform/ydb-go-sdk/v3/query"
 )
@@ -45,7 +46,7 @@ func (t *transaction) Exec(ctx context.Context, sql string, params *params.Param
 
 	err := t.tx.Exec(ctx, sql, opts...)
 	if err != nil {
-		return nil, xerrors.WithStackTrace(err)
+		return nil, badconn.Map(xerrors.WithStackTrace(err))
 	}
 
 	return r, nil
@@ -74,7 +75,7 @@ func (t *transaction) Query(ctx context.Context, sql string, params *params.Para
 
 	res, err := t.tx.Query(ctx, sql, opts...)
 	if err != nil {
-		return nil, xerrors.WithStackTrace(err)
+		return nil, badconn.Map(xerrors.WithStackTrace(err))
 	}
 
 	return &rows{
@@ -91,7 +92,7 @@ func beginTx(ctx context.Context, c *Conn, txOptions driver.TxOptions) (common.T
 
 	nativeTx, err := c.session.Begin(ctx, query.TxSettings(txc))
 	if err != nil {
-		return nil, xerrors.WithStackTrace(err)
+		return nil, badconn.Map(xerrors.WithStackTrace(err))
 	}
 
 	return &transaction{
@@ -102,7 +103,7 @@ func beginTx(ctx context.Context, c *Conn, txOptions driver.TxOptions) (common.T
 
 func (t *transaction) Commit(ctx context.Context) (finalErr error) {
 	if err := t.tx.CommitTx(ctx); err != nil {
-		return xerrors.WithStackTrace(err)
+		return badconn.Map(xerrors.WithStackTrace(err))
 	}
 
 	return nil
@@ -110,7 +111,7 @@ func (t *transaction) Commit(ctx context.Context) (finalErr error) {
 
 func (t *transaction) Rollback(ctx context.Context) (finalErr error) {
 	if err := t.tx.Rollback(ctx); err != nil {
-		return xerrors.WithStackTrace(err)
+		return badconn.Map(xerrors.WithStackTrace(err))
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
Query service `database/sql` transactions now pass errors from begin, commit, rollback, `Exec`, and `Query` through `badconn.Map` so YDB connection/session issues surface as `driver.ErrBadConn` when appropriate. That lets `database/sql` remove bad connections from the pool instead of returning opaque errors, matching the pattern used elsewhere in the `xsql` stack.

## Changelog
- [x] Entry added at the top of the unreleased `v3.135.0` section in `CHANGELOG.md`.

Made with [Cursor](https://cursor.com)