### PR TITLE
fix(topic): transactional topic writers with lazy query transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## v3.135.3
+* Fixed transactional topic writers with lazy query transactions (`query.WithLazyTx(true)`) and transactional multi-writer (`WithWriteToManyPartitions`) materializing the transaction and attaching it to messages before writes
 * Fixed gRPC stream operations (`CloseSend`, `SendMsg`, `RecvMsg`) to check the stream context directly instead of inspecting the error type, so errors from a cancelled stream are no longer misclassified as transport errors
 
 ## v3.135.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-* Fixed transactional topic writers with lazy query transactions (`query.WithLazyTx(true)`) and transactional multi-writer (`WithWriteToManyPartitions`) materializing the transaction and attaching it to messages before writes
+* Fixed transactional topic writers with lazy query transactions (`query.WithLazyTx(true)`)
 
 ## v3.135.3
 * Fixed gRPC stream operations (`CloseSend`, `SendMsg`, `RecvMsg`) to check the stream context directly instead of inspecting the error type, so errors from a cancelled stream are no longer misclassified as transport errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## v3.135.3
 * Fixed transactional topic writers with lazy query transactions (`query.WithLazyTx(true)`) and transactional multi-writer (`WithWriteToManyPartitions`) materializing the transaction and attaching it to messages before writes
+
+## v3.135.3
 * Fixed gRPC stream operations (`CloseSend`, `SendMsg`, `RecvMsg`) to check the stream context directly instead of inspecting the error type, so errors from a cancelled stream are no longer misclassified as transport errors
 
 ## v3.135.2

--- a/internal/topic/topicmultiwriter/multiwriter_transaction.go
+++ b/internal/topic/topicmultiwriter/multiwriter_transaction.go
@@ -2,7 +2,6 @@ package topicmultiwriter
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/topic/topicwriterinternal"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/tx"
@@ -77,14 +76,6 @@ func (w *MultiWriterWithTransaction) Write(
 	ctx context.Context,
 	messages []topicwriterinternal.PublicMessage,
 ) error {
-	if err := w.tx.UnLazy(ctx); err != nil {
-		return fmt.Errorf("ydb: failed to materialize transaction: %w", err)
-	}
-
-	for i := range messages {
-		messages[i].Tx = w.tx
-	}
-
 	return w.multiWriter.Write(ctx, messages)
 }
 

--- a/internal/topic/topicmultiwriter/multiwriter_transaction.go
+++ b/internal/topic/topicmultiwriter/multiwriter_transaction.go
@@ -2,6 +2,7 @@ package topicmultiwriter
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/topic/topicwriterinternal"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/tx"
@@ -76,6 +77,14 @@ func (w *MultiWriterWithTransaction) Write(
 	ctx context.Context,
 	messages []topicwriterinternal.PublicMessage,
 ) error {
+	if err := w.tx.UnLazy(ctx); err != nil {
+		return fmt.Errorf("ydb: failed to materialize transaction: %w", err)
+	}
+
+	for i := range messages {
+		messages[i].Tx = w.tx
+	}
+
 	return w.multiWriter.Write(ctx, messages)
 }
 

--- a/internal/topic/topicwriterinternal/writer_transaction.go
+++ b/internal/topic/topicwriterinternal/writer_transaction.go
@@ -2,6 +2,7 @@ package topicwriterinternal
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/tx"
 	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
