### PR TITLE
LOGBROKER-10206 Pass tx to incoming messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Fixed `MultiWriterWithTransaction.Write` to materialize lazy query transactions via `tx.UnLazy` before writing (same as single-partition transactional writer)
 * Fixed `MultiWriterWithTransaction`: pass transaction to each incoming message
 
 ## v3.136.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed `MultiWriterWithTransaction`: pass transaction to each incoming message
+
 ## v3.136.0
 * The `query.WithResponsePartPrefetch(n)` method has been added to enable the prefetching of parts of query results.
   By default, this feature is disabled. Prefetching produces the following effects:

--- a/internal/topic/topicmultiwriter/multiwriter_transaction.go
+++ b/internal/topic/topicmultiwriter/multiwriter_transaction.go
@@ -2,6 +2,7 @@ package topicmultiwriter
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/topic/topicwriterinternal"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/tx"
@@ -76,6 +77,10 @@ func (w *MultiWriterWithTransaction) Write(
 	ctx context.Context,
 	messages []topicwriterinternal.PublicMessage,
 ) error {
+	if err := w.tx.UnLazy(ctx); err != nil {
+		return fmt.Errorf("ydb: failed to materialize transaction: %w", err)
+	}
+
 	for i := range messages {
 		messages[i].Tx = w.tx
 	}

--- a/internal/topic/topicmultiwriter/multiwriter_transaction.go
+++ b/internal/topic/topicmultiwriter/multiwriter_transaction.go
@@ -76,6 +76,10 @@ func (w *MultiWriterWithTransaction) Write(
 	ctx context.Context,
 	messages []topicwriterinternal.PublicMessage,
 ) error {
+	for i := range messages {
+		messages[i].Tx = w.tx
+	}
+
 	return w.multiWriter.Write(ctx, messages)
 }
 

--- a/internal/topic/topicmultiwriter/multiwriter_transaction_test.go
+++ b/internal/topic/topicmultiwriter/multiwriter_transaction_test.go
@@ -1,0 +1,90 @@
+package topicmultiwriter
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/topic/topicmultiwriter/stubs"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/topic/topicwriterinternal"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/tx"
+	"github.com/ydb-platform/ydb-go-sdk/v3/pkg/xtest"
+	"github.com/ydb-platform/ydb-go-sdk/v3/topic/topictypes"
+)
+
+// stubTopicTransaction is a minimal tx.Transaction for MultiWriterWithTransaction tests.
+type stubTopicTransaction struct {
+	tx.Identifier
+
+	sessionID string
+}
+
+func newStubTopicTransaction(id string) *stubTopicTransaction {
+	return &stubTopicTransaction{
+		Identifier: tx.ID(id),
+		sessionID:  "test-session",
+	}
+}
+
+func (s *stubTopicTransaction) UnLazy(context.Context) error {
+	return nil
+}
+
+func (s *stubTopicTransaction) SessionID() string {
+	return s.sessionID
+}
+
+func (s *stubTopicTransaction) NodeID() uint32 {
+	return 0
+}
+
+func (*stubTopicTransaction) OnBeforeCommit(tx.OnTransactionBeforeCommit) {}
+
+func (*stubTopicTransaction) OnCompleted(tx.OnTransactionCompletedFunc) {}
+
+func (*stubTopicTransaction) Rollback(context.Context) error {
+	return nil
+}
+
+func TestMultiWriterWithTransaction_Write_SetsTx(t *testing.T) {
+	t.Parallel()
+
+	ctx := xtest.Context(t)
+	stubClient := stubs.NewStubTopicClient(t, stubs.DefaultStubTopicDescription(t))
+
+	multiWriter := newTestMultiWriterWithBasicWriter(
+		t,
+		func(ctx context.Context, path string) (topictypes.TopicDescription, error) {
+			return stubClient.Describe(ctx, path)
+		},
+	)
+
+	require.NoError(t, multiWriter.WaitInit(ctx))
+
+	stubTxn := newStubTopicTransaction("test-txn")
+
+	wrapped := NewTopicMultiWriterTransaction(multiWriter, stubTxn, nil)
+
+	messages := []topicwriterinternal.PublicMessage{
+		{
+			Data:  bytes.NewReader([]byte("a")),
+			SeqNo: 1,
+			Key:   "k1",
+		},
+		{
+			Data:  bytes.NewReader([]byte("b")),
+			SeqNo: 2,
+			Key:   "k2",
+		},
+	}
+
+	require.NoError(t, wrapped.Write(ctx, messages))
+
+	for i := range messages {
+		require.Same(t, stubTxn, messages[i].Tx, "message %d", i)
+	}
+
+	require.NoError(t, multiWriter.Close(ctx))
+}

--- a/tests/integration/topic_transactions_test.go
+++ b/tests/integration/topic_transactions_test.go
@@ -334,3 +334,118 @@ func TestWriteInTransaction(t *testing.T) {
 		t.Logf("transactions count: %v", transactionsCount)
 	})
 }
