### PR TITLE
fix(stats): chain WithStatsMode* callbacks instead of overwriting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed `ydb.WithStatsMode*` for `database/sql` silently dropping a previously registered stats callback when called more than once on the same context. Repeated calls now chain callbacks (they fire in registration order) and the effective stats mode is the most detailed one across the chain.
+
 ## v3.138.2
 * Added an internal query transaction trace field `WithCommit` for spans and logs
 

--- a/internal/stats/context.go
+++ b/internal/stats/context.go
@@ -12,12 +12,31 @@ type ModeCallback struct {
 	Callback func(QueryStats)
 }
 
-// WithModeCallback returns a new context with the specified statistics mode and callback.
-// The callback is invoked when query statistics become available.
-// If callback is nil, the original context is returned.
+// WithModeCallback returns a new context that triggers callback when query
+// statistics become available.
+//
+// If the parent context already carries a stats callback, the new callback is
+// chained with the existing one: both callbacks fire on every QueryStats, in
+// the order they were registered (existing first, then the new one). The
+// effective mode becomes max(existing mode, new mode) so the more detailed
+// mode wins and previously requested detail is never silently downgraded.
+//
+// If callback is nil, the parent context is returned unchanged.
 func WithModeCallback(ctx context.Context, mode Mode, callback func(QueryStats)) context.Context {
 	if callback == nil {
 		return ctx
+	}
+
+	if prev := ModeCallbackFromContext(ctx); prev != nil {
+		if mode < prev.Mode {
+			mode = prev.Mode
+		}
+
+		prevCallback, newCallback := prev.Callback, callback
+		callback = func(qs QueryStats) {
+			prevCallback(qs)
+			newCallback(qs)
+		}
 	}
 
 	return context.WithValue(ctx, ctxModeCallbackKey{}, &ModeCallback{
@@ -26,8 +45,8 @@ func WithModeCallback(ctx context.Context, mode Mode, callback func(QueryStats))
 	})
 }
 
