### PR TITLE
Changed the retry behavior for operation error `TIMEOUT` from `NonRetryable` to `ConditionallyRetryable`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 * Changed the retry behavior for operation error `TIMEOUT` from non-retryable to conditionally retryable
+* Added public `retry.TypeInstant` enum alias to `retry.TypeNoBackoff`
 
 ## v3.136.0
 * The `query.WithResponsePartPrefetch(n)` method has been added to enable the prefetching of parts of query results.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-* Changed the retry behavior for operation error `TIMEOUT` from `NonRetryable` to `ConditionallyRetryable`
+* Changed the retry behavior for operation error `TIMEOUT` from non-retryable to conditionally retryable
 
 ## v3.136.0
 * The `query.WithResponsePartPrefetch(n)` method has been added to enable the prefetching of parts of query results.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Changed the retry behavior for operation error `TIMEOUT` from `NonRetryable` to `ConditionallyRetryable`
+
 ## v3.136.0
 * The `query.WithResponsePartPrefetch(n)` method has been added to enable the prefetching of parts of query results.
   By default, this feature is disabled. Prefetching produces the following effects:

--- a/example_test.go
+++ b/example_test.go
@@ -411,7 +411,7 @@ func Example_scripting() {
 		if !res.NextResultSet(ctx) {
 			return retry.RetryableError(
 				fmt.Errorf("no result sets"), //nolint:err113
-				retry.WithBackoff(retry.TypeNoBackoff),
+				retry.WithBackoff(retry.TypeInstant),
 			)
 		}
 		if !res.NextRow() {

--- a/internal/backoff/delay_test.go
+++ b/internal/backoff/delay_test.go
@@ -17,17 +17,17 @@ func TestDelay(t *testing.T) {
 	}{
 		{
 			name: xtest.CurrentFileLine(),
-			act:  Delay(TypeNoBackoff, 0),
+			act:  Delay(TypeInstant, 0),
 			exp:  0,
 		},
 		{
 			name: xtest.CurrentFileLine(),
-			act:  Delay(TypeNoBackoff, 1),
+			act:  Delay(TypeInstant, 1),
 			exp:  0,
 		},
 		{
 			name: xtest.CurrentFileLine(),
-			act:  Delay(TypeNoBackoff, 2),
+			act:  Delay(TypeInstant, 2),
 			exp:  0,
 		},
 		{

--- a/internal/backoff/type.go
+++ b/internal/backoff/type.go
@@ -7,7 +7,7 @@ type Type uint8
 
 // Binary flags that used as Type
 const (
-	TypeNoBackoff Type = 1 << iota >> 1
+	TypeInstant Type = 1 << iota >> 1
 
 	TypeFast
 	TypeSlow
@@ -17,8 +17,8 @@ const (
 
 func (b Type) String() string {
 	switch b {
-	case TypeNoBackoff:
-		return "immediately"
+	case TypeInstant:
+		return "instant"
 	case TypeFast:
 		return "fast backoff"
 	case TypeSlow:

--- a/internal/xerrors/check.go
+++ b/internal/xerrors/check.go
@@ -13,7 +13,7 @@ func Check(err error) (
 	if err == nil {
 		return -1,
 			TypeNoError,
-			backoff.TypeNoBackoff
+			backoff.TypeInstant
 	}
 	var e Error
 	if As(err, &e) {
@@ -22,5 +22,5 @@ func Check(err error) (
 
 	return -1,
 		TypeNonRetryable, // unknown errors are not retryable
-		backoff.TypeNoBackoff
+		backoff.TypeInstant
 }

--- a/internal/xerrors/operation.go
+++ b/internal/xerrors/operation.go
@@ -173,7 +173,8 @@ func (e *operationError) Type() Type {
 		return TypeRetryable
 	case
 		Ydb.StatusIds_UNDETERMINED,
-		Ydb.StatusIds_SESSION_EXPIRED:
+		Ydb.StatusIds_SESSION_EXPIRED,
+		Ydb.StatusIds_TIMEOUT:
 		return TypeConditionallyRetryable
 	case Ydb.StatusIds_UNAUTHORIZED:
 		return TypeNonRetryable

--- a/internal/xerrors/operation.go
+++ b/internal/xerrors/operation.go
@@ -219,7 +219,7 @@ func (e *operationError) BackoffType() backoff.Type {
 		return backoff.TypeFast
 	case Ydb.StatusIds_ABORTED:
 		if e.hasIssueCodes(IssueCodeDatashardProgramSizeLimitExceeded) {
-			return backoff.TypeNoBackoff
+			return backoff.TypeInstant
 		}
 
 		return backoff.TypeFast
@@ -228,9 +228,9 @@ func (e *operationError) BackoffType() backoff.Type {
 			return backoff.TypeSlow
 		}
 
-		return backoff.TypeNoBackoff
+		return backoff.TypeInstant
 	default:
-		return backoff.TypeNoBackoff
+		return backoff.TypeInstant
 	}
 }
 

--- a/internal/xerrors/operation_test.go
+++ b/internal/xerrors/operation_test.go
@@ -209,7 +209,7 @@ func Test_operationError_SchemaOperationsLimitExceeded(t *testing.T) {
 				}}),
 			),
 			expectedType:    TypeUndefined,
-			expectedBackoff: backoff.TypeNoBackoff,
+			expectedBackoff: backoff.TypeInstant,
 		},
 		{
 			err: Operation(

--- a/internal/xerrors/transport.go
+++ b/internal/xerrors/transport.go
@@ -126,12 +126,12 @@ func (e *transportError) BackoffType() backoff.Type {
 		return backoff.TypeFast
 	case grpcCodes.ResourceExhausted:
 		if e.isMessageLargerThanMax() {
-			return backoff.TypeNoBackoff
+			return backoff.TypeInstant
 		}
 
 		return backoff.TypeSlow
 	default:
-		return backoff.TypeNoBackoff
+		return backoff.TypeInstant
 	}
 }
 

--- a/retry/errors_data_test.go
+++ b/retry/errors_data_test.go
@@ -37,7 +37,7 @@ var errsToCheck = []struct {
 	{
 		// retryer given unknown error - we will not operationStatus and will close session
 		err:     fmt.Errorf("unknown error"),
-		backoff: backoff.TypeNoBackoff,
+		backoff: backoff.TypeInstant,
 		canRetry: map[idempotency]bool{
 			idempotent:    false,
 			nonIdempotent: false,
@@ -46,7 +46,7 @@ var errsToCheck = []struct {
 	{
 		// golang context deadline exceeded
 		err:     context.DeadlineExceeded,
-		backoff: backoff.TypeNoBackoff,
+		backoff: backoff.TypeInstant,
 		canRetry: map[idempotency]bool{
 			idempotent:    false,
 			nonIdempotent: false,
@@ -55,7 +55,7 @@ var errsToCheck = []struct {
 	{
 		// golang context canceled
 		err:     context.Canceled,
-		backoff: backoff.TypeNoBackoff,
+		backoff: backoff.TypeInstant,
 		canRetry: map[idempotency]bool{
 			idempotent:    false,
 			nonIdempotent: false,
@@ -84,7 +84,7 @@ var errsToCheck = []struct {
 	},
 	{
 		err:     xerrors.Transport(grpcStatus.Error(grpcCodes.Unknown, "")),
-		backoff: backoff.TypeNoBackoff,
+		backoff: backoff.TypeInstant,
 		canRetry: map[idempotency]bool{
 			idempotent:    false,
 			nonIdempotent: false,
@@ -92,7 +92,7 @@ var errsToCheck = []struct {
 	},
 	{
 		err:     xerrors.Transport(grpcStatus.Error(grpcCodes.InvalidArgument, "")),
-		backoff: backoff.TypeNoBackoff,
+		backoff: backoff.TypeInstant,
 		canRetry: map[idempotency]bool{
 			idempotent:    false,
 			nonIdempotent: false,
@@ -108,7 +108,7 @@ var errsToCheck = []struct {
 	},
 	{
 		err:     xerrors.Transport(grpcStatus.Error(grpcCodes.NotFound, "")),
-		backoff: backoff.TypeNoBackoff,
+		backoff: backoff.TypeInstant,
 		canRetry: map[idempotency]bool{
 			idempotent:    false,
 			nonIdempotent: false,
@@ -116,7 +116,7 @@ var errsToCheck = []struct {
 	},
 	{
 		err:     xerrors.Transport(grpcStatus.Error(grpcCodes.AlreadyExists, "")),
-		backoff: backoff.TypeNoBackoff,
+		backoff: backoff.TypeInstant,
 		canRetry: map[idempotency]bool{
 			idempotent:    false,
 			nonIdempotent: false,
@@ -124,7 +124,7 @@ var errsToCheck = []struct {
 	},
 	{
 		err:     xerrors.Transport(grpcStatus.Error(grpcCodes.PermissionDenied, "")),
-		backoff: backoff.TypeNoBackoff,
+		backoff: backoff.TypeInstant,
 		canRetry: map[idempotency]bool{
 			idempotent:    false,
 			nonIdempotent: false,
@@ -140,7 +140,7 @@ var errsToCheck = []struct {
 	},
 	{
 		err:     xerrors.Transport(grpcStatus.Error(grpcCodes.ResourceExhausted, "trying to send message larger than max (70792102 vs. 64000000)")), //nolint:lll
-		backoff: backoff.TypeNoBackoff,
+		backoff: backoff.TypeInstant,
 		canRetry: map[idempotency]bool{
 			idempotent:    false,
 			nonIdempotent: false,
@@ -148,7 +148,7 @@ var errsToCheck = []struct {
 	},
 	{
 		err:     xerrors.Transport(grpcStatus.Error(grpcCodes.ResourceExhausted, "received message larger than max (70792102 vs. 64000000)")), //nolint:lll
-		backoff: backoff.TypeNoBackoff,
+		backoff: backoff.TypeInstant,
 		canRetry: map[idempotency]bool{
 			idempotent:    false,
 			nonIdempotent: false,
@@ -156,7 +156,7 @@ var errsToCheck = []struct {
 	},
 	{
 		err:     xerrors.Transport(grpcStatus.Error(grpcCodes.FailedPrecondition, "")),
-		backoff: backoff.TypeNoBackoff,
+		backoff: backoff.TypeInstant,
 		canRetry: map[idempotency]bool{
 			idempotent:    false,
 			nonIdempotent: false,
@@ -164,7 +164,7 @@ var errsToCheck = []struct {
 	},
 	{
 		err:     xerrors.Transport(grpcStatus.Error(grpcCodes.Aborted, "")),
-		backoff: backoff.TypeNoBackoff,
+		backoff: backoff.TypeInstant,
 		canRetry: map[idempotency]bool{
 			idempotent:    true,
 			nonIdempotent: true,
@@ -172,7 +172,7 @@ var errsToCheck = []struct {
 	},
 	{
 		err:     xerrors.Transport(grpcStatus.Error(grpcCodes.OutOfRange, "")),
-		backoff: backoff.TypeNoBackoff,
+		backoff: backoff.TypeInstant,
 		canRetry: map[idempotency]bool{
 			idempotent:    false,
 			nonIdempotent: false,
@@ -180,7 +180,7 @@ var errsToCheck = []struct {
 	},
 	{
 		err:     xerrors.Transport(grpcStatus.Error(grpcCodes.Unimplemented, "")),
-		backoff: backoff.TypeNoBackoff,
+		backoff: backoff.TypeInstant,
 		canRetry: map[idempotency]bool{
 			idempotent:    false,
 			nonIdempotent: false,
@@ -226,7 +226,7 @@ var errsToCheck = []struct {
 	},
 	{
 		err:     xerrors.Transport(grpcStatus.Error(grpcCodes.DataLoss, "")),
-		backoff: backoff.TypeNoBackoff,
+		backoff: backoff.TypeInstant,
 		canRetry: map[idempotency]bool{
 			idempotent:    false,
 			nonIdempotent: false,
@@ -234,7 +234,7 @@ var errsToCheck = []struct {
 	},
 	{
 		err:     xerrors.Transport(grpcStatus.Error(grpcCodes.Unauthenticated, "")),
-		backoff: backoff.TypeNoBackoff,
+		backoff: backoff.TypeInstant,
 		canRetry: map[idempotency]bool{
 			idempotent:    false,
 			nonIdempotent: false,
@@ -244,7 +244,7 @@ var errsToCheck = []struct {
 		err: xerrors.Operation(
 			xerrors.WithStatusCode(Ydb.StatusIds_STATUS_CODE_UNSPECIFIED),
 		),
-		backoff: backoff.TypeNoBackoff,
+		backoff: backoff.TypeInstant,
 		canRetry: map[idempotency]bool{
 			idempotent:    false,
 			nonIdempotent: false,
@@ -254,7 +254,7 @@ var errsToCheck = []struct {
 		err: xerrors.Operation(
 			xerrors.WithStatusCode(Ydb.StatusIds_BAD_REQUEST),
 		),
-		backoff: backoff.TypeNoBackoff,
+		backoff: backoff.TypeInstant,
 		canRetry: map[idempotency]bool{
 			idempotent:    false,
 			nonIdempotent: false,
@@ -264,7 +264,7 @@ var errsToCheck = []struct {
 		err: xerrors.Operation(
 			xerrors.WithStatusCode(Ydb.StatusIds_UNAUTHORIZED),
 		),
-		backoff: backoff.TypeNoBackoff,
+		backoff: backoff.TypeInstant,
 		canRetry: map[idempotency]bool{
 			idempotent:    false,
 			nonIdempotent: false,
@@ -274,7 +274,7 @@ var errsToCheck = []struct {
 		err: xerrors.Operation(
 			xerrors.WithStatusCode(Ydb.StatusIds_INTERNAL_ERROR),
 		),
-		backoff: backoff.TypeNoBackoff,
+		backoff: backoff.TypeInstant,
 		canRetry: map[idempotency]bool{
 			idempotent:    false,
 			nonIdempotent: false,
@@ -284,7 +284,7 @@ var errsToCheck = []struct {
 		err: xerrors.Operation(
 			xerrors.WithStatusCode(Ydb.StatusIds_EXTERNAL_ERROR),
 		),
-		backoff: backoff.TypeNoBackoff,
+		backoff: backoff.TypeInstant,
 		canRetry: map[idempotency]bool{
 			idempotent:    false,
 			nonIdempotent: false,
@@ -309,7 +309,7 @@ var errsToCheck = []struct {
 				},
 			}),
 		),
-		backoff: backoff.TypeNoBackoff,
+		backoff: backoff.TypeInstant,
 		canRetry: map[idempotency]bool{
 			idempotent:    false,
 			nonIdempotent: false,
@@ -339,7 +339,7 @@ var errsToCheck = []struct {
 		err: xerrors.Operation(
 			xerrors.WithStatusCode(Ydb.StatusIds_SCHEME_ERROR),
 		),
-		backoff: backoff.TypeNoBackoff,
+		backoff: backoff.TypeInstant,
 		canRetry: map[idempotency]bool{
 			idempotent:    false,
 			nonIdempotent: false,
@@ -349,7 +349,7 @@ var errsToCheck = []struct {
 		err: xerrors.Operation(
 			xerrors.WithStatusCode(Ydb.StatusIds_GENERIC_ERROR),
 		),
-		backoff: backoff.TypeNoBackoff,
+		backoff: backoff.TypeInstant,
 		canRetry: map[idempotency]bool{
 			idempotent:    false,
 			nonIdempotent: false,
@@ -359,7 +359,7 @@ var errsToCheck = []struct {
 		err: xerrors.Operation(
 			xerrors.WithStatusCode(Ydb.StatusIds_TIMEOUT),
 		),
-		backoff: backoff.TypeNoBackoff,
+		backoff: backoff.TypeInstant,
 		canRetry: map[idempotency]bool{
 			idempotent:    true,
 			nonIdempotent: false,
@@ -369,7 +369,7 @@ var errsToCheck = []struct {
 		err: xerrors.Operation(
 			xerrors.WithStatusCode(Ydb.StatusIds_BAD_SESSION),
 		),
-		backoff: backoff.TypeNoBackoff,
+		backoff: backoff.TypeInstant,
 		canRetry: map[idempotency]bool{
 			idempotent:    true,
 			nonIdempotent: true,
@@ -379,7 +379,7 @@ var errsToCheck = []struct {
 		err: xerrors.Operation(
 			xerrors.WithStatusCode(Ydb.StatusIds_PRECONDITION_FAILED),
 		),
-		backoff: backoff.TypeNoBackoff,
+		backoff: backoff.TypeInstant,
 		canRetry: map[idempotency]bool{
 			idempotent:    false,
 			nonIdempotent: false,
@@ -389,7 +389,7 @@ var errsToCheck = []struct {
 		err: xerrors.Operation(
 			xerrors.WithStatusCode(Ydb.StatusIds_ALREADY_EXISTS),
 		),
-		backoff: backoff.TypeNoBackoff,
+		backoff: backoff.TypeInstant,
 		canRetry: map[idempotency]bool{
 			idempotent:    false,
 			nonIdempotent: false,
@@ -399,7 +399,7 @@ var errsToCheck = []struct {
 		err: xerrors.Operation(
 			xerrors.WithStatusCode(Ydb.StatusIds_NOT_FOUND),
 		),
-		backoff: backoff.TypeNoBackoff,
+		backoff: backoff.TypeInstant,
 		canRetry: map[idempotency]bool{
 			idempotent:    false,
 			nonIdempotent: false,
@@ -409,7 +409,7 @@ var errsToCheck = []struct {
 		err: xerrors.Operation(
 			xerrors.WithStatusCode(Ydb.StatusIds_SESSION_EXPIRED),
 		),
-		backoff: backoff.TypeNoBackoff,
+		backoff: backoff.TypeInstant,
 		canRetry: map[idempotency]bool{
 			idempotent:    true,
 			nonIdempotent: false,
@@ -439,7 +439,7 @@ var errsToCheck = []struct {
 		err: xerrors.Operation(
 			xerrors.WithStatusCode(Ydb.StatusIds_UNSUPPORTED),
 		),
-		backoff: backoff.TypeNoBackoff,
+		backoff: backoff.TypeInstant,
 		canRetry: map[idempotency]bool{
 			idempotent:    false,
 			nonIdempotent: false,

--- a/retry/errors_data_test.go
+++ b/retry/errors_data_test.go
@@ -361,7 +361,7 @@ var errsToCheck = []struct {
 		),
 		backoff: backoff.TypeNoBackoff,
 		canRetry: map[idempotency]bool{
-			idempotent:    false,
+			idempotent:    true,
 			nonIdempotent: false,
 		},
 	},

--- a/retry/retryable_error.go
+++ b/retry/retryable_error.go
@@ -8,7 +8,8 @@ import (
 type retryableErrorOption xerrors.RetryableErrorOption
 
 const (
-	TypeNoBackoff   = backoff.TypeNoBackoff
+	TypeNoBackoff   = backoff.TypeInstant
+	TypeInstant     = backoff.TypeInstant
 	TypeFastBackoff = backoff.TypeFast
 	TypeSlowBackoff = backoff.TypeSlow
 )

--- a/scripting/example_test.go
+++ b/scripting/example_test.go
@@ -32,7 +32,7 @@ func Example_execute() {
 		if !res.NextResultSet(ctx) {
 			return retry.RetryableError(
 				fmt.Errorf("no result sets"),
-				retry.WithBackoff(retry.TypeNoBackoff),
+				retry.WithBackoff(retry.TypeInstant),
 			)
 		}
 		if !res.NextRow() {
@@ -77,7 +77,7 @@ func Example_streamExecute() {
 		if !res.NextResultSet(ctx) {
 			return retry.RetryableError(
 				fmt.Errorf("no result sets"),
-				retry.WithBackoff(retry.TypeNoBackoff),
+				retry.WithBackoff(retry.TypeInstant),
 				retry.WithDeleteSession(),
 			)
 		}

--- a/tests/integration/scripting_test.go
+++ b/tests/integration/scripting_test.go
@@ -68,7 +68,7 @@ func TestScripting(sourceTest *testing.T) {
 		if !res.NextResultSet(ctx) {
 			return retry.RetryableError(
 				fmt.Errorf("no result sets"),
-				retry.WithBackoff(retry.TypeNoBackoff),
+				retry.WithBackoff(retry.TypeInstant),
 			)
 		}
 		if !res.NextRow() {
@@ -104,7 +104,7 @@ func TestScripting(sourceTest *testing.T) {
 		if !res.NextResultSet(ctx) {
 			return retry.RetryableError(
 				fmt.Errorf("no result sets"),
-				retry.WithBackoff(retry.TypeNoBackoff),
+				retry.WithBackoff(retry.TypeInstant),
 				retry.WithDeleteSession(),
 			)
 		}


### PR DESCRIPTION
The ydb-go-sdk has now been updated to conform to the documentation https://ydb.tech/docs/en/reference/ydb-sdk/ydb-status-codes?version=main#timeout

## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