+
+func TestWriteInTransactionMultiWriter(t *testing.T) {
+	if os.Getenv("YDB_VERSION") != "nightly" && version.Lt(os.Getenv("YDB_VERSION"), "25.0") {
+		t.Skip("require enables transactions for topics")
+	}
+
+	// Single stable key routes all messages to one partition so read order matches TestWriteInTransaction.
+	const stablePartitionKey = "stable-partition-key-for-tx-order"
+
+	t.Run("OK", func(t *testing.T) {
+		scope := newScope(t)
+		reader := scope.TopicReader()
+
+		driver := scope.DriverWithGRPCLogging()
+
+		const writeTime = time.Second
+		protectCtx, cancel := context.WithTimeout(scope.Ctx, writeTime*10)
+		defer cancel()
+
+		deadline := time.Now().Add(writeTime)
+		transactionsCount := 0
+		for {
+			err := driver.Query().DoTx(scope.Ctx, func(ctx context.Context, tx query.TxActor) error {
+				writer, err := driver.Topic().StartTransactionalWriter(
+					tx,
+					scope.TopicPath(),
+					topicoptions.WithWriterSetAutoSeqNo(true),
+					topicoptions.WithWriteToManyPartitions(
+						topicoptions.WithWriterPartitionByKey(topicoptions.KafkaHashPartitionChooser()),
+						topicoptions.WithProducerIDPrefix("tx-multiwriter-ok"),
+					),
+				)
+				if err != nil {
+					return err
+				}
+
+				if err := writer.WaitInit(ctx); err != nil {
+					return err
+				}
+
+				return writer.Write(ctx, topicwriter.Message{
+					Data: strings.NewReader(strconv.Itoa(transactionsCount)),
+					Key:  stablePartitionKey,
+				})
+			})
+			require.NoError(t, err)
+			transactionsCount++
+			if time.Now().After(deadline) {
+				break
+			}
+		}
+
+		for i := 0; i < transactionsCount; i++ {
+			mess, err := reader.ReadMessage(protectCtx)
+			require.NoError(t, err)
+
+			contentBytes, _ := io.ReadAll(mess)
+			content := string(contentBytes)
+			require.Equal(t, strconv.Itoa(i), content)
+		}
+		t.Logf("transactions count: %v", transactionsCount)
+	})
+
+	t.Run("Rollback", func(t *testing.T) {
+		scope := newScope(t)
+		reader := scope.TopicReader()
+
+		driver := scope.Driver()
+
+		const writeTime = time.Second
+		protectCtx, cancel := context.WithTimeout(scope.Ctx, writeTime*10)
+		defer cancel()
+
+		deadline := time.Now().Add(writeTime)
+		transactionsCount := 0
+		testErr := errors.New("test")
+		for {
+			err := driver.Query().DoTx(scope.Ctx, func(ctx context.Context, tx query.TxActor) error {
+				writer, err := driver.Topic().StartTransactionalWriter(
+					tx,
+					scope.TopicPath(),
+					topicoptions.WithWriterSetAutoSeqNo(true),
+					topicoptions.WithWriteToManyPartitions(
+						topicoptions.WithWriterPartitionByKey(topicoptions.KafkaHashPartitionChooser()),
+						topicoptions.WithProducerIDPrefix("tx-multiwriter-rollback"),
+					),
+				)
+				if err != nil {
+					return err
+				}
+
+				require.NoError(t, writer.WaitInit(ctx))
+
+				require.NoError(t, writer.Write(ctx, topicwriter.Message{
+					Data: strings.NewReader(strconv.Itoa(transactionsCount)),
+					Key:  stablePartitionKey,
+				}))
+				return testErr
+			})
+			require.ErrorIs(t, err, testErr)
+			transactionsCount++
+			if time.Now().After(deadline) {
+				break
+			}
+		}
+
+		protectCtx, cancel = context.WithTimeout(scope.Ctx, time.Millisecond*10)
+		defer cancel()
+
+		mess, err := reader.ReadMessage(protectCtx)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		_ = mess
+		t.Logf("transactions count: %v", transactionsCount)
+	})
+}

--- a/tests/integration/topic_transactions_test.go
+++ b/tests/integration/topic_transactions_test.go
@@ -211,46 +211,6 @@ func TestTopicTransactionalWriterWithLazyTx(t *testing.T) {
 	require.Equal(t, payload, string(content))
 }
 