@@ -58,6 +59,10 @@ func (w *WriterWithTransaction) WaitInitInfo(ctx context.Context) (InitialInfo, 
 }
 
 func (w *WriterWithTransaction) Write(ctx context.Context, messages []PublicMessage) error {
+	if err := w.tx.UnLazy(ctx); err != nil {
+		return fmt.Errorf("ydb: failed to materialize transaction: %w", err)
+	}
+
 	for i := range messages {
 		messages[i].Tx = w.tx
 	}

--- a/tests/integration/topic_transactions_test.go
+++ b/tests/integration/topic_transactions_test.go
@@ -190,7 +190,6 @@ func TestTopicTransactionalWriterWithLazyTx(t *testing.T) {
 	err := db.Query().DoTx(ctx, func(ctx context.Context, tx query.TxActor) error {
 		writer, err := db.Topic().StartTransactionalWriter(tx, scope.TopicPath(),
 			topicoptions.WithWriterWaitServerAck(true))
-
 		if err != nil {
 			return fmt.Errorf("start transactional writer: %w", err)
 		}
@@ -236,7 +235,6 @@ func TestTopicTransactionalMultiWriterWithLazyTx(t *testing.T) {
 			Data: strings.NewReader(payload),
 			Key:  "abc",
 		})
-
 		if err != nil {
 			return fmt.Errorf("write message: %w", err)
 		}

--- a/tests/integration/topic_transactions_test.go
+++ b/tests/integration/topic_transactions_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/version"
 	"github.com/ydb-platform/ydb-go-sdk/v3/pkg/xtest"
 	"github.com/ydb-platform/ydb-go-sdk/v3/query"
+	"github.com/ydb-platform/ydb-go-sdk/v3/topic/topicoptions"
 	"github.com/ydb-platform/ydb-go-sdk/v3/topic/topicwriter"
 )
 
@@ -174,6 +175,82 @@ func TestTopicWriterTLI(t *testing.T) {
 	content, err := io.ReadAll(batch.Messages[0])
 	scope.Require.NoError(err)
 	scope.Require.Equal("test", string(content))
+}
+
+// TestTopicTransactionalWriterWithLazyTx exercises transactional topic writes when the query transaction is lazy
+// (`query.WithLazyTx(true)`). Without materializing the transaction before the topic stream sends the tx id, YDB
+// returns `Transaction not found: LAZY_TX` on the topic writer receive path.
+func TestTopicTransactionalWriterWithLazyTx(t *testing.T) {
+	scope := newScope(t)
+	ctx := scope.Ctx
+	db := scope.Driver()
+	reader := scope.TopicReader()
+
+	const payload = "lazy-tx-writer"
+	err := db.Query().DoTx(ctx, func(ctx context.Context, tx query.TxActor) error {
+		writer, err := db.Topic().StartTransactionalWriter(tx, scope.TopicPath(),
+			topicoptions.WithWriterWaitServerAck(true))
+
+		if err != nil {
+			return fmt.Errorf("start transactional writer: %w", err)
+		}
+
+		err = writer.Write(ctx, topicwriter.Message{Data: strings.NewReader(payload)})
+		if err != nil {
+			return fmt.Errorf("write message: %w", err)
+		}
+
+		return nil
+	}, query.WithLazyTx(true))
+	require.NoError(t, err)
+
+	batch, err := reader.ReadMessagesBatch(ctx)
+	require.NoError(t, err)
+	require.Len(t, batch.Messages, 1)
+	content, err := io.ReadAll(batch.Messages[0])
+	require.NoError(t, err)
+	require.Equal(t, payload, string(content))
+}
+
+// TestTopicTransactionalMultiWriterWithLazyTx uses StartTransactionalWriter with
+// topicoptions.WithWriteToManyPartitions (internal multi-writer) together with lazy query transactions.
+func TestTopicTransactionalMultiWriterWithLazyTx(t *testing.T) {
+	scope := newScope(t)
+	ctx := scope.Ctx
+	db := scope.Driver()
+	reader := scope.TopicReader()
+
+	const payload = "lazy-tx-multi-writer"
+	err := db.Query().DoTx(ctx, func(ctx context.Context, tx query.TxActor) error {
+		writer, err := db.Topic().StartTransactionalWriter(tx, scope.TopicPath(),
+			topicoptions.WithWriterWaitServerAck(true),
+			topicoptions.WithWriteToManyPartitions(
+				topicoptions.WithProducerIDPrefix("lazy-tx-multi"),
+			),
+		)
+		if err != nil {
+			return fmt.Errorf("start transactional writer: %w", err)
+		}
+
+		err = writer.Write(ctx, topicwriter.Message{
+			Data: strings.NewReader(payload),
+			Key:  "abc",
+		})
+
+		if err != nil {
+			return fmt.Errorf("write message: %w", err)
+		}
+
+		return nil
+	}, query.WithLazyTx(true))
+	require.NoError(t, err)
+
+	batch, err := reader.ReadMessagesBatch(ctx)
+	require.NoError(t, err)
+	require.Len(t, batch.Messages, 1)
+	content, err := io.ReadAll(batch.Messages[0])
+	require.NoError(t, err)
+	require.Equal(t, payload, string(content))
 }
 
 func TestWriteInTransaction(t *testing.T) {


### PR DESCRIPTION
## Summary

- **Single-writer `StartTransactionalWriter`:** call `tx.UnLazy(ctx)` before attaching the transaction to messages and writing. Lazy query transactions (`query.WithLazyTx(true)`) only had placeholder id `LAZY_TX` until the first query; the topic service then returned `Transaction not found: LAZY_TX` on the writer stream.
- **Transactional multi-writer** (`WithWriteToManyPartitions`): same `UnLazy` before `Write`, and set `Tx` on each `PublicMessage` so behavior matches the single-writer transactional path.

## Tests

- `TestTopicTransactionalWriterWithLazyTx` — `DoTx` + `WithLazyTx(true)` + `StartTransactionalWriter` (no prior `tx.Exec`).
- `TestTopicTransactionalMultiWriterWithLazyTx` — same with `WithWriteToManyPartitions`.

Run: `go test -tags=integration -run 'TestTopicTransactional(Writer|MultiWriter)WithLazyTx' ./tests/integration/`

## Changelog

Entry added under the current `v3.135.3` section in `CHANGELOG.md`.

Made with [Cursor](https://cursor.com)