### PR TITLE
feat(topic): support topic metrics_level

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,8 +1,6 @@
 name: changelog
 on:
   pull_request_target:
-  pull_request:
-    types: [opened, reopened, synchronize, labeled]
 jobs:
   changelog:
     name: changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+* Added `topicoptions.CreateWithMetricsLevel`, `topicoptions.AlterWithSetMetricsLevel`, and `topicoptions.AlterWithResetMetricsLevel` to configure topic metrics level
+* Added `MetricsLevel` field to `topictypes.TopicDescription`
+* Bumped `ydb-go-genproto` to expose the `metrics_level` field on topic create/alter/describe protos
+
 ## v3.138.2
 * Added an internal query transaction trace field `WithCommit` for spans and logs
 

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -59,7 +59,7 @@ require (
 	github.com/sethvargo/go-retry v0.3.0 // indirect
 	github.com/syndtr/goleveldb v1.0.0 // indirect
 	github.com/yandex-cloud/go-genproto v0.0.0-20220815090733-4c139c0154e2 // indirect
-	github.com/ydb-platform/ydb-go-genproto v0.0.0-20260311095541-ebbf792c1180 // indirect
+	github.com/ydb-platform/ydb-go-genproto v0.0.0-20260428144813-1c07baab7f7b // indirect
 	github.com/ydb-platform/ydb-go-yc-metadata v0.6.1 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.48.0 // indirect

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -3553,8 +3553,8 @@ github.com/ydb-platform/gorm-driver v0.1.3 h1:uewwScbRuCixNPC0LF7gDKvWcB13/iLj76
 github.com/ydb-platform/gorm-driver v0.1.3/go.mod h1:49cSoG5J18muQTiKj4StL2dHs1/dB94OitnHOvetK24=
 github.com/ydb-platform/xorm v0.0.3 h1:MXk42lANB6r/MMLg/XdJfyXJycGUDlCeLiMlLGDKVPw=
 github.com/ydb-platform/xorm v0.0.3/go.mod h1:hFsU7EUF0o3S+l5c0eyP2yPVjJ0d4gsFdqCsyazzwBc=
-github.com/ydb-platform/ydb-go-genproto v0.0.0-20260311095541-ebbf792c1180 h1:avIdi8eGXjKbn1WLokNR1Ofnz1k8t7tJ88YQLD/iCi8=
-github.com/ydb-platform/ydb-go-genproto v0.0.0-20260311095541-ebbf792c1180/go.mod h1:Er+FePu1dNUieD+XTMDduGpQuCPssK5Q4BjF+IIXJ3I=
+github.com/ydb-platform/ydb-go-genproto v0.0.0-20260428144813-1c07baab7f7b h1:xeiobG1riqe6dTMZuTcOvwOY0BbFidSk3gRLyVeLfJA=
+github.com/ydb-platform/ydb-go-genproto v0.0.0-20260428144813-1c07baab7f7b/go.mod h1:Er+FePu1dNUieD+XTMDduGpQuCPssK5Q4BjF+IIXJ3I=
 github.com/ydb-platform/ydb-go-sdk-auth-environ v0.3.0 h1:JxSvw+Moont8qCmibP2MjSEIHfkWJLkw0fHZemAk+d0=
 github.com/ydb-platform/ydb-go-sdk-auth-environ v0.3.0/go.mod h1:YzCPoNrTbrXZg9bO2YkbjI6eQLkaRIE9Bq8ponu0g8A=
 github.com/ydb-platform/ydb-go-sdk-prometheus/v2 v2.1.2 h1:/kDHhXMNGjsqy+SZ3Zn7gZ2ziZekUJLnPXqwy6vyAX8=

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/google/uuid v1.6.0
 	github.com/jonboulle/clockwork v0.5.0
-	github.com/ydb-platform/ydb-go-genproto v0.0.0-20260311095541-ebbf792c1180
+	github.com/ydb-platform/ydb-go-genproto v0.0.0-20260428144813-1c07baab7f7b
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/sync v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/ydb-platform/ydb-go-genproto v0.0.0-20260311095541-ebbf792c1180 h1:avIdi8eGXjKbn1WLokNR1Ofnz1k8t7tJ88YQLD/iCi8=
-github.com/ydb-platform/ydb-go-genproto v0.0.0-20260311095541-ebbf792c1180/go.mod h1:Er+FePu1dNUieD+XTMDduGpQuCPssK5Q4BjF+IIXJ3I=
+github.com/ydb-platform/ydb-go-genproto v0.0.0-20260428144813-1c07baab7f7b h1:xeiobG1riqe6dTMZuTcOvwOY0BbFidSk3gRLyVeLfJA=
+github.com/ydb-platform/ydb-go-genproto v0.0.0-20260428144813-1c07baab7f7b/go.mod h1:Er+FePu1dNUieD+XTMDduGpQuCPssK5Q4BjF+IIXJ3I=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.38.0 h1:RkfdswUDRimDg0m2Az18RKOsnI8UDzppJAtj01/Ymk8=

--- a/internal/grpcwrapper/rawoptional/rawoptional.go
+++ b/internal/grpcwrapper/rawoptional/rawoptional.go
@@ -93,6 +93,33 @@ func (v *Int32) ToProto() *int32 {
 	return &val
 }
 
+type Uint32 struct {
+	Value    uint32
+	HasValue bool
+}
+
+func (v *Uint32) ToProto() *uint32 {
+	if !v.HasValue {
+		return nil
+	}
+
+	val := v.Value
+
+	return &val
+}
+
+func (v *Uint32) MustFromProto(proto *uint32) {
+	if proto == nil {
+		v.Value = 0
+		v.HasValue = false
+
+		return
+	}
+
+	v.HasValue = true
+	v.Value = *proto
+}
+
 type Time struct {
 	Value    time.Time
 	HasValue bool

--- a/internal/grpcwrapper/rawtopic/alter_topic.go
+++ b/internal/grpcwrapper/rawtopic/alter_topic.go
@@ -26,6 +26,8 @@ type AlterTopicRequest struct {
 	DropConsumers                        []string
 	AlterConsumers                       []AlterConsumer
 	SetMeteringMode                      MeteringMode
+	SetMetricsLevel                      rawoptional.Uint32
+	ResetMetricsLevel                    bool
 }
 
 func (req *AlterTopicRequest) ToProto() *Ydb_Topic.AlterTopicRequest {
@@ -43,6 +45,17 @@ func (req *AlterTopicRequest) ToProto() *Ydb_Topic.AlterTopicRequest {
 
 	if req.SetSupportedCodecs {
 		res.SetSupportedCodecs = req.SetSupportedCodecsValue.ToProto()
+	}
+
+	if req.SetMetricsLevel.HasValue {
+		res.MetricsLevel = &Ydb_Topic.AlterTopicRequest_SetMetricsLevel{
+			SetMetricsLevel: req.SetMetricsLevel.Value,
+		}
+	}
+	if req.ResetMetricsLevel {
+		res.MetricsLevel = &Ydb_Topic.AlterTopicRequest_ResetMetricsLevel{
+			ResetMetricsLevel: &emptypb.Empty{},
+		}
 	}
 
 	res.AddConsumers = make([]*Ydb_Topic.Consumer, len(req.AddConsumers))

--- a/internal/grpcwrapper/rawtopic/create_topic.go
+++ b/internal/grpcwrapper/rawtopic/create_topic.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Topic"
 	"google.golang.org/protobuf/types/known/durationpb"
 
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawoptional"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawtopic/rawtopiccommon"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawydb"
 )
@@ -23,6 +24,7 @@ type CreateTopicRequest struct {
 	Attributes                        map[string]string
 	Consumers                         []Consumer
 	MeteringMode                      MeteringMode
+	MetricsLevel                      rawoptional.Uint32
 }
 
 func (req *CreateTopicRequest) ToProto() *Ydb_Topic.CreateTopicRequest {
@@ -46,6 +48,8 @@ func (req *CreateTopicRequest) ToProto() *Ydb_Topic.CreateTopicRequest {
 	}
 
 	proto.MeteringMode = Ydb_Topic.MeteringMode(req.MeteringMode)
+
+	proto.MetricsLevel = req.MetricsLevel.ToProto()
 
 	return proto
 }

--- a/internal/grpcwrapper/rawtopic/describe_topic.go
+++ b/internal/grpcwrapper/rawtopic/describe_topic.go
@@ -7,6 +7,7 @@ import (
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Topic"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/clone"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawoptional"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawscheme"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawtopic/rawtopiccommon"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawydb"
@@ -42,6 +43,7 @@ type DescribeTopicResult struct {
 	Attributes                        map[string]string
 	Consumers                         []Consumer
 	MeteringMode                      MeteringMode
+	MetricsLevel                      rawoptional.Uint32
 }
 
 func (res *DescribeTopicResult) FromProto(response operation.Response) error {
@@ -89,6 +91,8 @@ func (res *DescribeTopicResult) FromProto(response operation.Response) error {
 	}
 
 	res.MeteringMode = MeteringMode(protoResult.GetMeteringMode())
+
+	res.MetricsLevel.MustFromProto(protoResult.MetricsLevel)
 
 	return nil
 }

--- a/tests/integration/topic_client_test.go
+++ b/tests/integration/topic_client_test.go
@@ -723,21 +723,13 @@ func TestTopicMetricsLevel(t *testing.T) {
 	scope := newScope(t)
 	ctx := scope.Ctx
 
-	topicName := "test-topic-" + t.Name()
-	topicPath := scope.Driver().Name() + "/" + topicName
-
-	_ = scope.Driver().Topic().Drop(ctx, topicPath)
-
 	const initialLevel = uint32(3)
-	err := scope.Driver().Topic().Create(ctx, topicPath,
+
+	topicPath := scope.TopicPath(
 		topicoptions.CreateWithMinActivePartitions(1),
 		topicoptions.CreateWithMaxActivePartitions(1),
 		topicoptions.CreateWithMetricsLevel(initialLevel),
 	)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = scope.Driver().Topic().Drop(ctx, topicPath)
-	})
 
 	desc, err := scope.Driver().Topic().Describe(ctx, topicPath)
 	require.NoError(t, err)
@@ -767,10 +759,6 @@ func TestTopicMetricsLevel(t *testing.T) {
 
 func connect(t testing.TB, opts ...ydb.Option) *ydb.Driver {
 	return connectWithLogOption(t, false, opts...)
-}
-
-func connectWithGrpcLogging(t testing.TB, opts ...ydb.Option) *ydb.Driver {
-	return connectWithLogOption(t, true, opts...)
 }
 
 func connectWithLogOption(t testing.TB, logGRPC bool, opts ...ydb.Option) *ydb.Driver {

--- a/tests/integration/topic_client_test.go
+++ b/tests/integration/topic_client_test.go
@@ -18,6 +18,7 @@ import (
 
 	ydb "github.com/ydb-platform/ydb-go-sdk/v3"
 	"github.com/ydb-platform/ydb-go-sdk/v3/config"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/version"
 	xtest "github.com/ydb-platform/ydb-go-sdk/v3/pkg/xtest"
 	"github.com/ydb-platform/ydb-go-sdk/v3/topic/topicoptions"
 	"github.com/ydb-platform/ydb-go-sdk/v3/topic/topictypes"
@@ -710,6 +711,58 @@ func TestAlterTopic(t *testing.T) {
 	topicDesc, err = scope.Driver().Topic().Describe(ctx, topicPath)
 	require.NoError(t, err)
 	require.Equal(t, newMinActivePartitions, topicDesc.PartitionSettings.MinActivePartitions)
+}
+
+func TestTopicMetricsLevel(t *testing.T) {
+	if ydbVersion := os.Getenv("YDB_VERSION"); ydbVersion != "" &&
+		ydbVersion != "nightly" && ydbVersion != "edge" && ydbVersion != "latest" &&
+		version.Lt(ydbVersion, "25.4") {
+		t.Skip("require support for topic metrics_level")
+	}
+
+	scope := newScope(t)
+	ctx := scope.Ctx
+
+	topicName := "test-topic-" + t.Name()
+	topicPath := scope.Driver().Name() + "/" + topicName
+
+	_ = scope.Driver().Topic().Drop(ctx, topicPath)
+
+	const initialLevel = uint32(3)
+	err := scope.Driver().Topic().Create(ctx, topicPath,
+		topicoptions.CreateWithMinActivePartitions(1),
+		topicoptions.CreateWithMaxActivePartitions(1),
+		topicoptions.CreateWithMetricsLevel(initialLevel),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = scope.Driver().Topic().Drop(ctx, topicPath)
+	})
+
+	desc, err := scope.Driver().Topic().Describe(ctx, topicPath)
+	require.NoError(t, err)
+	require.NotNil(t, desc.MetricsLevel, "metrics_level must be populated after create")
+	require.Equal(t, initialLevel, *desc.MetricsLevel)
+
+	const updatedLevel = uint32(5)
+	err = scope.Driver().Topic().Alter(ctx, topicPath,
+		topicoptions.AlterWithSetMetricsLevel(updatedLevel),
+	)
+	require.NoError(t, err)
+
+	desc, err = scope.Driver().Topic().Describe(ctx, topicPath)
+	require.NoError(t, err)
+	require.NotNil(t, desc.MetricsLevel, "metrics_level must be populated after alter set")
+	require.Equal(t, updatedLevel, *desc.MetricsLevel)
+
+	err = scope.Driver().Topic().Alter(ctx, topicPath,
+		topicoptions.AlterWithResetMetricsLevel(),
+	)
+	require.NoError(t, err)
+
+	desc, err = scope.Driver().Topic().Describe(ctx, topicPath)
+	require.NoError(t, err)
+	require.Nil(t, desc.MetricsLevel, "metrics_level must be reset to the database default")
 }
 
 func connect(t testing.TB, opts ...ydb.Option) *ydb.Driver {

--- a/tests/slo/go.mod
+++ b/tests/slo/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/syndtr/goleveldb v1.0.0 // indirect
 	github.com/yandex-cloud/go-genproto v0.0.0-20211115083454-9ca41db5ed9e // indirect
-	github.com/ydb-platform/ydb-go-genproto v0.0.0-20260311095541-ebbf792c1180 // indirect
+	github.com/ydb-platform/ydb-go-genproto v0.0.0-20260428144813-1c07baab7f7b // indirect
 	github.com/ydb-platform/ydb-go-yc v0.12.1 // indirect
 	github.com/ydb-platform/ydb-go-yc-metadata v0.6.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/tests/slo/go.sum
+++ b/tests/slo/go.sum
@@ -3522,8 +3522,8 @@ github.com/ydb-platform/gorm-driver v0.1.3 h1:uewwScbRuCixNPC0LF7gDKvWcB13/iLj76
 github.com/ydb-platform/gorm-driver v0.1.3/go.mod h1:49cSoG5J18muQTiKj4StL2dHs1/dB94OitnHOvetK24=
 github.com/ydb-platform/xorm v0.0.3 h1:MXk42lANB6r/MMLg/XdJfyXJycGUDlCeLiMlLGDKVPw=
 github.com/ydb-platform/xorm v0.0.3/go.mod h1:hFsU7EUF0o3S+l5c0eyP2yPVjJ0d4gsFdqCsyazzwBc=
-github.com/ydb-platform/ydb-go-genproto v0.0.0-20260311095541-ebbf792c1180 h1:avIdi8eGXjKbn1WLokNR1Ofnz1k8t7tJ88YQLD/iCi8=
-github.com/ydb-platform/ydb-go-genproto v0.0.0-20260311095541-ebbf792c1180/go.mod h1:Er+FePu1dNUieD+XTMDduGpQuCPssK5Q4BjF+IIXJ3I=
+github.com/ydb-platform/ydb-go-genproto v0.0.0-20260428144813-1c07baab7f7b h1:xeiobG1riqe6dTMZuTcOvwOY0BbFidSk3gRLyVeLfJA=
+github.com/ydb-platform/ydb-go-genproto v0.0.0-20260428144813-1c07baab7f7b/go.mod h1:Er+FePu1dNUieD+XTMDduGpQuCPssK5Q4BjF+IIXJ3I=
 github.com/ydb-platform/ydb-go-sdk-auth-environ v0.3.0 h1:JxSvw+Moont8qCmibP2MjSEIHfkWJLkw0fHZemAk+d0=
 github.com/ydb-platform/ydb-go-sdk-auth-environ v0.3.0/go.mod h1:YzCPoNrTbrXZg9bO2YkbjI6eQLkaRIE9Bq8ponu0g8A=
 github.com/ydb-platform/ydb-go-yc v0.12.1 h1:qw3Fa+T81+Kpu5Io2vYHJOwcrYrVjgJlT6t/0dOXJrA=

--- a/topic/topicoptions/topicoptions.go
+++ b/topic/topicoptions/topicoptions.go
@@ -31,6 +31,26 @@ func (mode withMeteringMode) ApplyAlterOption(req *rawtopic.AlterTopicRequest) {
 	(*topictypes.MeteringMode)(&mode).ToRaw(&req.SetMeteringMode)
 }
 
+type withMetricsLevel uint32
+
+func (level withMetricsLevel) ApplyCreateOption(request *rawtopic.CreateTopicRequest) {
+	request.MetricsLevel.HasValue = true
+	request.MetricsLevel.Value = uint32(level)
+}
+
+func (level withMetricsLevel) ApplyAlterOption(req *rawtopic.AlterTopicRequest) {
+	req.SetMetricsLevel.HasValue = true
+	req.SetMetricsLevel.Value = uint32(level)
+	req.ResetMetricsLevel = false
+}
+
+type withResetMetricsLevel struct{}
+
+func (withResetMetricsLevel) ApplyAlterOption(req *rawtopic.AlterTopicRequest) {
+	req.ResetMetricsLevel = true
+	req.SetMetricsLevel.HasValue = false
+}
+
 type withMinActivePartitions int64
 
 func (minActivePartitions withMinActivePartitions) ApplyCreateOption(request *rawtopic.CreateTopicRequest) {

--- a/topic/topicoptions/topicoptions_alter.go
+++ b/topic/topicoptions/topicoptions_alter.go
@@ -162,6 +162,16 @@ func AlterWithMaxActivePartitions(maxActivePartitions int64) AlterOption {
 	return alterWithMaxActivePartitions(maxActivePartitions)
 }
 
+// AlterWithSetMetricsLevel sets the metrics level for the topic.
+func AlterWithSetMetricsLevel(level uint32) AlterOption {
+	return withMetricsLevel(level)
+}
+
+// AlterWithResetMetricsLevel resets the topic metrics level back to the database default.
+func AlterWithResetMetricsLevel() AlterOption {
+	return withResetMetricsLevel{}
+}
+
 // AlterWithAutoPartitioningStrategy change auto partitioning strategy for the topic
 func AlterWithAutoPartitioningStrategy(strategy topictypes.AutoPartitioningStrategy) AlterOption {
 	return withAutoPartitioningStrategy(strategy)

--- a/topic/topicoptions/topicoptions_create.go
+++ b/topic/topicoptions/topicoptions_create.go
@@ -78,6 +78,12 @@ func CreateWithMaxActivePartitions(count int64) CreateOption {
 	return withMaxActivePartitions(count)
 }
 
+// CreateWithMetricsLevel sets the metrics level for the topic.
+// If this option is not provided, the database default is used.
+func CreateWithMetricsLevel(level uint32) CreateOption {
+	return withMetricsLevel(level)
+}
+
 // CreateWithAutoPartitioningSettings set auto partitioning settings for the topic
 func CreateWithAutoPartitioningSettings(settings topictypes.AutoPartitioningSettings) CreateOption {
 	return withAutoPartitioningSettings(settings)

--- a/topic/topicoptions/topicoptions_test.go
+++ b/topic/topicoptions/topicoptions_test.go
@@ -5,6 +5,9 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawtopic"
 )
 
 func TestEqualAlterOptions(t *testing.T) {
@@ -73,6 +76,41 @@ func TestEqualAlterOptions(t *testing.T) {
 			assert.ElementsMatch(t, tt.lhs, tt.rhs) // compare slices with ignore ordering
 		})
 	}
+}
+
+func TestCreateWithMetricsLevel(t *testing.T) {
+	req := &rawtopic.CreateTopicRequest{}
+	CreateWithMetricsLevel(3).ApplyCreateOption(req)
+
+	require.True(t, req.MetricsLevel.HasValue)
+	require.Equal(t, uint32(3), req.MetricsLevel.Value)
+
+	proto := req.ToProto()
+	require.Equal(t, uint32(3), proto.GetMetricsLevel())
+}
+
+func TestAlterWithSetMetricsLevel(t *testing.T) {
+	req := &rawtopic.AlterTopicRequest{}
+	AlterWithSetMetricsLevel(2).ApplyAlterOption(req)
+
+	require.True(t, req.SetMetricsLevel.HasValue)
+	require.Equal(t, uint32(2), req.SetMetricsLevel.Value)
+	require.False(t, req.ResetMetricsLevel)
+
+	proto := req.ToProto()
+	require.Equal(t, uint32(2), proto.GetSetMetricsLevel())
+}
+
+func TestAlterWithResetMetricsLevel(t *testing.T) {
+	req := &rawtopic.AlterTopicRequest{}
+	AlterWithSetMetricsLevel(5).ApplyAlterOption(req)
+	AlterWithResetMetricsLevel().ApplyAlterOption(req)
+
+	require.False(t, req.SetMetricsLevel.HasValue)
+	require.True(t, req.ResetMetricsLevel)
+
+	proto := req.ToProto()
+	require.NotNil(t, proto.GetResetMetricsLevel())
 }
 
 func TestEqualCreateOptions(t *testing.T) {

--- a/topic/topictypes/topictypes.go
+++ b/topic/topictypes/topictypes.go
@@ -204,6 +204,10 @@ type TopicDescription struct {
 	Attributes                        map[string]string
 	Consumers                         []Consumer
 	MeteringMode                      MeteringMode
+
+	// MetricsLevel reports the metrics level configured for the topic.
+	// A nil value means the topic uses the database default.
+	MetricsLevel *uint32
 }
 
 // FromRaw convert from public format to internal. Used internally only.
@@ -239,6 +243,13 @@ func (d *TopicDescription) FromRaw(raw *rawtopic.DescribeTopicResult) {
 	}
 
 	d.MeteringMode.FromRaw(raw.MeteringMode)
+
+	if raw.MetricsLevel.HasValue {
+		level := raw.MetricsLevel.Value
+		d.MetricsLevel = &level
+	} else {
+		d.MetricsLevel = nil
+	}
 }
 
 // PartitionInfo contains info about partition.


### PR DESCRIPTION
## Summary
- Add `topicoptions.CreateWithMetricsLevel`, `AlterWithSetMetricsLevel`, `AlterWithResetMetricsLevel` and `topictypes.TopicDescription.MetricsLevel` (`*uint32`, `nil` ⇒ database default) so SDK users can configure the topic `metrics_level` documented at https://github.com/ydb-platform/ydb-api-protos/blob/master/protos/ydb_topic.proto.
- Plumb the field through `internal/grpcwrapper/rawtopic` for create/alter/describe (the alter side maps to the `set_metrics_level` / `reset_metrics_level` proto oneof) and introduce `rawoptional.Uint32` to mirror the existing optional helpers.
- Bump `ydb-go-genproto` to a revision that exposes the proto fields (older revision did not contain `metrics_level`).

## Test plan
- [x] `go build ./...`
- [x] `go test ./topic/... ./internal/grpcwrapper/...` — unit tests pass (incl. new `TestCreateWithMetricsLevel`, `TestAlterWithSetMetricsLevel`, `TestAlterWithResetMetricsLevel`)
- [x] `go test -tags integration -c ./tests/integration/` — integration test binary builds; new `TestTopicMetricsLevel` covers create → describe, alter set → describe, alter reset → describe and is gated by `YDB_VERSION` so it skips on YDB versions older than `25.4` (and runs on `latest`/`edge`/`nightly`).
- [x] `golangci-lint run` on affected packages and `--build-tags=integration` on `tests/integration/` — no new issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)