-// ModeCallbackFromContext extracts the ModeCallback from the context.
-// Returns the ModeCallback if present in the context, otherwise returns nil.
+// ModeCallbackFromContext returns the ModeCallback stored in ctx by
+// WithModeCallback, or nil if none was set.
 func ModeCallbackFromContext(ctx context.Context) *ModeCallback {
 	if v, ok := ctx.Value(ctxModeCallbackKey{}).(*ModeCallback); ok {
 		return v
@@ -36,13 +55,23 @@ func ModeCallbackFromContext(ctx context.Context) *ModeCallback {
 	return nil
 }
 
-// ModeCallbackFromContextWith extracts the ModeCallback from the context,
-// appending a configuration to the context mode.
+// ModeCallbackFromContextWith returns a ModeCallback that combines the stats
+// callback stored in ctx (if any) with the provided callback. The effective
+// mode is max(ctx mode, mode) so the more detailed mode wins. The combined
+// callback first invokes the ctx callback, then the provided one.
+//
+// The result is ephemeral: it is NOT written back into ctx. This lets callers
+// attach per-call internal callbacks (for example, an internal helper that
+// reads rowsAffected from QueryStats) without leaking them into ctx and
+// affecting later, unrelated calls that reuse the same ctx.
+//
+// callback must be non-nil. To read the ctx callback without combining, use
+// ModeCallbackFromContext instead.
 func ModeCallbackFromContextWith(ctx context.Context, mode Mode, callback func(QueryStats)) *ModeCallback {
 	fn := callback
 
-	if v, ok := ctx.Value(ctxModeCallbackKey{}).(*ModeCallback); ok {
-		if mode < v.Mode { // greater mode wins
+	if v := ModeCallbackFromContext(ctx); v != nil {
+		if mode < v.Mode {
 			mode = v.Mode
 		}
 

--- a/internal/stats/context_test.go
+++ b/internal/stats/context_test.go
@@ -4,87 +4,219 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/stats"
 )
 
-func TestStatsModeContext(t *testing.T) {
-	t.Run("nil by default", func(t *testing.T) {
-		sm := stats.ModeCallbackFromContext(context.Background())
-		require.Nil(t, sm)
+// recorder collects callback invocations in the order they happen, so tests
+// can assert both "was called" and "in what order relative to other callbacks".
+type recorder struct {
+	calls []string
+}
+
+func (r *recorder) record(name string) func(stats.QueryStats) {
+	return func(stats.QueryStats) {
+		r.calls = append(r.calls, name)
+	}
+}
+
+func TestWithModeCallback(t *testing.T) {
+	t.Run("NilCallbackReturnsSameContext", func(t *testing.T) {
+		parent := context.Background()
+
+		ctx := stats.WithModeCallback(parent, stats.ModeBasic, nil)
+
+		require.Equal(t, parent, ctx)
+		require.Nil(t, stats.ModeCallbackFromContext(ctx))
 	})
 
-	t.Run("round-trip", func(t *testing.T) {
-		called := false
-		ctx := stats.WithModeCallback(context.Background(), stats.ModeBasic, func(qs stats.QueryStats) {
-			called = true
-		})
-		sm := stats.ModeCallbackFromContext(ctx)
-		require.NotNil(t, sm)
-		require.Equal(t, stats.ModeBasic, sm.Mode)
-		sm.Callback(nil)
-		require.True(t, called)
+	t.Run("NilCallbackKeepsExistingValue", func(t *testing.T) {
+		var r recorder
+		parent := stats.WithModeCallback(context.Background(), stats.ModeFull, r.record("existing"))
+
+		ctx := stats.WithModeCallback(parent, stats.ModeBasic, nil)
+
+		got := stats.ModeCallbackFromContext(ctx)
+		require.NotNil(t, got)
+		require.Equal(t, stats.ModeFull, got.Mode)
+		got.Callback(nil)
+		require.Equal(t, []string{"existing"}, r.calls)
 	})
 
-	t.Run("all modes", func(t *testing.T) {
-		modes := []stats.Mode{
-			stats.ModeBasic,
-			stats.ModeFull,
-			stats.ModeProfile,
+	t.Run("StoresFirstCallback", func(t *testing.T) {
+		var r recorder
+
+		ctx := stats.WithModeCallback(context.Background(), stats.ModeBasic, r.record("first"))
+
+		got := stats.ModeCallbackFromContext(ctx)
+		require.NotNil(t, got)
+		require.Equal(t, stats.ModeBasic, got.Mode)
+		got.Callback(nil)
+		require.Equal(t, []string{"first"}, r.calls)
+	})
+
+	t.Run("ChainsCallbacksInOrder", func(t *testing.T) {
+		// Regression: previously WithModeCallback overwrote the context value,
+		// so a second WithStatsMode* call silently dropped the first callback.
+		var r recorder
+
+		ctx := context.Background()
+		ctx = stats.WithModeCallback(ctx, stats.ModeBasic, r.record("first"))
+		ctx = stats.WithModeCallback(ctx, stats.ModeBasic, r.record("second"))
+
+		got := stats.ModeCallbackFromContext(ctx)
+		require.NotNil(t, got)
+		got.Callback(nil)
+		require.Equal(t, []string{"first", "second"}, r.calls)
+	})
+
+	t.Run("UpgradesModeWhenChainedWithMoreDetailed", func(t *testing.T) {
+		var r recorder
+
+		ctx := context.Background()
+		ctx = stats.WithModeCallback(ctx, stats.ModeBasic, r.record("basic"))
+		ctx = stats.WithModeCallback(ctx, stats.ModeProfile, r.record("profile"))
+
+		got := stats.ModeCallbackFromContext(ctx)
+		require.NotNil(t, got)
+		require.Equal(t, stats.ModeProfile, got.Mode, "max(basic, profile) must win so detail is preserved")
+		got.Callback(nil)
+		require.Equal(t, []string{"basic", "profile"}, r.calls)
+	})
+
+	t.Run("KeepsHigherModeWhenChainedWithLessDetailed", func(t *testing.T) {
+		var r recorder
+
+		ctx := context.Background()
+		ctx = stats.WithModeCallback(ctx, stats.ModeProfile, r.record("profile"))
+		ctx = stats.WithModeCallback(ctx, stats.ModeBasic, r.record("basic"))
+
+		got := stats.ModeCallbackFromContext(ctx)
+		require.NotNil(t, got)
+		require.Equal(t, stats.ModeProfile, got.Mode, "already-requested detail must not be downgraded")
+		got.Callback(nil)
+		require.Equal(t, []string{"profile", "basic"}, r.calls)
+	})
+
+	t.Run("KeepsModeWhenChainedAtSameDetail", func(t *testing.T) {
+		var r recorder
+
+		ctx := context.Background()
+		ctx = stats.WithModeCallback(ctx, stats.ModeFull, r.record("first"))
+		ctx = stats.WithModeCallback(ctx, stats.ModeFull, r.record("second"))
+
+		got := stats.ModeCallbackFromContext(ctx)
+		require.NotNil(t, got)
+		require.Equal(t, stats.ModeFull, got.Mode)
+		got.Callback(nil)
+		require.Equal(t, []string{"first", "second"}, r.calls)
+	})
+
+	t.Run("ChainsThreeCallbacks", func(t *testing.T) {
+		var r recorder
+
+		ctx := context.Background()
+		ctx = stats.WithModeCallback(ctx, stats.ModeBasic, r.record("a"))
+		ctx = stats.WithModeCallback(ctx, stats.ModeFull, r.record("b"))
+		ctx = stats.WithModeCallback(ctx, stats.ModeProfile, r.record("c"))
+
+		got := stats.ModeCallbackFromContext(ctx)
+		require.NotNil(t, got)
+		require.Equal(t, stats.ModeProfile, got.Mode)
+		got.Callback(nil)
+		require.Equal(t, []string{"a", "b", "c"}, r.calls)
+	})
+
+	t.Run("AllModes", func(t *testing.T) {
+		for _, mode := range []stats.Mode{stats.ModeBasic, stats.ModeFull, stats.ModeProfile} {
+			t.Run(modeName(mode), func(t *testing.T) {
+				ctx := stats.WithModeCallback(context.Background(), mode, func(stats.QueryStats) {})
+
+				got := stats.ModeCallbackFromContext(ctx)
+				require.NotNil(t, got)
+				require.Equal(t, mode, got.Mode)
+			})
 		}
-		for _, mode := range modes {
-			ctx := stats.WithModeCallback(context.Background(), mode, func(qs stats.QueryStats) {})
-			sm := stats.ModeCallbackFromContext(ctx)
-			require.NotNil(t, sm)
-			require.Equal(t, mode, sm.Mode)
-		}
-	})
-
-	t.Run("callback is nil", func(t *testing.T) {
-		ctx := stats.WithModeCallback(context.Background(), stats.ModeBasic, nil)
-		sm := stats.ModeCallbackFromContext(ctx)
-		require.Nil(t, sm)
 	})
 }
 
-func TestStatsModeContextWithDefault(t *testing.T) {
-	t.Run("default", func(t *testing.T) {
-		var (
-			called bool
-			ctx    = context.Background()
-		)
-
-		sm := stats.ModeCallbackFromContextWith(ctx, stats.ModeBasic, func(_ stats.QueryStats) {
-			called = true
-		})
-
-		require.NotNil(t, sm)
-		sm.Callback(nil)
-
-		assert.True(t, called)
-		assert.Equal(t, stats.ModeBasic, sm.Mode)
+func TestModeCallbackFromContext(t *testing.T) {
+	t.Run("ReturnsNilForEmptyContext", func(t *testing.T) {
+		require.Nil(t, stats.ModeCallbackFromContext(context.Background()))
 	})
 
-	t.Run("with", func(t *testing.T) {
-		var (
-			called1, called2 bool
-			ctx              = context.Background()
-		)
+	t.Run("ReturnsStoredValue", func(t *testing.T) {
+		var r recorder
+		ctx := stats.WithModeCallback(context.Background(), stats.ModeFull, r.record("cb"))
 
-		ctx = stats.WithModeCallback(ctx, stats.ModeFull, func(_ stats.QueryStats) {
-			called1 = true
-		})
+		got := stats.ModeCallbackFromContext(ctx)
 
-		sm := stats.ModeCallbackFromContextWith(ctx, stats.ModeBasic, func(_ stats.QueryStats) { called2 = true })
-		require.NotNil(t, sm)
-
-		assert.Equal(t, stats.ModeFull, sm.Mode)
-
-		sm.Callback(nil)
-
-		assert.True(t, called1)
-		assert.True(t, called2)
+		require.NotNil(t, got)
+		require.Equal(t, stats.ModeFull, got.Mode)
+		got.Callback(nil)
+		require.Equal(t, []string{"cb"}, r.calls)
 	})
+}
+
+func TestModeCallbackFromContextWith(t *testing.T) {
+	t.Run("ReturnsProvidedCallbackWhenContextEmpty", func(t *testing.T) {
+		var r recorder
+
+		got := stats.ModeCallbackFromContextWith(context.Background(), stats.ModeBasic, r.record("internal"))
+
+		require.NotNil(t, got)
+		require.Equal(t, stats.ModeBasic, got.Mode)
+		got.Callback(nil)
+		require.Equal(t, []string{"internal"}, r.calls)
+	})
+
+	t.Run("CombinesContextAndProvidedCallback", func(t *testing.T) {
+		var r recorder
+		ctx := stats.WithModeCallback(context.Background(), stats.ModeFull, r.record("user"))
+
+		got := stats.ModeCallbackFromContextWith(ctx, stats.ModeBasic, r.record("internal"))
+
+		require.NotNil(t, got)
+		require.Equal(t, stats.ModeFull, got.Mode, "max(user mode, internal mode) wins")
+		got.Callback(nil)
+		require.Equal(t, []string{"user", "internal"}, r.calls, "ctx callback runs before the provided one")
+	})
+
+	t.Run("UpgradesModeWhenProvidedIsHigher", func(t *testing.T) {
+		var r recorder
+		ctx := stats.WithModeCallback(context.Background(), stats.ModeBasic, r.record("user"))
+
+		got := stats.ModeCallbackFromContextWith(ctx, stats.ModeProfile, r.record("internal"))
+
+		require.Equal(t, stats.ModeProfile, got.Mode)
+	})
+
+	t.Run("DoesNotMutateContext", func(t *testing.T) {
+		// The combined callback is meant to be ephemeral; subsequent reads of
+		// the same ctx must still see only what the user put there.
+		var r recorder
+		ctx := stats.WithModeCallback(context.Background(), stats.ModeBasic, r.record("user"))
+
+		_ = stats.ModeCallbackFromContextWith(ctx, stats.ModeFull, r.record("internal"))
+
+		got := stats.ModeCallbackFromContext(ctx)
+		require.NotNil(t, got)
+		require.Equal(t, stats.ModeBasic, got.Mode)
+		got.Callback(nil)
+		require.Equal(t, []string{"user"}, r.calls, "only the ctx callback should fire on the un-combined value")
+	})
+}
+
+func modeName(m stats.Mode) string {
+	switch m {
+	case stats.ModeBasic:
+		return "Basic"
+	case stats.ModeFull:
+		return "Full"
+	case stats.ModeProfile:
+		return "Profile"
+	default:
+		return "Unknown"
+	}
 }

--- a/internal/stats/query_go1.23_test.go
+++ b/internal/stats/query_go1.23_test.go
@@ -1,100 +1,137 @@
 //go:build go1.23
 
-package stats
+package stats_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_TableStats"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/stats"
 )
 
-func TestIterateOverQueryPhases(t *testing.T) {
-	s := FromQueryStats(&Ydb_TableStats.QueryStats{
+// iterableQueryStatsPB has 3 phases × 3 tables: enough variety to verify
+// ordering, full traversal, and early-break behavior of the range iterators.
+func iterableQueryStatsPB() *Ydb_TableStats.QueryStats {
+	return &Ydb_TableStats.QueryStats{
 		QueryPhases: []*Ydb_TableStats.QueryPhaseStats{
 			{
 				DurationUs: 1,
 				TableAccess: []*Ydb_TableStats.TableAccessStats{
-					{
-						Name: "a",
-					},
-					{
-						Name: "b",
-					},
-					{
-						Name: "c",
-					},
+					{Name: "a"}, {Name: "b"}, {Name: "c"},
 				},
 			},
 			{
 				DurationUs: 2,
 				TableAccess: []*Ydb_TableStats.TableAccessStats{
-					{
-						Name: "d",
-					},
-					{
-						Name: "e",
-					},
-					{
-						Name: "f",
-					},
+					{Name: "d"}, {Name: "e"}, {Name: "f"},
 				},
 			},
 			{
 				DurationUs: 3,
 				TableAccess: []*Ydb_TableStats.TableAccessStats{
-					{
-						Name: "g",
-					},
-					{
-						Name: "h",
-					},
-					{
-						Name: "i",
-					},
+					{Name: "g"}, {Name: "h"}, {Name: "i"},
 				},
 			},
 		},
-	})
-	t.Run("ImmutableIteration", func(t *testing.T) {
-		for i := range make([]struct{}, 3) {
-			t.Run(fmt.Sprintf("Pass#%d", i), func(t *testing.T) {
-				durations := make([]time.Duration, 0, 3)
-				tables := make([]string, 0, 9)
-				for phase := range s.QueryPhases() {
-					durations = append(durations, phase.Duration())
-					for access := range phase.TableAccess() {
-						tables = append(tables, access.Name)
-					}
-				}
-				require.Equal(t, []time.Duration{1000, 2000, 3000}, durations)
-				require.Equal(t, []string{"a", "b", "c", "d", "e", "f", "g", "h", "i"}, tables)
-			})
-		}
-	})
-	t.Run("MutableIteration", func(t *testing.T) {
-		durations := make([]time.Duration, 0, 3)
-		tables := make([]string, 0, 9)
-		for {
-			phase, ok := s.NextPhase()
-			if !ok {
-				break
-			}
+	}
+}
+
+func TestQueryPhasesIterator(t *testing.T) {
+	t.Run("WalksAllPhasesAndTables", func(t *testing.T) {
+		s := stats.FromQueryStats(iterableQueryStatsPB())
+
+		var (
+			durations []time.Duration
+			tables    []string
+		)
+		for phase := range s.QueryPhases() {
 			durations = append(durations, phase.Duration())
-			for {
-				access, ok := phase.NextTableAccess()
-				if !ok {
-					break
-				}
+			for access := range phase.TableAccess() {
 				tables = append(tables, access.Name)
 			}
 		}
-		require.Equal(t, []time.Duration{1000, 2000, 3000}, durations)
-		require.Equal(t, []string{"a", "b", "c", "d", "e", "f", "g", "h", "i"}, tables)
 
-		_, ok := s.NextPhase()
-		require.False(t, ok)
+		require.Equal(t, []time.Duration{us(1), us(2), us(3)}, durations)
+		require.Equal(t, []string{"a", "b", "c", "d", "e", "f", "g", "h", "i"}, tables)
 	})
+
+	t.Run("IsRestartable", func(t *testing.T) {
+		// The range iterator must be independent of NextPhase/NextTableAccess
+		// cursors: calling it multiple times must yield the same sequence.
+		s := stats.FromQueryStats(iterableQueryStatsPB())
+
+		for pass := range 3 {
+			var tables []string
+			for phase := range s.QueryPhases() {
+				for access := range phase.TableAccess() {
+					tables = append(tables, access.Name)
+				}
+			}
+			require.Equalf(t, []string{"a", "b", "c", "d", "e", "f", "g", "h", "i"}, tables, "pass #%d", pass)
+		}
+	})
+
+	t.Run("BreakStopsPhaseIteration", func(t *testing.T) {
+		s := stats.FromQueryStats(iterableQueryStatsPB())
+
+		var durations []time.Duration
+		for phase := range s.QueryPhases() {
+			durations = append(durations, phase.Duration())
+			if len(durations) == 2 {
+				break
+			}
+		}
+
+		require.Equal(t, []time.Duration{us(1), us(2)}, durations)
+	})
+
+	t.Run("BreakStopsTableAccessIteration", func(t *testing.T) {
+		s := stats.FromQueryStats(iterableQueryStatsPB())
+
+		phase, ok := s.NextPhase()
+		require.True(t, ok)
+
+		var tables []string
+		for access := range phase.TableAccess() {
+			tables = append(tables, access.Name)
+			if len(tables) == 2 {
+				break
+			}
+		}
+
+		require.Equal(t, []string{"a", "b"}, tables)
+	})
+
+	t.Run("EmptyPhasesYieldsNothing", func(t *testing.T) {
+		s := stats.FromQueryStats(&Ydb_TableStats.QueryStats{})
+
+		var count int
+		for range s.QueryPhases() {
+			count++
+		}
+
+		require.Zero(t, count)
+	})
+}
+
+func TestNextPhaseAndIteratorCursorsAreIndependent(t *testing.T) {
+	// Mutating cursors (NextPhase, NextTableAccess) advance internal state;
+	// the range iterator must NOT share that state and must always start from
+	// the beginning of the underlying slice. This protects callers that mix
+	// the two styles (e.g. peek with NextPhase then iterate with range).
+	s := stats.FromQueryStats(iterableQueryStatsPB())
+
+	first, ok := s.NextPhase()
+	require.True(t, ok)
+	require.Equal(t, us(1), first.Duration())
+
+	var durations []time.Duration
+	for phase := range s.QueryPhases() {
+		durations = append(durations, phase.Duration())
+	}
+
+	require.Equal(t, []time.Duration{us(1), us(2), us(3)}, durations)
 }

--- a/internal/stats/query_test.go
+++ b/internal/stats/query_test.go
@@ -1,32 +1,33 @@
-package stats
+package stats_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_TableStats"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/stats"
 )
 
-func TestFromQueryStats(t *testing.T) {
-	s := FromQueryStats(&Ydb_TableStats.QueryStats{
+func us(microseconds uint64) time.Duration {
+	return time.Duration(microseconds) * time.Microsecond
+}
+
+// sampleQueryStatsPB returns a fully-populated QueryStats proto used by
+// scalar-field tests. Two query phases let us also exercise NextPhase
+// advancement and table access on more than one phase.
+func sampleQueryStatsPB() *Ydb_TableStats.QueryStats {
+	return &Ydb_TableStats.QueryStats{
 		QueryPhases: []*Ydb_TableStats.QueryPhaseStats{
 			{
 				DurationUs: 10,
 				TableAccess: []*Ydb_TableStats.TableAccessStats{
 					{
-						Name: "a",
-						Reads: &Ydb_TableStats.OperationStats{
-							Rows:  100,
-							Bytes: 200,
-						},
-						Updates: &Ydb_TableStats.OperationStats{
-							Rows:  300,
-							Bytes: 400,
-						},
-						Deletes: &Ydb_TableStats.OperationStats{
-							Rows:  500,
-							Bytes: 600,
-						},
+						Name:            "a",
+						Reads:           &Ydb_TableStats.OperationStats{Rows: 100, Bytes: 200},
+						Updates:         &Ydb_TableStats.OperationStats{Rows: 300, Bytes: 400},
+						Deletes:         &Ydb_TableStats.OperationStats{Rows: 500, Bytes: 600},
 						PartitionsCount: 700,
 					},
 				},
@@ -38,19 +39,10 @@ func TestFromQueryStats(t *testing.T) {
 				DurationUs: 11,
 				TableAccess: []*Ydb_TableStats.TableAccessStats{
 					{
-						Name: "b",
-						Reads: &Ydb_TableStats.OperationStats{
-							Rows:  101,
-							Bytes: 201,
-						},
-						Updates: &Ydb_TableStats.OperationStats{
-							Rows:  301,
-							Bytes: 401,
-						},
-						Deletes: &Ydb_TableStats.OperationStats{
-							Rows:  501,
-							Bytes: 601,
-						},
+						Name:            "b",
+						Reads:           &Ydb_TableStats.OperationStats{Rows: 101, Bytes: 201},
+						Updates:         &Ydb_TableStats.OperationStats{Rows: 301, Bytes: 401},
+						Deletes:         &Ydb_TableStats.OperationStats{Rows: 501, Bytes: 601},
 						PartitionsCount: 701,
 					},
 				},
@@ -69,69 +61,114 @@ func TestFromQueryStats(t *testing.T) {
 		QueryAst:         "ast",
 		TotalDurationUs:  200,
 		TotalCpuTimeUs:   300,
+	}
+}
+
+func TestFromQueryStats(t *testing.T) {
+	t.Run("NilProtoReturnsNil", func(t *testing.T) {
+		require.Nil(t, stats.FromQueryStats(nil))
 	})
-	require.Equal(t, fromUs(100), s.ProcessCPUTime())
-	require.Equal(t, fromUs(200), s.TotalDuration())
-	require.Equal(t, fromUs(300), s.TotalCPUTime())
+
+	t.Run("WrapsProto", func(t *testing.T) {
+		require.NotNil(t, stats.FromQueryStats(&Ydb_TableStats.QueryStats{}))
+	})
+}
+
+func TestQueryStatsScalarFields(t *testing.T) {
+	s := stats.FromQueryStats(sampleQueryStatsPB())
+
+	require.Equal(t, us(100), s.ProcessCPUTime())
+	require.Equal(t, us(200), s.TotalDuration())
+	require.Equal(t, us(300), s.TotalCPUTime())
 	require.Equal(t, "ast", s.QueryAST())
 	require.Equal(t, "plan", s.QueryPlan())
-	require.Equal(t, &CompilationStats{
+	require.Equal(t, &stats.CompilationStats{
 		FromCache: true,
-		Duration:  fromUs(123),
-		CPUTime:   fromUs(456),
+		Duration:  us(123),
+		CPUTime:   us(456),
 	}, s.Compilation())
-	phase1, ok := s.NextPhase()
-	require.True(t, ok)
-	require.True(t, phase1.IsLiteralPhase())
-	require.Equal(t, fromUs(10), phase1.Duration())
-	require.Equal(t, fromUs(20), phase1.CPUTime())
-	require.Equal(t, uint64(30), phase1.AffectedShards())
-	tableAccess1FromPhase1, ok := phase1.NextTableAccess()
-	require.True(t, ok)
-	require.Equal(t, &TableAccess{
-		Name: "a",
-		Reads: OperationStats{
-			Rows:  100,
-			Bytes: 200,
-		},
-		Updates: OperationStats{
-			Rows:  300,
-			Bytes: 400,
-		},
-		Deletes: OperationStats{
-			Rows:  500,
-			Bytes: 600,
-		},
-		PartitionsCount: 700,
-	}, tableAccess1FromPhase1)
-	tableAccess2FromPhase1, ok := phase1.NextTableAccess()
-	require.False(t, ok)
-	require.Nil(t, tableAccess2FromPhase1)
-	phase2, ok := s.NextPhase()
-	require.True(t, ok)
-	require.False(t, phase2.IsLiteralPhase())
-	require.Equal(t, fromUs(11), phase2.Duration())
-	require.Equal(t, fromUs(21), phase2.CPUTime())
-	require.Equal(t, uint64(31), phase2.AffectedShards())
-	tableAccess1FromPhase2, ok := phase2.NextTableAccess()
-	require.True(t, ok)
-	require.Equal(t, &TableAccess{
-		Name: "b",
-		Reads: OperationStats{
-			Rows:  101,
-			Bytes: 201,
-		},
-		Updates: OperationStats{
-			Rows:  301,
-			Bytes: 401,
-		},
-		Deletes: OperationStats{
-			Rows:  501,
-			Bytes: 601,
-		},
-		PartitionsCount: 701,
-	}, tableAccess1FromPhase2)
-	tableAccess2FromPhase2, ok := phase2.NextTableAccess()
-	require.False(t, ok)
-	require.Nil(t, tableAccess2FromPhase2)
+}
+
+func TestQueryStatsNextPhase(t *testing.T) {
+	t.Run("WalksAllPhasesAndStops", func(t *testing.T) {
+		s := stats.FromQueryStats(sampleQueryStatsPB())
+
+		phase1, ok := s.NextPhase()
+		require.True(t, ok)
+		require.NotNil(t, phase1)
+		require.Equal(t, us(10), phase1.Duration())
+		require.Equal(t, us(20), phase1.CPUTime())
+		require.Equal(t, uint64(30), phase1.AffectedShards())
+		require.True(t, phase1.IsLiteralPhase())
+
+		phase2, ok := s.NextPhase()
+		require.True(t, ok)
+		require.NotNil(t, phase2)
+		require.Equal(t, us(11), phase2.Duration())
+		require.Equal(t, us(21), phase2.CPUTime())
+		require.Equal(t, uint64(31), phase2.AffectedShards())
+		require.False(t, phase2.IsLiteralPhase())
+
+		end, ok := s.NextPhase()
+		require.False(t, ok)
+		require.Nil(t, end)
+	})
+
+	t.Run("ReturnsFalseOnEmpty", func(t *testing.T) {
+		s := stats.FromQueryStats(&Ydb_TableStats.QueryStats{})
+
+		p, ok := s.NextPhase()
+
+		require.False(t, ok)
+		require.Nil(t, p)
+	})
+
+	t.Run("ReturnsFalseOnNilPhaseEntry", func(t *testing.T) {
+		// A nil entry inside the QueryPhases slice must terminate iteration
+		// cleanly instead of panicking when callers later dereference the
+		// returned phase.
+		s := stats.FromQueryStats(&Ydb_TableStats.QueryStats{
+			QueryPhases: []*Ydb_TableStats.QueryPhaseStats{nil},
+		})
+
+		p, ok := s.NextPhase()
+
+		require.False(t, ok)
+		require.Nil(t, p)
+	})
+}
+
+func TestQueryPhaseNextTableAccess(t *testing.T) {
+	t.Run("WalksAllAccessesAndStops", func(t *testing.T) {
+		s := stats.FromQueryStats(sampleQueryStatsPB())
+		phase, ok := s.NextPhase()
+		require.True(t, ok)
+
+		ta, ok := phase.NextTableAccess()
+		require.True(t, ok)
+		require.Equal(t, &stats.TableAccess{
+			Name:            "a",
+			Reads:           stats.OperationStats{Rows: 100, Bytes: 200},
+			Updates:         stats.OperationStats{Rows: 300, Bytes: 400},
+			Deletes:         stats.OperationStats{Rows: 500, Bytes: 600},
+			PartitionsCount: 700,
+		}, ta)
+
+		end, ok := phase.NextTableAccess()
+		require.False(t, ok)
+		require.Nil(t, end)
+	})
+
+	t.Run("ReturnsFalseOnEmpty", func(t *testing.T) {
+		s := stats.FromQueryStats(&Ydb_TableStats.QueryStats{
+			QueryPhases: []*Ydb_TableStats.QueryPhaseStats{{}},
+		})
+		phase, ok := s.NextPhase()
+		require.True(t, ok)
+
+		ta, ok := phase.NextTableAccess()
+
+		require.False(t, ok)
+		require.Nil(t, ta)
+	})
 }


### PR DESCRIPTION
## Summary

- `internal/stats.WithModeCallback` used to overwrite the stats callback stored in context via `context.WithValue`, silently dropping any callback registered by an earlier `ydb.WithStatsMode*` call.
- The bug surfaced when two user-level `WithStatsMode*` calls existed on the same context (e.g. middleware registers a metrics handler, the request handler later registers a debug handler — the metrics handler was lost).
- `WithModeCallback` now chains: existing callback fires first, new callback second, and the effective mode becomes `max(existing, new)` so previously-requested detail is not silently downgraded. Both `WithModeCallback` and `ModeCallbackFromContextWith` now read the context through `ModeCallbackFromContext` to avoid duplicated key lookups.
- Test coverage for `internal/stats` raised to **100%**, including the regression case for chained callbacks, mode-upgrade / mode-keep-higher scenarios, and previously-uncovered `nil`-branches in `FromQueryStats` / `NextPhase` / iterator `break` paths.

## Test plan

- [x] `go test ./internal/stats/... -cover` → `coverage: 100.0% of statements`
- [x] `go test ./internal/xsql/... ./internal/query/...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint run ./internal/stats/...` → `0 issues`

🤖 Generated with [Claude Code](https://claude.com/claude-code)