-// TestTopicTransactionalMultiWriterWithLazyTx uses StartTransactionalWriter with
-// topicoptions.WithWriteToManyPartitions (internal multi-writer) together with lazy query transactions.
-func TestTopicTransactionalMultiWriterWithLazyTx(t *testing.T) {
-	scope := newScope(t)
-	ctx := scope.Ctx
-	db := scope.Driver()
-	reader := scope.TopicReader()
-
-	const payload = "lazy-tx-multi-writer"
-	err := db.Query().DoTx(ctx, func(ctx context.Context, tx query.TxActor) error {
-		writer, err := db.Topic().StartTransactionalWriter(tx, scope.TopicPath(),
-			topicoptions.WithWriterWaitServerAck(true),
-			topicoptions.WithWriteToManyPartitions(
-				topicoptions.WithProducerIDPrefix("lazy-tx-multi"),
-			),
-		)
-		if err != nil {
-			return fmt.Errorf("start transactional writer: %w", err)
-		}
-
-		err = writer.Write(ctx, topicwriter.Message{
-			Data: strings.NewReader(payload),
-			Key:  "abc",
-		})
-		if err != nil {
-			return fmt.Errorf("write message: %w", err)
-		}
-
-		return nil
-	}, query.WithLazyTx(true))
-	require.NoError(t, err)
-
-	batch, err := reader.ReadMessagesBatch(ctx)
-	require.NoError(t, err)
-	require.Len(t, batch.Messages, 1)
-	content, err := io.ReadAll(batch.Messages[0])
-	require.NoError(t, err)
-	require.Equal(t, payload, string(content))
-}
-
 func TestWriteInTransaction(t *testing.T) {
 	if os.Getenv("YDB_VERSION") != "nightly" && version.Lt(os.Getenv("YDB_VERSION"), "25.0") {
 		t.Skip("require enables transactions for topics")

--- a/tests/integration/topic_transactions_test.go
+++ b/tests/integration/topic_transactions_test.go
@@ -231,10 +231,6 @@ func TestTopicTransactionalMultiWriterWithLazyTx(t *testing.T) {
 			return fmt.Errorf("start transactional writer: %w", err)
 		}
 
-		if err := writer.WaitInit(ctx); err != nil {
-			return fmt.Errorf("wait init: %w", err)
-		}
-
 		err = writer.Write(ctx, topicwriter.Message{
 			Data: strings.NewReader(payload),
 			Key:  "abc",
@@ -374,10 +370,6 @@ func TestWriteInTransactionMultiWriter(t *testing.T) {
 					return err
 				}
 
-				if err := writer.WaitInit(ctx); err != nil {
-					return err
-				}
-
 				return writer.Write(ctx, topicwriter.Message{
 					Data: strings.NewReader(strconv.Itoa(transactionsCount)),
 					Key:  stablePartitionKey,
@@ -435,6 +427,7 @@ func TestWriteInTransactionMultiWriter(t *testing.T) {
 					Data: strings.NewReader(strconv.Itoa(transactionsCount)),
 					Key:  stablePartitionKey,
 				}))
+				time.Sleep(time.Second * 3)
 				return testErr
 			})
 			require.ErrorIs(t, err, testErr)

--- a/tests/integration/topic_transactions_test.go
+++ b/tests/integration/topic_transactions_test.go
@@ -211,6 +211,50 @@ func TestTopicTransactionalWriterWithLazyTx(t *testing.T) {
 	require.Equal(t, payload, string(content))
 }
 
+// TestTopicTransactionalMultiWriterWithLazyTx uses StartTransactionalWriter with
+// topicoptions.WithWriteToManyPartitions (internal multi-writer) together with lazy query transactions.
+func TestTopicTransactionalMultiWriterWithLazyTx(t *testing.T) {
+	scope := newScope(t)
+	ctx := scope.Ctx
+	db := scope.Driver()
+	reader := scope.TopicReader()
+
+	const payload = "lazy-tx-multi-writer"
+	err := db.Query().DoTx(ctx, func(ctx context.Context, tx query.TxActor) error {
+		writer, err := db.Topic().StartTransactionalWriter(tx, scope.TopicPath(),
+			topicoptions.WithWriterWaitServerAck(true),
+			topicoptions.WithWriteToManyPartitions(
+				topicoptions.WithProducerIDPrefix("lazy-tx-multi"),
+			),
+		)
+		if err != nil {
+			return fmt.Errorf("start transactional writer: %w", err)
+		}
+
+		if err := writer.WaitInit(ctx); err != nil {
+			return fmt.Errorf("wait init: %w", err)
+		}
+
+		err = writer.Write(ctx, topicwriter.Message{
+			Data: strings.NewReader(payload),
+			Key:  "abc",
+		})
+		if err != nil {
+			return fmt.Errorf("write message: %w", err)
+		}
+
+		return nil
+	}, query.WithLazyTx(true))
+	require.NoError(t, err)
+
+	batch, err := reader.ReadMessagesBatch(ctx)
+	require.NoError(t, err)
+	require.Len(t, batch.Messages, 1)
+	content, err := io.ReadAll(batch.Messages[0])
+	require.NoError(t, err)
+	require.Equal(t, payload, string(content))
+}
+
 func TestWriteInTransaction(t *testing.T) {
 	if os.Getenv("YDB_VERSION") != "nightly" && version.Lt(os.Getenv("YDB_VERSION"), "25.0") {
 		t.Skip("require enables transactions for topics")


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix

## What is the current behavior?

No transaction is passed to incoming messages to transactional writer

Issue Number: N/A

## What is the new behavior?

Now we pass tx object to each incoming message

## Other information

