### PR TITLE
fix: prevent TopicListener panic on shutdown race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed panic and data race in `TopicListener` when partition workers were closed while the read stream still delivered messages: `internal/xsync.UnboundedChan` no longer closes its signal channel on shutdown, stop the read loop before closing partition workers, and ignore routed messages after listener shutdown starts
+
 ## v3.139.4
 * Fixed query result stream draining when `Close` is called with a fresh context after `NextResultSet` used a cancelled per-call context while `ExecStats` arrive in later stream parts ([#2187](https://github.com/ydb-platform/ydb-go-sdk/issues/2187))
 * Fixed query result `Close` to succeed when the execute stream is already closed (for example after full iteration or per-call context cancellation), matching `database/sql` expectations and table result close behavior ([#2187](https://github.com/ydb-platform/ydb-go-sdk/issues/2187))

--- a/internal/topic/topiclistenerinternal/partition_worker.go
+++ b/internal/topic/topiclistenerinternal/partition_worker.go
@@ -172,10 +172,11 @@ func (w *PartitionWorker) receiveMessagesLoop(ctx context.Context) {
 		if !ok {
 			// Queue was closed - this is a normal stop reason during shutdown
 			reason := xerrors.WithStackTrace(xerrors.Wrap(fmt.Errorf(
-				"partition worker message queue closed: topic=%s, partition=%d, partitionSession=%d",
+				"partition worker message queue closed: topic=%s, partition=%d, partitionSession=%d: %w",
 				w.partitionSession.Topic,
 				w.partitionSession.PartitionID,
 				w.partitionSessionID,
+				errPartitionQueueClosed,
 			)))
 			w.onStopped(w.partitionSessionID, reason)
 

--- a/internal/topic/topiclistenerinternal/partition_worker_test.go
+++ b/internal/topic/topiclistenerinternal/partition_worker_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawtopic/rawtopicreader"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawydb"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/topic/topicreadercommon"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
 	xtest "github.com/ydb-platform/ydb-go-sdk/v3/pkg/xtest"
 	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
 )
@@ -582,14 +583,13 @@ func TestPartitionWorkerImpl_QueueClosureHandling(t *testing.T) {
 	errPtr := stoppedErr.Load()
 	require.NotNil(t, errPtr)
 	if *errPtr != nil {
-		// When Close() is called, there's a race between queue closure and context cancellation
-		// Both are valid shutdown reasons, so accept either one
-		errorMsg := (*errPtr).Error()
-		isQueueClosed := strings.Contains(errorMsg, "partition worker message queue closed")
-		isContextCanceled := strings.Contains(errorMsg, "partition worker message queue context error") &&
-			strings.Contains(errorMsg, "context canceled")
+		// When Close() is called, there's a race between queue closure and context cancellation.
+		// Both are valid shutdown reasons, so accept either one.
+		isQueueClosed := xerrors.Is(*errPtr, errPartitionQueueClosed)
+		isContextCanceled := strings.Contains((*errPtr).Error(), "partition worker message queue context error") &&
+			strings.Contains((*errPtr).Error(), "context canceled")
 		require.True(t, isQueueClosed || isContextCanceled,
-			"Expected either queue closure or context cancellation error, got: %s", errorMsg)
+			"Expected either queue closure or context cancellation error, got: %v", *errPtr)
 	}
 }
 

--- a/internal/topic/topiclistenerinternal/stream_listener.go
+++ b/internal/topic/topiclistenerinternal/stream_listener.go
@@ -130,20 +130,21 @@ func (l *streamListener) Close(ctx context.Context, reason error) error {
 		}
 	})
 
-	// Close workers without holding the mutex
-	for _, worker := range workers {
-		if err := worker.Close(ctx, reason); err != nil {
-			resErrors = append(resErrors, err)
-		}
-	}
-
-	// should be first because background wait stop of steams
+	// Stop the read stream and background workers before closing partition workers,
+	// so receiveMessagesLoop does not route messages into shutting-down workers.
 	if l.stream != nil {
 		l.streamClose(reason)
 	}
 
 	if err := l.background.Close(ctx, reason); err != nil {
 		resErrors = append(resErrors, err)
+	}
+
+	// Close workers without holding the mutex
+	for _, worker := range workers {
+		if err := worker.Close(ctx, reason); err != nil {
+			resErrors = append(resErrors, err)
+		}
 	}
 
 	if err := l.syncCommitter.Close(ctx, reason); err != nil {
@@ -364,6 +365,10 @@ func (l *streamListener) receiveMessagesLoop(ctx context.Context) {
 
 // routeMessage routes messages to appropriate handlers/workers
 func (l *streamListener) routeMessage(ctx context.Context, mess rawtopicreader.ServerMessage) error {
+	if l.closing.Load() {
+		return nil
+	}
+
 	switch m := mess.(type) {
 	case *rawtopicreader.StartPartitionSessionRequest:
 		return l.handleStartPartition(ctx, m)

--- a/internal/xsync/unbounded_chan.go
+++ b/internal/xsync/unbounded_chan.go
@@ -9,7 +9,11 @@ import (
 // UnboundedChan is a generic unbounded channel implementation that supports
 // message merging and concurrent access.
 type UnboundedChan[T any] struct {
-	signal empty.Chan // buffered channel with capacity 1
+	// signal is a capacity-1 wakeup for Receive only; it is never closed.
+	// Closing it would race with Send/SendWithMerge after Close (e.g. TopicListener
+	// shutdown) and panic with "send on closed channel", because notify sends
+	// outside the buffer mutex. Shutdown is signaled via closed and notify().
+	signal empty.Chan
 
 	mutex  Mutex
 	buffer []T
@@ -24,19 +28,26 @@ func NewUnboundedChan[T any]() *UnboundedChan[T] {
 	}
 }
 
+func (c *UnboundedChan[T]) notify() {
+	select {
+	case c.signal <- empty.Struct{}:
+	default:
+	}
+}
+
 // Send adds a message to the channel.
 // The operation is non-blocking and thread-safe.
 func (c *UnboundedChan[T]) Send(msg T) {
+	var notify bool
 	c.mutex.WithLock(func() {
 		if !c.closed {
 			c.buffer = append(c.buffer, msg)
+			notify = true
 		}
 	})
 
-	// Signal that something happened
-	select {
-	case c.signal <- struct{}{}:
-	default: // channel already has signal, skip
+	if notify {
+		c.notify()
 	}
 }
 
@@ -44,24 +55,27 @@ func (c *UnboundedChan[T]) Send(msg T) {
 // If mergeFunc returns true, the new message will be merged with the last message.
 // The merge operation is atomic and preserves message order.
 func (c *UnboundedChan[T]) SendWithMerge(msg T, mergeFunc func(last, new T) (T, bool)) {
+	var notify bool
 	c.mutex.WithLock(func() {
-		if !c.closed {
-			if len(c.buffer) > 0 {
-				if merged, shouldMerge := mergeFunc(c.buffer[len(c.buffer)-1], msg); shouldMerge {
-					c.buffer[len(c.buffer)-1] = merged
-
-					return
-				}
-			}
-
-			c.buffer = append(c.buffer, msg)
+		if c.closed {
+			return
 		}
+
+		if len(c.buffer) > 0 {
+			if merged, shouldMerge := mergeFunc(c.buffer[len(c.buffer)-1], msg); shouldMerge {
+				c.buffer[len(c.buffer)-1] = merged
+				notify = true
+
+				return
+			}
+		}
+
+		c.buffer = append(c.buffer, msg)
+		notify = true
 	})
 
-	// Signal that something happened
-	select {
-	case c.signal <- empty.Struct{}:
-	default: // channel already has signal, skip
+	if notify {
+		c.notify()
 	}
 }
 
@@ -117,5 +131,5 @@ func (c *UnboundedChan[T]) Close() {
 		return
 	}
 
-	close(c.signal)
+	c.notify()
 }

--- a/internal/xsync/unbounded_chan_test.go
+++ b/internal/xsync/unbounded_chan_test.go
@@ -3,6 +3,7 @@ package xsync
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -112,6 +113,34 @@ func TestUnboundedChanClose(t *testing.T) {
 	}
 }
 
+func TestUnboundedChanSendAfterClose(t *testing.T) {
+	ch := NewUnboundedChan[int]()
+
+	ch.Close()
+
+	// Must not panic when sending after close (e.g. race with partition worker shutdown).
+	ch.Send(1)
+	ch.SendWithMerge(2, func(last, new int) (int, bool) { return last + new, true })
+}
+
+func TestUnboundedChanSendCloseConcurrent(t *testing.T) {
+	ch := NewUnboundedChan[int]()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for range 10000 {
+			ch.Send(1)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		ch.Close()
+	}()
+	wg.Wait()
+}
+
 func TestUnboundedChanReceiveAfterClose(t *testing.T) {
 	ctx := context.Background()
 	ch := NewUnboundedChan[int]()
@@ -145,16 +174,15 @@ func TestUnboundedChanMultipleMessages(t *testing.T) {
 	}
 }
 
-func TestUnboundedChanSignalChannelBehavior(t *testing.T) {
+func TestUnboundedChanManyMessagesInOrder(t *testing.T) {
 	ctx := context.Background()
 	ch := NewUnboundedChan[int]()
 
-	// Send multiple messages rapidly
 	for i := range 100 {
 		ch.Send(i)
 	}
 
-	// Should receive all messages despite signal channel being buffered
+	// Should receive all messages in order
 	for i := range 100 {
 		msg, ok, err := ch.Receive(ctx)
 		if err != nil || !ok || msg != i {


### PR DESCRIPTION
## Summary

- Fixed `panic: send on closed channel` in `internal/xsync.UnboundedChan`: the wakeup channel is no longer closed on `Close`; shutdown uses `closed` + `notify()` instead.
- Fixed `TopicListener` shutdown order: stop the read stream and background loop before closing partition workers, and ignore routed messages after listener shutdown starts.
- Wrapped partition worker queue-closure error with `errPartitionQueueClosed` so `xerrors.Is` works while keeping topic/partition/session details in the message.

## Test plan

- [x] `go test ./internal/xsync/... -race`
- [x] `go test ./internal/topic/topiclistenerinternal/... -race`


Made with [Cursor](https://cursor.com)