### PR TITLE
Add .agents/ workspace for AI coding agents

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -6,7 +6,7 @@ Canonical home for AI coding agent assets. Human and agent entry point remains [
 
 | Directory | Purpose | Load when |
 |-----------|---------|-----------|
-| [`context/`](context/) | Project knowledge — focus, progress, architecture, tooling | Every session: `activeContext.md`; others on demand |
+| [`context/`](context/) | Project knowledge — architecture, tooling, progress | Stable files on demand; `activeContext.md` is branch-only (see its header) |
 | [`rules/`](rules/) | Coding standards and workflow | On demand via `AGENTS.md` router |
 
 `skills/` and `prompts/` may be added later when project-specific agent workflows are needed (see [ydb-rs-sdk `.agents/`](https://github.com/ydb-platform/ydb-rs-sdk/tree/feat/memory-bank-for-agents/.agents) and [ydb-pg-extension `.agents/`](https://github.com/ydb-platform/ydb-pg-extension/pull/257)).

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,0 +1,12 @@
+# Agent workspace — ydb-go-sdk
+
+Canonical home for AI coding agent assets. Human and agent entry point remains [`AGENTS.md`](../AGENTS.md) in the repo root.
+
+## Layout
+
+| Directory | Purpose | Load when |
+|-----------|---------|-----------|
+| [`context/`](context/) | Project knowledge — focus, progress, architecture, tooling | Every session: `activeContext.md`; others on demand |
+| [`rules/`](rules/) | Coding standards and workflow | On demand via `AGENTS.md` router |
+
+`skills/` and `prompts/` may be added later when project-specific agent workflows are needed (see [ydb-rs-sdk `.agents/`](https://github.com/ydb-platform/ydb-rs-sdk/tree/feat/memory-bank-for-agents/.agents) and [ydb-pg-extension `.agents/`](https://github.com/ydb-platform/ydb-pg-extension/pull/257)).

--- a/.agents/context/README.md
+++ b/.agents/context/README.md
@@ -14,8 +14,8 @@ ydb-go-sdk/
 │   ├── README.md                   layout of context / rules
 │   ├── context/                    ← you are here
 │   │   ├── README.md               entry point, reading/update strategy
-│   │   ├── activeContext.md        volatile: current focus, decisions, next steps
-│   │   ├── progress.md             volatile: status, milestones, open work
+│   │   ├── activeContext.md        branch-only scratch pad (policy placeholder on master)
+│   │   ├── progress.md             evolving: completed milestones
 │   │   ├── projectBrief.md         stable: scope, goals, constraints
 │   │   ├── productContext.md       stable: users, API surface, feature parity
 │   │   ├── systemPatterns.md       evolving: package layout, Do/DoTx, retry, pools
@@ -36,8 +36,8 @@ ydb-go-sdk/
 
 | File | Stability | Read when |
 |------|-----------|-----------|
-| [`activeContext.md`](activeContext.md) | **Volatile** | **Every session** — current focus (may conflict across parallel PRs; see file header) |
-| [`progress.md`](progress.md) | **Volatile** | Resuming work, closing a PR, status checks |
+| [`activeContext.md`](activeContext.md) | **Branch-only** | Policy placeholder on `master`; optional scratch pad on a feature branch — **never merge edits** |
+| [`progress.md`](progress.md) | Evolving | Completed milestones — update in the PR that delivers the work |
 | [`systemPatterns.md`](systemPatterns.md) | Evolving | Architecture, new modules, Do/DoTx patterns |
 | [`techContext.md`](techContext.md) | Evolving | CI, Go versions, local YDB, lint/test commands |
 | [`productContext.md`](productContext.md) | Stable | Public API, users, feature parity |
@@ -46,8 +46,7 @@ ydb-go-sdk/
 ## Reading strategy
 
 ```
-Every session:  activeContext.md
-If needed:      one stable file matching the task
+If needed:      one stable file matching the task (see table)
 Code patterns:  .agents/rules/ via AGENTS.md router (on demand)
 Full review:    all files (on "update memory bank" or major onboarding)
 ```
@@ -56,7 +55,7 @@ Avoid loading all six core files at session start — it wastes context tokens w
 
 ## Update triggers
 
-1. Feature/fix ready for PR → `activeContext.md` + `progress.md`
+1. Feature/fix ready for PR → `progress.md` (if milestone); revert `activeContext.md` to placeholder
 2. Architecture or CI changed → `systemPatterns.md` or `techContext.md`
 3. Scope changed → `projectBrief.md` or `productContext.md`
 4. User says **"update memory bank"** → review every core file

--- a/.agents/context/README.md
+++ b/.agents/context/README.md
@@ -1,0 +1,69 @@
+# Project context — ydb-go-sdk
+
+Structured, version-controlled context for AI coding agents.
+
+`AGENTS.md` stays minimal (operational router). This directory holds detailed context — read **selectively**, not all at once.
+
+> Paths in context files may lag behind refactors — verify with Glob/Grep before acting on specific filenames.
+
+## Knowledge tree
+
+```
+ydb-go-sdk/
+├── .agents/                        ← agent workspace (you are in context/)
+│   ├── README.md                   layout of context / rules
+│   ├── context/                    ← you are here
+│   │   ├── README.md               entry point, reading/update strategy
+│   │   ├── activeContext.md        volatile: current focus, decisions, next steps
+│   │   ├── progress.md             volatile: status, milestones, open work
+│   │   ├── projectBrief.md         stable: scope, goals, constraints
+│   │   ├── productContext.md       stable: users, API surface, feature parity
+│   │   ├── systemPatterns.md       evolving: package layout, Do/DoTx, retry, pools
+│   │   └── techContext.md          evolving: CI, Go versions, local YDB, build commands
+│   └── rules/                      coding standards (on demand via AGENTS.md)
+│
+├── AGENTS.md                       lean agent router (read first)
+├── CLAUDE.md                       tool entry point → AGENTS.md
+├── driver.go, sql.go               root package entry points
+├── table/, query/, scheme/, topic/ public service clients
+├── internal/                       implementations (not stable API)
+├── tests/integration/              integration tests (build tag: integration)
+├── examples/                       runnable examples (separate go.mod)
+└── .devcontainer/                  dev environment + local YDB sidecar
+```
+
+## Core files
+
+| File | Stability | Read when |
+|------|-----------|-----------|
+| [`activeContext.md`](activeContext.md) | **Volatile** | **Every session** — current focus, decisions, next steps |
+| [`progress.md`](progress.md) | **Volatile** | Resuming work, closing a PR, status checks |
+| [`systemPatterns.md`](systemPatterns.md) | Evolving | Architecture, new modules, Do/DoTx patterns |
+| [`techContext.md`](techContext.md) | Evolving | CI, Go versions, local YDB, lint/test commands |
+| [`productContext.md`](productContext.md) | Stable | Public API, users, feature parity |
+| [`projectBrief.md`](projectBrief.md) | Stable | Scope, goals, constraints |
+
+## Reading strategy
+
+```
+Every session:  activeContext.md
+If needed:      one stable file matching the task
+Code patterns:  .agents/rules/ via AGENTS.md router (on demand)
+Full review:    all files (on "update memory bank" or major onboarding)
+```
+
+Avoid loading all six core files at session start — it wastes context tokens without improving outcomes.
+
+## Update triggers
+
+1. Feature/fix ready for PR → `activeContext.md` + `progress.md`
+2. Architecture or CI changed → `systemPatterns.md` or `techContext.md`
+3. Scope changed → `projectBrief.md` or `productContext.md`
+4. User says **"update memory bank"** → review every core file
+
+## What not to store
+
+- Secrets, tokens, credentials
+- Large generated artifacts (link to pkg.go.dev instead)
+- Chat transcripts
+- Duplication of `AGENTS.md` rules — link instead

--- a/.agents/context/README.md
+++ b/.agents/context/README.md
@@ -36,7 +36,7 @@ ydb-go-sdk/
 
 | File | Stability | Read when |
 |------|-----------|-----------|
-| [`activeContext.md`](activeContext.md) | **Volatile** | **Every session** — current focus, decisions, next steps |
+| [`activeContext.md`](activeContext.md) | **Volatile** | **Every session** — current focus (may conflict across parallel PRs; see file header) |
 | [`progress.md`](progress.md) | **Volatile** | Resuming work, closing a PR, status checks |
 | [`systemPatterns.md`](systemPatterns.md) | Evolving | Architecture, new modules, Do/DoTx patterns |
 | [`techContext.md`](techContext.md) | Evolving | CI, Go versions, local YDB, lint/test commands |

--- a/.agents/context/activeContext.md
+++ b/.agents/context/activeContext.md
@@ -1,28 +1,21 @@
 # Active Context
 
-> **Volatile file** — update at the end of a work session or before closing a PR.
->
-> **Merge conflicts:** with many parallel PRs this file conflicts often. On conflict, keep the union of recent decisions or reset to a short generic focus — do not block the feature PR on agent housekeeping.
+> **Branch-only scratch pad** — not merge material for `main`/`master`.
+
+## Policy
+
+- **Green master:** `main`/`master` holds only completed, merged work. Half-done tasks do not land in the default branch.
+- **This file must have no diff at PR merge time.** While iterating on a feature branch you may edit it freely; **before merge, revert this file** so the PR does not change it relative to the target branch.
+- On `main`/`master` this file stays exactly this placeholder — no session notes, no current-PR focus, no “recent changes”.
 
 ## Current focus
 
-_No active task recorded._ Check open PRs and GitHub Issues for ongoing work.
+_(empty on master — use only on a local/feature branch; do not commit branch notes here when opening a merge-ready PR)_
 
-## Recent changes
+## Where to put durable knowledge
 
-- `.agents/` workspace added for AI coding agents (see `systemPatterns.md` for driver architecture).
-
-## Open questions
-
-- Whether to add nested `AGENTS.md` per major package as the SDK grows.
-- Whether to add `.agents/skills/` shared across YDB SDK repos.
-
-## Next steps
-
-- Update this file when starting or finishing significant work.
-
-## Working conventions (reminder)
-
-- Read this file every session; other context files only when relevant.
-- Coding rules: `AGENTS.md` → `.agents/rules/` (on demand).
-- Run `golangci-lint run ./...` and `go test -race ./...` before requesting review.
+| What | Where |
+|------|-------|
+| Architecture, tooling, scope | stable files: `systemPatterns.md`, `techContext.md`, `projectBrief.md`, … |
+| Completed milestones | `progress.md` — update in the same PR that delivers the work |
+| Coding rules | `AGENTS.md` → `.agents/rules/` |

--- a/.agents/context/activeContext.md
+++ b/.agents/context/activeContext.md
@@ -1,0 +1,29 @@
+# Active Context
+
+> **Volatile file** — update after every significant work session.
+
+## Current focus
+
+Introduce `.agents/` workspace for AI coding agents — aligned with [ydb-rs-sdk #430](https://github.com/ydb-platform/ydb-rs-sdk/pull/430) and [ydb-pg-extension #257](https://github.com/ydb-platform/ydb-pg-extension/pull/257).
+
+## Recent changes
+
+- Added `.agents/context/` for project knowledge and `.agents/rules/` for coding standards.
+- Slimmed `AGENTS.md` to a lean router; migrated changelog, lint, and dependency rules to `.agents/rules/`.
+
+## Open questions
+
+- Whether to add nested `AGENTS.md` per major package (`table/`, `query/`, …) as the SDK grows.
+- Whether to add `.agents/skills/` (e.g. PR review) shared across YDB SDK repos via `ai-dev-kit`.
+
+## Next steps
+
+- Keep this file and `progress.md` updated as features land.
+- Add rules to `AGENTS.md` only after repeated agent mistakes (incremental, not upfront).
+
+## Working conventions (reminder)
+
+- Read `activeContext.md` every session; other context files only when relevant.
+- Coding rules: `AGENTS.md` → `.agents/rules/` (on demand).
+- Update this file and `progress.md` before closing a PR.
+- Run `golangci-lint run ./...` and `go test -race ./...` before requesting review.

--- a/.agents/context/activeContext.md
+++ b/.agents/context/activeContext.md
@@ -1,29 +1,28 @@
 # Active Context
 
-> **Volatile file** — update after every significant work session.
+> **Volatile file** — update at the end of a work session or before closing a PR.
+>
+> **Merge conflicts:** with many parallel PRs this file conflicts often. On conflict, keep the union of recent decisions or reset to a short generic focus — do not block the feature PR on agent housekeeping.
 
 ## Current focus
 
-Introduce `.agents/` workspace for AI coding agents — aligned with [ydb-rs-sdk #430](https://github.com/ydb-platform/ydb-rs-sdk/pull/430) and [ydb-pg-extension #257](https://github.com/ydb-platform/ydb-pg-extension/pull/257).
+_No active task recorded._ Check open PRs and GitHub Issues for ongoing work.
 
 ## Recent changes
 
-- Added `.agents/context/` for project knowledge and `.agents/rules/` for coding standards.
-- Slimmed `AGENTS.md` to a lean router; migrated changelog, lint, and dependency rules to `.agents/rules/`.
+- `.agents/` workspace added for AI coding agents (see `systemPatterns.md` for driver architecture).
 
 ## Open questions
 
-- Whether to add nested `AGENTS.md` per major package (`table/`, `query/`, …) as the SDK grows.
-- Whether to add `.agents/skills/` (e.g. PR review) shared across YDB SDK repos via `ai-dev-kit`.
+- Whether to add nested `AGENTS.md` per major package as the SDK grows.
+- Whether to add `.agents/skills/` shared across YDB SDK repos.
 
 ## Next steps
 
-- Keep this file and `progress.md` updated as features land.
-- Add rules to `AGENTS.md` only after repeated agent mistakes (incremental, not upfront).
+- Update this file when starting or finishing significant work.
 
 ## Working conventions (reminder)
 
-- Read `activeContext.md` every session; other context files only when relevant.
+- Read this file every session; other context files only when relevant.
 - Coding rules: `AGENTS.md` → `.agents/rules/` (on demand).
-- Update this file and `progress.md` before closing a PR.
 - Run `golangci-lint run ./...` and `go test -race ./...` before requesting review.

--- a/.agents/context/productContext.md
+++ b/.agents/context/productContext.md
@@ -2,9 +2,11 @@
 
 ## Users
 
-- Go application developers connecting to YDB for OLTP, streaming (topics), and metadata (scheme).
+- Go application developers connecting to YDB for OLTP and OLAP workloads, streaming (topics), and metadata (scheme).
 - Maintainers integrating Go into YDB platform services.
 - Contributors extending SDK coverage to match Java, Rust, and other language SDKs.
+
+YDB targets OLTP primarily; the SDK also supports OLAP-oriented scenarios (analytics queries, column tables) where the server exposes them — see [README.md](../../README.md).
 
 ## Problems solved
 
@@ -15,9 +17,13 @@
 | Browse database directory / schema | `db.Scheme()` |
 | Produce/consume topic messages | `db.Topic()` — reader/writer/listener APIs |
 | Distributed locks / semaphores | `db.Coordination()` |
+| Run YQL scripts (legacy service) | `db.Scripting()` |
+| Long-running operations | `db.Operation()` (experimental) |
+| Request rate limiting / quotas | `db.Ratelimiter()` |
+| Cluster endpoint discovery | `db.Discovery()` + balancers |
 | Auth (static token, metadata, OAuth) | `credentials` options on `ydb.Open` |
-| Multi-node clusters | Discovery + balancers (`RandomChoice`, `PreferNearestDC`, …) |
-| Observability | `trace/` callbacks + `log/`, `metrics/`, `spans/` adapters |
+| Multi-node clusters | `config.WithBalancer(balancers.*)` |
+| Observability | `trace/` + `log/`, `metrics/`, `spans/` adapters |
 
 ## Developer experience goals
 

--- a/.agents/context/productContext.md
+++ b/.agents/context/productContext.md
@@ -1,0 +1,39 @@
+# Product Context
+
+## Users
+
+- Go application developers connecting to YDB for OLTP, streaming (topics), and metadata (scheme).
+- Maintainers integrating Go into YDB platform services.
+- Contributors extending SDK coverage to match Java, Rust, and other language SDKs.
+
+## Problems solved
+
+| Need | SDK surface |
+|------|-------------|
+| Run YQL queries and transactions | `db.Query().Do` / `DoTx`, `db.Table().Do` / `DoTx` |
+| `database/sql` compatibility | `sql.Open("ydb", dsn)` via `sql.go` |
+| Browse database directory / schema | `db.Scheme()` |
+| Produce/consume topic messages | `db.Topic()` — reader/writer/listener APIs |
+| Distributed locks / semaphores | `db.Coordination()` |
+| Auth (static token, metadata, OAuth) | `credentials` options on `ydb.Open` |
+| Multi-node clusters | Discovery + balancers (`RandomChoice`, `PreferNearestDC`, …) |
+| Observability | `trace/` callbacks + `log/`, `metrics/`, `spans/` adapters |
+
+## Developer experience goals
+
+- **DSN** as primary entry: `grpc://host:port/database` or `grpcs://...`.
+- **Automatic retries** in `Do`/`DoTx` on retriable errors (use `WithIdempotent()` for safe retries).
+- **Examples** in `examples/` for common patterns; integration tests as living documentation.
+- **Devcontainer** with local YDB pre-wired (`.devcontainer/`).
+
+## API stability
+
+- Published as `github.com/ydb-platform/ydb-go-sdk/v3` on pkg.go.dev.
+- `// Experimental`, `// Deprecated`, `// Internals` markers per `VERSIONING.md`.
+- Breaking changes tracked by `breaking.yml` (`gorelease`); label `broken changes` to skip gate.
+
+## Related resources
+
+- [YDB documentation](https://ydb.tech/docs) — server-side concepts, YQL
+- [ydb-rs-sdk](https://github.com/ydb-platform/ydb-rs-sdk) — Rust SDK for cross-language parity
+- [ydb-java-sdk](https://github.com/ydb-platform/ydb-java-sdk) — Java SDK reference

--- a/.agents/context/progress.md
+++ b/.agents/context/progress.md
@@ -9,10 +9,11 @@
 - **Scheme API**: directory listing, path operations.
 - **Topics**: reader/writer/listener/multiwriter.
 - **Coordination**: distributed semaphores.
+- **Scripting / Ratelimiter / Operation**: exposed on `Driver` (see `systemPatterns.md`).
 - **Discovery** + balancers (`RandomChoice`, `PreferNearestDC`, …).
 - **database/sql** driver via `sql.Open("ydb", ...)`.
 - **Auth**: static tokens, metadata, OAuth credentials.
-- **TLS**: custom CA via `ydb_certs/`, rustls-compatible stack.
+- **TLS**: custom CA via `ydb_certs/`.
 - **Observability**: trace callbacks, log/metrics/spans adapters.
 
 ## CI status
@@ -25,14 +26,13 @@
 
 - Check GitHub Issues for active bugs and feature requests.
 - Cross-SDK parity with Java/Rust tracked issue-by-issue.
-- `CONTRIBUTING.md` mentions `-tags fast` for unit tests — tag does not exist; default `go test ./...` already excludes integration.
 
 ## Milestones
 
 | Date | Milestone |
 |------|-----------|
-| 2026-06 | `.agents/` workspace for AI agents (aligned with ydb-rs-sdk #430) |
-| ongoing | Trace handler hardening, fuzz tests ([#2194](https://github.com/ydb-platform/ydb-go-sdk/pull/2194)) |
+| 2026-06 | `.agents/` workspace for AI agents |
+| ongoing | Trace handler hardening ([#2194](https://github.com/ydb-platform/ydb-go-sdk/pull/2194)) |
 
 ## Changelog for agents
 

--- a/.agents/context/progress.md
+++ b/.agents/context/progress.md
@@ -1,0 +1,39 @@
+# Progress
+
+> **Volatile file** — append/update as work completes.
+
+## What works (baseline)
+
+- **Table API**: `Do`/`DoTx`, sessions, transactions, bulk operations.
+- **Query API**: streaming results, `Do`/`DoTx`, lazy tx options.
+- **Scheme API**: directory listing, path operations.
+- **Topics**: reader/writer/listener/multiwriter.
+- **Coordination**: distributed semaphores.
+- **Discovery** + balancers (`RandomChoice`, `PreferNearestDC`, …).
+- **database/sql** driver via `sql.Open("ydb", ...)`.
+- **Auth**: static tokens, metadata, OAuth credentials.
+- **TLS**: custom CA via `ydb_certs/`, rustls-compatible stack.
+- **Observability**: trace callbacks, log/metrics/spans adapters.
+
+## CI status
+
+- Lint: golangci-lint v2.11.4 on Go 1.26.
+- Unit tests: `go test -race ./...` on ubuntu/windows/macOS × Go 1.21/1.26.
+- Integration: `tests/integration` vs YDB 24.4/latest/edge images.
+
+## Known gaps
+
+- Check GitHub Issues for active bugs and feature requests.
+- Cross-SDK parity with Java/Rust tracked issue-by-issue.
+- `CONTRIBUTING.md` mentions `-tags fast` for unit tests — tag does not exist; default `go test ./...` already excludes integration.
+
+## Milestones
+
+| Date | Milestone |
+|------|-----------|
+| 2026-06 | `.agents/` workspace for AI agents (aligned with ydb-rs-sdk #430) |
+| ongoing | Trace handler hardening, fuzz tests ([#2194](https://github.com/ydb-platform/ydb-go-sdk/pull/2194)) |
+
+## Changelog for agents
+
+User-facing API or behavior changes require a bullet at the **top** of `CHANGELOG.md` (past tense, no version number). Internal-only agent docs: label PR `no changelog`.

--- a/.agents/context/projectBrief.md
+++ b/.agents/context/projectBrief.md
@@ -1,0 +1,45 @@
+# Project Brief
+
+## What this is
+
+**ydb-go-sdk** is the official Go SDK for [YDB](https://ydb.tech/) — a distributed SQL database. Module path: `github.com/ydb-platform/ydb-go-sdk/v3`. Provides native clients and a `database/sql` driver.
+
+## Goals
+
+- Idiomatic async Go client for YDB table, query, scheme, topic, coordination, discovery, and related APIs.
+- Production concerns: connection pooling, session pooling, load balancing, retries, credentials, TLS.
+- Stay compatible with YDB gRPC/protobuf contracts via `ydb-go-genproto`.
+- Maintain semver per [`VERSIONING.md`](../../VERSIONING.md); publish releases via GitHub Actions.
+
+## Non-goals
+
+- `internal/` packages are not a public API for application developers.
+- This repo does not host the YDB server or non-Go SDKs.
+- `testutil/` is explicitly unstable (see `VERSIONING.md`).
+
+## Key constraints
+
+| Area | Constraint |
+|------|------------|
+| Language | Go (module declares `go 1.24.0`; CI tests 1.21.x and 1.26.x) |
+| Public API | Facade in root + service packages; implementations in `internal/` |
+| Retries | `Do`/`DoTx` loops with backoff; idempotent ops via `WithIdempotent()` |
+| Tests | Unit tests co-located; integration in `tests/integration/` with `//go:build integration` |
+| Changelog | User-facing PRs require `CHANGELOG.md` entry (or `no changelog` label) |
+| Codegen | `trace/` changes require `go generate` — CI enforces clean diff |
+
+## Success criteria for agent work
+
+- Public API changes are intentional, documented, semver-aware, and have changelog entries.
+- New code follows existing package boundaries and `Do`/`DoTx` patterns.
+- `.agents/context/` reflects current state after significant work.
+
+## Reference docs (by depth)
+
+| Depth | File |
+|-------|------|
+| Quick start | `README.md` |
+| Agent router | `AGENTS.md` → `.agents/rules/` |
+| Versioning | `VERSIONING.md` |
+| SQL driver | `SQL.md` |
+| API reference | [pkg.go.dev/ydb-go-sdk/v3](https://pkg.go.dev/github.com/ydb-platform/ydb-go-sdk/v3) |

--- a/.agents/context/systemPatterns.md
+++ b/.agents/context/systemPatterns.md
@@ -1,0 +1,86 @@
+# System Patterns
+
+## Repository structure
+
+```
+ydb-go-sdk/
+├── driver.go, sql.go, with.go     # ydb.Open, Driver, options
+├── table/, query/, scheme/, topic/ # public service client packages
+├── coordination/, discovery/, scripting/, operation/, ratelimiter/
+├── config/, balancers/, credentials/, retry/, sugar/
+├── trace/, log/, metrics/, spans/ # observability
+├── internal/                      # implementations (unstable)
+│   ├── table/, query/, scheme/, topic/, conn/, balancer/, pool/, ...
+│   └── cmd/gtrace/, cmd/gstack/   # codegen tools
+├── tests/integration/             # //go:build integration
+├── examples/                      # separate go.mod
+└── .agents/                       # agent workspace
+```
+
+## Layered architecture
+
+```
+ydb.Open(ctx, dsn, opts...)
+    └── Driver
+            ├── Table()      → table.Client      → internal/table/
+            ├── Query()      → query.Client      → internal/query/
+            ├── Scheme()     → scheme.Client     → internal/scheme/
+            ├── Topic()      → topic.Client      → internal/topic/
+            └── ...
+
+Driver
+    └── internal/balancer/     # discovery, endpoint selection, ban/pessimization
+            └── internal/conn/ # gRPC connection pool per endpoint
+
+table.Client / query.Client
+    └── internal/pool/         # YDB session pool
+            └── internal/grpcwrapper/
+```
+
+## Key patterns
+
+### Do / DoTx
+
+Canonical user API for table and query services:
+
+```go
+err := db.Query().Do(ctx, func(ctx context.Context, s query.Session) error {
+    // return err to retry; return nil on success
+}, query.WithIdempotent())
+```
+
+- `DoTx` — auto begin/commit/rollback.
+- Non-nil callback error triggers retry with backoff (`retry/` package).
+- Always close result sets/streams (`defer result.Close(ctx)`).
+
+### Balancers
+
+Configure via `config.WithBalancer(balancers.PreferNearestDC(balancers.RandomChoice()))`.
+
+Presets in `balancers/`: `RandomChoice`, `SingleConn`, `PreferNearestDC`, location filters.
+
+### Trace codegen
+
+- Callback types in `trace/`; generated wrappers `*_gtrace.go` via `go generate ./trace`.
+- CI `check-codegen.yml` fails on dirty generated files.
+
+### Public vs internal
+
+- Edit public interfaces in `table/`, `query/`, etc.
+- Implement in matching `internal/<service>/` package.
+- Do not expose `internal/` types in public API without stable wrappers.
+
+## Adding a new API
+
+1. Confirm protobuf support in `ydb-go-genproto`.
+2. Add methods in `internal/<service>/` + `internal/grpcwrapper/`.
+3. Expose through public `*/client.go` with `Do`/`DoTx` or direct methods + retry.
+4. Add `trace/` callbacks if needed; run `go generate`.
+5. Unit tests co-located; integration test in `tests/integration/` if server needed.
+
+## Anti-patterns
+
+- Bypassing session pool or connection pool for production RPC paths.
+- Returning from `Do` callback without closing streams/results.
+- Adding dependencies without explicit task requirement.
+- Editing `*_gtrace.go` by hand instead of regenerating.

--- a/.agents/context/systemPatterns.md
+++ b/.agents/context/systemPatterns.md
@@ -1,86 +1,175 @@
 # System Patterns
 
-## Repository structure
+## Repository layout
 
 ```
 ydb-go-sdk/
-├── driver.go, sql.go, with.go     # ydb.Open, Driver, options
-├── table/, query/, scheme/, topic/ # public service client packages
+├── driver.go, with.go, sql.go    # ydb.Open, Driver, ydb.Option, database/sql driver
+├── table/, query/, scheme/, topic/ # public service client packages (+ types/options/result)
 ├── coordination/, discovery/, scripting/, operation/, ratelimiter/
-├── config/, balancers/, credentials/, retry/, sugar/
-├── trace/, log/, metrics/, spans/ # observability
-├── internal/                      # implementations (unstable)
-│   ├── table/, query/, scheme/, topic/, conn/, balancer/, pool/, ...
-│   └── cmd/gtrace/, cmd/gstack/   # codegen tools
-├── tests/integration/             # //go:build integration
-├── examples/                      # separate go.mod
-└── .agents/                       # agent workspace
+├── config/, balancers/, credentials/, retry/, sugar/, trace/
+├── log/, metrics/, spans/        # trace adapters
+├── internal/                     # implementations (unstable; do not expose in public API)
+├── tests/integration/            # //go:build integration
+├── examples/                     # separate go.mod
+└── .agents/                      # agent workspace
 ```
 
-## Layered architecture
+Public packages define interfaces and option types. Implementations live under `internal/<service>/` and are wired in `driver.go`.
+
+## Driver lifecycle
+
+### Entry points
+
+| API | File | Role |
+|-----|------|------|
+| `ydb.Open(ctx, dsn, opts...)` | `driver.go` | Parse DSN, apply `ydb.Option`s, connect, return `*Driver` |
+| `ydb.New(ctx, opts...)` | `driver.go` | Same without DSN in args (endpoint/database from options) |
+| `sql.Open("ydb", dsn)` | `sql.go` | Registers `database/sql` driver; uses same `Driver` underneath |
+| `ydb.Connector(driver)` | `internal/xsql` | Wrap native driver for `sql.OpenDB` |
+
+`ydb.Option` functions (`with.go`) mutate `*Driver` before connect: credentials, balancer, trace, timeouts, table/query config, etc.
+
+### `connect()` sequence (`driver.go`)
 
 ```
-ydb.Open(ctx, dsn, opts...)
-    └── Driver
-            ├── Table()      → table.Client      → internal/table/
-            ├── Query()      → query.Client      → internal/query/
-            ├── Scheme()     → scheme.Client     → internal/scheme/
-            ├── Topic()      → topic.Client      → internal/topic/
-            └── ...
+driverFromOptions()
+  → apply env defaults (YDB_SSL_ROOT_CERTIFICATES_FILE, YDB_LOG_SEVERITY_LEVEL)
+  → apply user opts
+  → build config.Config
 
-Driver
-    └── internal/balancer/     # discovery, endpoint selection, ban/pessimization
-            └── internal/conn/ # gRPC connection pool per endpoint
-
-table.Client / query.Client
-    └── internal/pool/         # YDB session pool
-            └── internal/grpcwrapper/
+connect(ctx)
+  1. conn.NewPool(ctx, config)           # gRPC connection pool (if not preset)
+  2. balancer.New(ctx, config, pool)     # discovery + endpoint selection
+  3. metaBalancer.meta = config.Meta()   # request metadata (database, credentials hints)
+  4. xsync.OnceValue per service client  # lazy init on first Table()/Query()/...
 ```
 
-## Key patterns
+Service clients are **lazy**: `d.Table()` calls `d.table.Must()` which runs the `OnceValue` factory only once.
 
-### Do / DoTx
+### `balancerWithMeta` — shared RPC transport
 
-Canonical user API for table and query services:
+All service clients receive the same `*balancerWithMeta` (implements `grpc.ClientConnInterface`):
+
+- `Invoke()` / `NewStream()` inject `meta.Meta` into context, then delegate to `internal/balancer.Balancer`.
+- `Balancer` picks an endpoint, gets `conn.Pool.Get(endpoint)`, executes RPC.
+- On stream/call errors that indicate a bad connection, the endpoint may be **banned** (pessimization) and rediscovered.
+
+This is the single production path for gRPC — do not dial around the balancer.
+
+## Two pool layers
+
+### 1. gRPC connection pool (`internal/conn/pool.go`)
+
+- One `*conn` per `endpoint.Endpoint` (host:port + node metadata).
+- Created on demand via `pool.Get(endpoint)`; tracks TTL, dial options, trace.
+- Used by balancer to obtain `grpc.ClientConn` for a chosen node.
+
+### 2. YDB session pool (`internal/pool/pool.go`)
+
+- Generic pool used by **table** and **query** clients for YDB `Session` objects.
+- Configurable: limit, warm-up size, idle TTL, usage limit/TTL, create/delete timeouts.
+- `MustDelete` predicate drops sessions on `xerrors.MustDeleteTableOrQuerySession(err)`.
+
+Table and query each maintain their own session pool instance inside `internal/table.Client` / `internal/query.Client`.
+
+Query additionally has **implicit** session pool for server-side session management (see `internal/query/client.go`).
+
+## Balancer and discovery (`internal/balancer/`)
+
+```
+Balancer
+  ├── clusterDiscovery()     # periodic / on-init endpoint list refresh
+  ├── discover endpoints     # via Discovery gRPC (or static single endpoint)
+  ├── localDCDetector        # for PreferNearestDC balancers
+  ├── filter by balancerConfig (RandomChoice, PreferNearestDC, location filters)
+  └── wrapCall / wrapStream  # ban endpoint on retriable connection failures
+```
+
+User-facing presets: `balancers/RandomChoice`, `SingleConn`, `PreferNearestDC`, `PreferNearestDCWithFallBack`.
+
+Configured via `config.WithBalancer(...)` or `ydb.WithBalancer(...)`.
+
+`Driver.Discovery()` exposes a separate discovery client (uses bootstrap connection from pool, not the main balancer loop).
+
+## Service client map
+
+| `Driver` accessor | Public package | Internal impl | Session pool? | Notes |
+|-------------------|----------------|---------------|---------------|-------|
+| `Table()` | `table/` | `internal/table/` | Yes | `Do`/`DoTx`, bulk ops |
+| `Query()` | `query/` | `internal/query/` | Yes (+ implicit) | Streaming `ResultSets`, `Do`/`DoTx` |
+| `Scheme()` | `scheme/` | `internal/scheme/` | No | Directory, describe path |
+| `Topic()` | `topic/` | `internal/topic/` | No | Reader/writer/listener; own connection semantics |
+| `Coordination()` | `coordination/` | `internal/coordination/` | No | Semaphores, distributed locks |
+| `Scripting()` | `scripting/` | `internal/scripting/` | No | YQL scripts (legacy path) |
+| `Ratelimiter()` | `ratelimiter/` | `internal/ratelimiter/` | No | Quota control |
+| `Discovery()` | `discovery/` | `internal/discovery/` | No | Endpoint discovery API |
+| `Operation()` | `operation/` | `operation/` | No | Long-running ops (experimental) |
+
+`database/sql` path: `internal/xsql` connector acquires table sessions via the same table client stack.
+
+## Do / DoTx pattern
+
+Canonical pattern for **table** and **query** (public API mirrors internal):
 
 ```go
 err := db.Query().Do(ctx, func(ctx context.Context, s query.Session) error {
-    // return err to retry; return nil on success
+    rs, err := s.Query(ctx, "SELECT 1")
+    if err != nil { return err }
+    defer func() { _ = rs.Close(ctx) }()
+    // ...
+    return nil  // success → exit retry loop
 }, query.WithIdempotent())
 ```
 
-- `DoTx` — auto begin/commit/rollback.
-- Non-nil callback error triggers retry with backoff (`retry/` package).
-- Always close result sets/streams (`defer result.Close(ctx)`).
+Internal flow (`internal/table/client.go`, `internal/query/client.go`):
 
-### Balancers
+```
+Do(ctx, op, opts)
+  → merge retry options (label, idempotent, backoff, trace)
+  → retry loop (retry.Retry / do+backoff)
+      → sessionPool.Get(ctx)     # acquire Session
+      → op(ctx, session)         # user callback
+      → on error: classify retryable, maybe delete session, retry
+      → on success: return nil
+```
 
-Configure via `config.WithBalancer(balancers.PreferNearestDC(balancers.RandomChoice()))`.
+`DoTx`: acquire session → `BeginTransaction` → user op → `Commit` (rollback on error). Retries whole transaction when safe.
 
-Presets in `balancers/`: `RandomChoice`, `SingleConn`, `PreferNearestDC`, location filters.
+**Rules for agents:**
 
-### Trace codegen
+- Return non-nil error from callback to trigger retry; nil means success.
+- Use `WithIdempotent()` for operations safe to repeat.
+- Always `Close()` result sets / streams in callback.
+- Unbounded `context.Context` can retry indefinitely — use deadlines.
 
-- Callback types in `trace/`; generated wrappers `*_gtrace.go` via `go generate ./trace`.
-- CI `check-codegen.yml` fails on dirty generated files.
+## Retry package (`retry/`)
 
-### Public vs internal
+- `retry.Retry()` — core loop with fast/slow backoff (`internal/backoff`).
+- `xerrors.Retryable(err)` — mark errors for retry.
+- `retry/budget/` — optional retry budget from driver config.
+- Wired into `Do`/`DoTx` and balancer discovery.
 
-- Edit public interfaces in `table/`, `query/`, etc.
-- Implement in matching `internal/<service>/` package.
-- Do not expose `internal/` types in public API without stable wrappers.
+## Trace and codegen
 
-## Adding a new API
+- Callback structs in `trace/` (per service).
+- `go generate ./trace` → `*_gtrace.go` wrappers in public and internal packages.
+- `internal/cmd/gstack/` — `stack.FunctionID` for trace spans.
+- CI `check-codegen.yml` enforces clean generated diff.
 
-1. Confirm protobuf support in `ydb-go-genproto`.
-2. Add methods in `internal/<service>/` + `internal/grpcwrapper/`.
-3. Expose through public `*/client.go` with `Do`/`DoTx` or direct methods + retry.
-4. Add `trace/` callbacks if needed; run `go generate`.
-5. Unit tests co-located; integration test in `tests/integration/` if server needed.
+## `database/sql` integration
 
-## Anti-patterns
+- Driver registered as `"ydb"` in `sql.go`.
+- `internal/xsql/connector.go` — `CreateSession` uses native table client; balancing happens at session creation.
+- See `SQL.md` for DSN params, balancing, and connector options.
 
-- Bypassing session pool or connection pool for production RPC paths.
-- Returning from `Do` callback without closing streams/results.
-- Adding dependencies without explicit task requirement.
-- Editing `*_gtrace.go` by hand instead of regenerating.
+## Adding a new RPC surface
+
+1. Confirm protobuf in `ydb-go-genproto`.
+2. Add `internal/grpcwrapper/` or service-specific raw client methods.
+3. Implement `internal/<service>/client.go` using `balancerWithMeta` as `grpc.ClientConnInterface`.
+4. Expose public package with stable types; add `trace/` callbacks + regenerate.
+5. Wire lazy `xsync.OnceValue` factory in `driver.go` `connect()`.
+6. Unit tests co-located; `tests/integration/` if server interaction needed.
+
+Checklist and coding anti-patterns: [`.agents/rules/coding-standards.md`](../rules/coding-standards.md).

--- a/.agents/context/techContext.md
+++ b/.agents/context/techContext.md
@@ -1,0 +1,72 @@
+# Tech Context
+
+## Toolchain
+
+| Item | Value |
+|------|-------|
+| Module | `github.com/ydb-platform/ydb-go-sdk/v3` |
+| Go (module) | 1.24.0 |
+| CI Go matrix | 1.21.x, 1.26.x |
+| gRPC | `google.golang.org/grpc` |
+| Protos | `github.com/ydb-platform/ydb-go-genproto` |
+| Linter (CI) | golangci-lint **v2.11.4** (`.github/workflows/lint.yml`) |
+
+## Local development
+
+```bash
+# Unit tests (default — integration tag excluded)
+go test -race ./...
+
+# Lint
+golangci-lint run ./...
+```
+
+### Devcontainer (recommended)
+
+`.devcontainer/compose.yml` — Go devcontainer + `ghcr.io/ydb-platform/local-ydb:24.3`.
+
+Pre-set env vars: `YDB_CONNECTION_STRING`, `YDB_CONNECTION_STRING_SECURE`, `YDB_SSL_ROOT_CERTIFICATES_FILE`.
+
+### Integration tests (manual / host)
+
+```bash
+docker run -itd --name ydb -dp 2135:2135 -dp 2136:2136 -dp 8765:8765 \
+  -v "$(pwd)/ydb_certs:/ydb_certs" \
+  -e YDB_LOCAL_SURVIVE_RESTART=true -e YDB_USE_IN_MEMORY_PDISKS=true \
+  -h localhost ydbplatform/local-ydb:latest
+
+export YDB_CONNECTION_STRING="grpcs://localhost:2135/local"
+export YDB_SSL_ROOT_CERTIFICATES_FILE="$(pwd)/ydb_certs/ca.pem"
+export YDB_SESSIONS_SHUTDOWN_URLS="http://localhost:8765/actors/kqp_proxy?force_shutdown=all"
+
+go test -race -tags integration ./tests/integration
+```
+
+## CI workflows
+
+| Workflow | Trigger | What it runs |
+|----------|---------|--------------|
+| `lint.yml` | push/PR to `master`, `release-*` | `golangci-lint`, gofumpt/gci format check |
+| `tests.yml` | push/PR + hourly cron | unit: `go test -race ./...`; integration vs local YDB |
+| `changelog.yml` | PR | `CHANGELOG.md` required (skip: `no changelog` label) |
+| `check-codegen.yml` | PR | `go generate` trace/gstack diff |
+| `breaking.yml` | PR | `gorelease` API diff (skip: `broken changes`) |
+| `examples.yml` | PR | examples vs local YDB (skip: `no examples`) |
+| `publish.yml` | manual | version bump + release |
+
+## PR labels that skip CI gates
+
+`no lint`, `no tests`, `no integration tests`, `no changelog`, `no examples`, `broken changes`
+
+## Dependencies
+
+Shared in root `go.mod`. Do not run `go mod tidy` or `go get` unless the task requires it.
+
+## Codegen
+
+After touching `trace/` or stack IDs:
+
+```bash
+go generate ./trace
+# gstack as needed — see check-codegen.yml
+```

--- a/.agents/context/techContext.md
+++ b/.agents/context/techContext.md
@@ -14,20 +14,17 @@
 ## Local development
 
 ```bash
-# Unit tests (default — integration tag excluded)
-go test -race ./...
-
-# Lint
+go test -race ./...          # unit only (integration tag excluded)
 golangci-lint run ./...
 ```
 
-### Devcontainer (recommended)
+### Devcontainer
 
 `.devcontainer/compose.yml` — Go devcontainer + `ghcr.io/ydb-platform/local-ydb:24.3`.
 
-Pre-set env vars: `YDB_CONNECTION_STRING`, `YDB_CONNECTION_STRING_SECURE`, `YDB_SSL_ROOT_CERTIFICATES_FILE`.
+Env: `YDB_CONNECTION_STRING=grpc://ydb:2136/local`, `YDB_CONNECTION_STRING_SECURE=grpcs://ydb:2135/local`, `YDB_SSL_ROOT_CERTIFICATES_FILE=/ydb_certs/ca.pem`.
 
-### Integration tests (manual / host)
+### Integration tests (host)
 
 ```bash
 docker run -itd --name ydb -dp 2135:2135 -dp 2136:2136 -dp 8765:8765 \
@@ -35,23 +32,27 @@ docker run -itd --name ydb -dp 2135:2135 -dp 2136:2136 -dp 8765:8765 \
   -e YDB_LOCAL_SURVIVE_RESTART=true -e YDB_USE_IN_MEMORY_PDISKS=true \
   -h localhost ydbplatform/local-ydb:latest
 
-export YDB_CONNECTION_STRING="grpcs://localhost:2135/local"
+export YDB_CONNECTION_STRING="grpc://localhost:2136/local"
+export YDB_CONNECTION_STRING_SECURE="grpcs://localhost:2135/local"
 export YDB_SSL_ROOT_CERTIFICATES_FILE="$(pwd)/ydb_certs/ca.pem"
 export YDB_SESSIONS_SHUTDOWN_URLS="http://localhost:8765/actors/kqp_proxy?force_shutdown=all"
 
 go test -race -tags integration ./tests/integration
 ```
 
+`YDB_CONNECTION_STRING` is the **insecure** endpoint (port 2136); TLS uses `YDB_CONNECTION_STRING_SECURE` (port 2135). Default in `tests/integration/helpers_test.go`: `grpc://localhost:2136/local`.
+
 ## CI workflows
 
 | Workflow | Trigger | What it runs |
 |----------|---------|--------------|
 | `lint.yml` | push/PR to `master`, `release-*` | `golangci-lint`, gofumpt/gci format check |
-| `tests.yml` | push/PR + hourly cron | unit: `go test -race ./...`; integration vs local YDB |
-| `changelog.yml` | PR | `CHANGELOG.md` required (skip: `no changelog` label) |
+| `tests.yml` | push/PR + hourly cron | unit: `go test -race ./...`; integration vs `ydbplatform/local-ydb:{24.4,latest,edge}` |
+| `changelog.yml` | PR | `CHANGELOG.md` required (skip: `no changelog`) |
 | `check-codegen.yml` | PR | `go generate` trace/gstack diff |
-| `breaking.yml` | PR | `gorelease` API diff (skip: `broken changes`) |
+| `breaking.yml` | PR | `gorelease` (skip: `broken changes`) |
 | `examples.yml` | PR | examples vs local YDB (skip: `no examples`) |
+| `slo.yml` | push/PR + manual | SLO benchmarks (active in go-sdk) |
 | `publish.yml` | manual | version bump + release |
 
 ## PR labels that skip CI gates
@@ -60,13 +61,12 @@ go test -race -tags integration ./tests/integration
 
 ## Dependencies
 
-Shared in root `go.mod`. Do not run `go mod tidy` or `go get` unless the task requires it.
+Do not run `go mod tidy` or `go get` unless the task requires it.
 
 ## Codegen
 
-After touching `trace/` or stack IDs:
-
 ```bash
 go generate ./trace
-# gstack as needed — see check-codegen.yml
 ```
+
+After touching `trace/` or stack IDs — CI `check-codegen.yml` must pass.

--- a/.agents/rules/changelog.md
+++ b/.agents/rules/changelog.md
@@ -1,0 +1,26 @@
+# Changelog
+
+**Every pull request with user-facing changes must include a `CHANGELOG.md` entry.**
+
+## When to add an entry
+
+- API changes: additions, renames, deletions, deprecations.
+- Observable behavior changes.
+
+Internal refactoring, agent docs, or non-observable changes: add PR label **`no changelog`** to skip `changelog.yml`.
+
+## Format
+
+1. **Past tense verbs**: Added, Fixed, Changed, Removed, Deprecated.
+2. **Insert at the very top** of `CHANGELOG.md`, before existing entries (including before `## v3.x.x` headers).
+3. **No version number** — versions are assigned at release (`.github/workflows/publish.yml`).
+
+Example:
+
+```markdown
+* Added `query.WithLazyTx(bool)` option for `query.Client.DoTx` calls to enable/disable lazy transactions per operation
+```
+
+## Release process (maintainer)
+
+`publish.yml` reads unreleased bullets, bumps `internal/version/version.go`, prepends `## vX.Y.Z`, tags, and creates GitHub release.

--- a/.agents/rules/coding-standards.md
+++ b/.agents/rules/coding-standards.md
@@ -1,0 +1,33 @@
+# Coding Standards
+
+Read when touching public API, package layout, dependencies, or error handling.
+
+## Style
+
+- Comments, godoc, error messages, and logs: **English**.
+- Match naming and formatting in the touched package; do not reformat unrelated code.
+- Run `golangci-lint run ./...` before handoff (CI also checks gofumpt + gci).
+
+## Dependencies
+
+- Do **not** change `go.mod` / `go.sum` unless the task explicitly requires it.
+- Do not run `go mod tidy` or `go get` as a side effect of code changes.
+- If a dependency change is required, document it clearly in the PR description.
+
+## Public API
+
+- Implementations live in `internal/` — do not leak internal types in public packages without stable wrappers.
+- New service APIs follow: `internal/<service>/` → public `table/` / `query/` / … facade with `Do`/`DoTx` where applicable.
+- Respect `// Experimental`, `// Deprecated`, `// Internals` markers per `VERSIONING.md`.
+- `testutil/` is unstable — do not treat as semver-guaranteed API.
+
+## Codegen
+
+- Do not hand-edit `*_gtrace.go` or gstack-generated files.
+- After changing `trace/` definitions: `go generate ./trace` and verify `check-codegen.yml` passes.
+
+## Architecture anti-patterns
+
+- Bypassing connection pool or session pool for production paths.
+- Returning from `Do`/`DoTx` without closing streams and result sets.
+- Unbounded retry loops without idempotency consideration on mutating operations.

--- a/.agents/rules/coding-standards.md
+++ b/.agents/rules/coding-standards.md
@@ -28,6 +28,9 @@ Read when touching public API, package layout, dependencies, or error handling.
 
 ## Architecture anti-patterns
 
-- Bypassing connection pool or session pool for production paths.
+See [`.agents/context/systemPatterns.md`](../context/systemPatterns.md) for driver layout. In short:
+
+- Bypassing `balancerWithMeta` / `conn.Pool` for production RPC paths.
 - Returning from `Do`/`DoTx` without closing streams and result sets.
 - Unbounded retry loops without idempotency consideration on mutating operations.
+- Hand-editing `*_gtrace.go` instead of `go generate ./trace`.

--- a/.agents/rules/environment.md
+++ b/.agents/rules/environment.md
@@ -1,0 +1,56 @@
+# Environment and CI
+
+## Toolchain
+
+| Item | Value |
+|------|-------|
+| Module | `github.com/ydb-platform/ydb-go-sdk/v3` |
+| Go | 1.24.0 (module); CI: 1.21.x, 1.26.x |
+| Linter | golangci-lint v2.11.4 |
+
+Full CI details: [`.agents/context/techContext.md`](../context/techContext.md).
+
+## Devcontainer (recommended)
+
+```text
+Dev Containers: Reopen in Container
+```
+
+`.devcontainer/compose.yml`:
+
+- **sdk** — Go devcontainer, `network_mode: service:ydb`
+- **ydb** — `ghcr.io/ydb-platform/local-ydb:24.3`
+
+Env pre-configured: `YDB_CONNECTION_STRING=grpc://ydb:2136/local`, TLS vars, certs volume.
+
+`postStartCommand` runs `.devcontainer/configure.sh` (YDB CLI profile).
+
+## Local YDB (without devcontainer)
+
+```bash
+docker run -itd --name ydb -dp 2135:2135 -dp 2136:2136 -dp 8765:8765 \
+  -v "$(pwd)/ydb_certs:/ydb_certs" \
+  -e YDB_LOCAL_SURVIVE_RESTART=true -e YDB_USE_IN_MEMORY_PDISKS=true \
+  -h localhost ydbplatform/local-ydb:latest
+
+export YDB_CONNECTION_STRING="grpcs://localhost:2135/local"
+export YDB_SSL_ROOT_CERTIFICATES_FILE="$(pwd)/ydb_certs/ca.pem"
+export YDB_SESSIONS_SHUTDOWN_URLS="http://localhost:8765/actors/kqp_proxy?force_shutdown=all"
+```
+
+## Lint install
+
+CI uses golangci-lint **v2.11.4**. Install matching version:
+
+```bash
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | \
+  sh -s -- -b "$(go env GOPATH)/bin" v2.11.4
+```
+
+## golangci-lint
+
+```bash
+golangci-lint run ./...
+```
+
+Also linted: `examples/`, `tests/slo/` (separate configs via `.github/scripts/golangci-lint-gen-configs.sh`).

--- a/.agents/rules/environment.md
+++ b/.agents/rules/environment.md
@@ -1,56 +1,32 @@
-# Environment and CI
+# Environment — quick commands
 
-## Toolchain
-
-| Item | Value |
-|------|-------|
-| Module | `github.com/ydb-platform/ydb-go-sdk/v3` |
-| Go | 1.24.0 (module); CI: 1.21.x, 1.26.x |
-| Linter | golangci-lint v2.11.4 |
-
-Full CI details: [`.agents/context/techContext.md`](../context/techContext.md).
+Authoritative CI/toolchain reference: [`.agents/context/techContext.md`](../context/techContext.md).
 
 ## Devcontainer (recommended)
 
-```text
-Dev Containers: Reopen in Container
-```
+VS Code: **Dev Containers: Reopen in Container** (`.devcontainer/compose.yml`).
 
-`.devcontainer/compose.yml`:
+Pre-configured: `YDB_CONNECTION_STRING=grpc://ydb:2136/local`, TLS vars, YDB CLI profile.
 
-- **sdk** — Go devcontainer, `network_mode: service:ydb`
-- **ydb** — `ghcr.io/ydb-platform/local-ydb:24.3`
-
-Env pre-configured: `YDB_CONNECTION_STRING=grpc://ydb:2136/local`, TLS vars, certs volume.
-
-`postStartCommand` runs `.devcontainer/configure.sh` (YDB CLI profile).
-
-## Local YDB (without devcontainer)
-
-```bash
-docker run -itd --name ydb -dp 2135:2135 -dp 2136:2136 -dp 8765:8765 \
-  -v "$(pwd)/ydb_certs:/ydb_certs" \
-  -e YDB_LOCAL_SURVIVE_RESTART=true -e YDB_USE_IN_MEMORY_PDISKS=true \
-  -h localhost ydbplatform/local-ydb:latest
-
-export YDB_CONNECTION_STRING="grpcs://localhost:2135/local"
-export YDB_SSL_ROOT_CERTIFICATES_FILE="$(pwd)/ydb_certs/ca.pem"
-export YDB_SESSIONS_SHUTDOWN_URLS="http://localhost:8765/actors/kqp_proxy?force_shutdown=all"
-```
-
-## Lint install
-
-CI uses golangci-lint **v2.11.4**. Install matching version:
-
-```bash
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | \
-  sh -s -- -b "$(go env GOPATH)/bin" v2.11.4
-```
-
-## golangci-lint
+## Lint and unit tests
 
 ```bash
 golangci-lint run ./...
+go test -race ./...
 ```
 
-Also linted: `examples/`, `tests/slo/` (separate configs via `.github/scripts/golangci-lint-gen-configs.sh`).
+## Integration tests (host)
+
+Requires local YDB. Env vars match CI (`tests.yml`, `helpers_test.go`):
+
+```bash
+export YDB_CONNECTION_STRING="grpc://localhost:2136/local"
+export YDB_CONNECTION_STRING_SECURE="grpcs://localhost:2135/local"
+export YDB_SSL_ROOT_CERTIFICATES_FILE="$(pwd)/ydb_certs/ca.pem"
+# optional for session-shutdown tests:
+export YDB_SESSIONS_SHUTDOWN_URLS="http://localhost:8765/actors/kqp_proxy?force_shutdown=all"
+
+go test -race -tags integration ./tests/integration
+```
+
+See [`.agents/rules/testing.md`](testing.md) for details.

--- a/.agents/rules/testing.md
+++ b/.agents/rules/testing.md
@@ -20,8 +20,8 @@ Requires running YDB and environment variables (see `environment.md`):
 
 | Variable | Purpose |
 |----------|---------|
-| `YDB_CONNECTION_STRING` | Insecure gRPC DSN |
-| `YDB_CONNECTION_STRING_SECURE` | TLS gRPC DSN |
+| `YDB_CONNECTION_STRING` | Insecure gRPC DSN (default: `grpc://localhost:2136/local`) |
+| `YDB_CONNECTION_STRING_SECURE` | TLS gRPC DSN (`grpcs://localhost:2135/local`) |
 | `YDB_SSL_ROOT_CERTIFICATES_FILE` | CA for TLS tests |
 | `YDB_SESSIONS_SHUTDOWN_URLS` | Rolling-restart / session shutdown tests |
 

--- a/.agents/rules/testing.md
+++ b/.agents/rules/testing.md
@@ -1,0 +1,43 @@
+# Testing
+
+## Unit tests (default)
+
+```bash
+go test -race ./...
+```
+
+Integration tests in `tests/integration/` are excluded automatically (`//go:build integration`).
+
+> Note: `CONTRIBUTING.md` documents `-tags fast` for unit-only runs, but that build tag does not exist. Default `go test ./...` is correct.
+
+## Integration tests
+
+```bash
+go test -race -tags integration ./tests/integration
+```
+
+Requires running YDB and environment variables (see `environment.md`):
+
+| Variable | Purpose |
+|----------|---------|
+| `YDB_CONNECTION_STRING` | Insecure gRPC DSN |
+| `YDB_CONNECTION_STRING_SECURE` | TLS gRPC DSN |
+| `YDB_SSL_ROOT_CERTIFICATES_FILE` | CA for TLS tests |
+| `YDB_SESSIONS_SHUTDOWN_URLS` | Rolling-restart / session shutdown tests |
+
+Helpers: `tests/integration/helpers_test.go`.
+
+## CI parity
+
+Before requesting review:
+
+```bash
+golangci-lint run ./...
+go test -race ./...
+```
+
+Integration changes: run `-tags integration ./tests/integration` locally or rely on CI (skip with `no integration tests` label only when appropriate).
+
+## Test libraries
+
+`github.com/stretchr/testify`, `github.com/rekby/fixenv`, `go.uber.org/mock` — test-only dependencies in `go.mod`.

--- a/.agents/rules/workflow.md
+++ b/.agents/rules/workflow.md
@@ -1,0 +1,38 @@
+# Workflow
+
+## Issue-first (required for non-trivial work)
+
+Per [`CONTRIBUTING.md`](../../CONTRIBUTING.md): discuss new features and bug fixes in a GitHub issue before implementing.
+
+Look for labels: `good first issue`, `student project`, `30min`.
+
+## User-request boundaries
+
+Stop and ask when blocked — do not ship an unsanctioned alternative approach.
+
+✅ **Correct**
+
+```
+User: "Implement feature X using approach A"
+Agent: "Attempting approach A..."
+Agent: "Approach A hit error P: <details>. Next step?"
+```
+
+❌ **Wrong**
+
+```
+User: "Fix the build using method M"
+Agent: "Method M failed, so I implemented alternative N instead."
+```
+
+## Code reuse
+
+1. Search the repo (`rg`, IDE search) for similar helpers before adding new utilities.
+2. Follow existing `Do`/`DoTx`, retry, and error-mapping patterns in `internal/table/`, `internal/query/`.
+3. Extend shared helpers in `internal/` rather than duplicating logic in public packages.
+
+## Memory bank updates
+
+After significant work, update `.agents/context/activeContext.md` and `progress.md` before closing a PR.
+
+Add rules to `AGENTS.md` only after repeated agent mistakes — incremental, not upfront.

--- a/.agents/rules/workflow.md
+++ b/.agents/rules/workflow.md
@@ -31,8 +31,10 @@ Agent: "Method M failed, so I implemented alternative N instead."
 2. Follow existing `Do`/`DoTx`, retry, and error-mapping patterns in `internal/table/`, `internal/query/`.
 3. Extend shared helpers in `internal/` rather than duplicating logic in public packages.
 
-## Memory bank updates
+## Context updates
 
-After significant work, update `.agents/context/activeContext.md` and `progress.md` before closing a PR.
+- **`activeContext.md`** — branch-only scratch pad. Revert to the placeholder before merge; never land session notes on `master`.
+- **`progress.md`** — update in the PR that delivers completed work.
+- Stable files (`systemPatterns.md`, …) — only when architecture, tooling, or scope actually changed.
 
 Add rules to `AGENTS.md` only after repeated agent mistakes — incremental, not upfront.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,48 +1,54 @@
-# Agent Guidelines
+# Agent Guidelines — ydb-go-sdk
 
-This document contains guidelines for AI agents working on this codebase.
+Canonical agent entry point. Tool configs (`CLAUDE.md`, Cursor rules) start here and route to [`.agents/`](.agents/).
 
-## Code Comments
+Keep this file **lean** (~60 lines) — it routes to detailed sources. Loading a large AGENTS.md on every session wastes context tokens; industry practice is a thin navigation file plus on-demand docs ([agents.md convention](https://agents.md/)).
 
-**All code comments must be written in English.**
+## Project context
 
-- Inline comments, function documentation, and package documentation should use English
-- Variable names and function names should follow Go naming conventions
-- Error messages and log messages should be in English
-- This ensures consistency and maintainability across the codebase
+Project knowledge lives in [`.agents/context/`](.agents/context/). Coding rules live in [`.agents/rules/`](.agents/rules/) (below). See [`.agents/README.md`](.agents/README.md) for the full layout.
 
-## Linting
+**Before coding** — read selectively:
 
-**The linter is run with `golangci-lint run` from the project root.**
+1. [`.agents/context/activeContext.md`](.agents/context/activeContext.md) — always
+2. One stable file if needed:
+   - architecture / module layout → [`systemPatterns.md`](.agents/context/systemPatterns.md)
+   - toolchain / CI / local dev → [`techContext.md`](.agents/context/techContext.md)
+   - API surface / users → [`productContext.md`](.agents/context/productContext.md)
+   - scope / goals → [`projectBrief.md`](.agents/context/projectBrief.md)
+3. Quick lookup: [`README.md`](README.md), [`CONTRIBUTING.md`](CONTRIBUTING.md), [pkg.go.dev](https://pkg.go.dev/github.com/ydb-platform/ydb-go-sdk/v3)
 
-If `golangci-lint` is not installed, it can be installed using:
+**After significant work** — update `.agents/context/activeContext.md` and `.agents/context/progress.md`. Update stable context files only when architecture, tooling, or scope changed.
+
+On **"update memory bank"** — review all core files in [`.agents/context/README.md`](.agents/context/README.md).
+
+## Coding rules (load on demand)
+
+| Topic | File |
+|-------|------|
+| Style, API boundaries, dependencies | [`.agents/rules/coding-standards.md`](.agents/rules/coding-standards.md) |
+| Unit vs integration tests, local YDB | [`.agents/rules/testing.md`](.agents/rules/testing.md) |
+| Changelog requirements | [`.agents/rules/changelog.md`](.agents/rules/changelog.md) |
+| Issue-first workflow, user boundaries | [`.agents/rules/workflow.md`](.agents/rules/workflow.md) |
+| Local dev, devcontainer, CI commands | [`.agents/rules/environment.md`](.agents/rules/environment.md) |
+
+## Non-obvious rules (always on)
+
+- Comments, godoc, error messages, logs: **English**.
+- Match style in the touched package; do not reformat unrelated code.
+- Do **not** change `go.mod` / `go.sum` unless the task requires it.
+- User-facing PRs need a `CHANGELOG.md` entry at the top (or `no changelog` label) — see `changelog.md`.
+- Non-trivial changes: discuss in a GitHub issue first ([`CONTRIBUTING.md`](CONTRIBUTING.md)).
+
+## Done when
+
+From repo root:
+
 ```bash
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.4.0
-```
-(The version `v2.4.0` is specified in [`.github/workflows/lint.yml`](.github/workflows/lint.yml#L10). This installation command is taken from the official documentation)
-
-## Changelog
-
-**Every pull request must include a changelog entry in [`CHANGELOG.md`](CHANGELOG.md).**
-
-Rules for adding a changelog entry:
-
-1. **Only include user-facing changes**: API changes (additions, renames, deletions, deprecations) or behavior changes. Internal refactoring or non-observable changes do not require an entry.
-2. **Use past tense verbs** (e.g., "Added", "Fixed", "Changed", "Removed", "Deprecated").
-3. **Insert the new line(s) at the very beginning of `CHANGELOG.md`**, before any existing entries.
-4. **Do not include a version number** — version numbers are assigned by the maintainer at release time (see [`.github/workflows/publish.yml`](.github/workflows/publish.yml)).
-
-Example entry format:
-```markdown
-* Added `query.WithLazyTx(bool)` option for `query.Client.DoTx` calls to enable/disable lazy transactions per operation
+golangci-lint run ./...
+go test -race ./...
 ```
 
-If the pull request contains no user-facing changes, add the label `no changelog` to the PR to skip the changelog check.
+Also: `.agents/context/` volatile files updated before PR.
 
-## Dependencies
-
-**Do not update `go.mod` or `go.sum` unless the task explicitly requires it.**
-
-- Do not add, remove, or upgrade dependencies as a side effect of making code changes.
-- If a dependency change is truly necessary to complete the task, document it clearly in the PR description.
-- Never run `go mod tidy` or `go get` unless the task requires a dependency change.
+Ask the user before dependency upgrades, public API design choices, or touching `trace/` codegen.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,15 +10,14 @@ Project knowledge lives in [`.agents/context/`](.agents/context/). Coding rules 
 
 **Before coding** — read selectively:
 
-1. [`.agents/context/activeContext.md`](.agents/context/activeContext.md) — always (volatile; may conflict across parallel PRs — see file header)
-2. One stable file if needed:
+1. One stable file as needed:
    - architecture / module layout → [`systemPatterns.md`](.agents/context/systemPatterns.md)
    - toolchain / CI / local dev → [`techContext.md`](.agents/context/techContext.md)
    - API surface / users → [`productContext.md`](.agents/context/productContext.md)
    - scope / goals → [`projectBrief.md`](.agents/context/projectBrief.md)
 3. Quick lookup: [`README.md`](README.md), [`CONTRIBUTING.md`](CONTRIBUTING.md), [pkg.go.dev](https://pkg.go.dev/github.com/ydb-platform/ydb-go-sdk/v3)
 
-**After significant work** — update `.agents/context/activeContext.md` and `.agents/context/progress.md`. Update stable context files only when architecture, tooling, or scope changed.
+**After significant work** — update `progress.md` and stable context files when the work itself merges. Do **not** merge changes to `activeContext.md` (branch-only scratch pad — see file header).
 
 On **"update memory bank"** — review all core files in [`.agents/context/README.md`](.agents/context/README.md).
 
@@ -49,6 +48,6 @@ golangci-lint run ./...
 go test -race ./...
 ```
 
-Also: `.agents/context/` volatile files updated before PR.
+Also: update `progress.md` only when the delivered work merges.
 
 Ask the user before dependency upgrades, public API design choices, or touching `trace/` codegen.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 Canonical agent entry point. Tool configs (`CLAUDE.md`, Cursor rules) start here and route to [`.agents/`](.agents/).
 
-Keep this file **lean** (~60 lines) — it routes to detailed sources. Loading a large AGENTS.md on every session wastes context tokens; industry practice is a thin navigation file plus on-demand docs ([agents.md convention](https://agents.md/)).
+Keep this file **lean** (~60 lines) — it routes to detailed sources. Loading a large AGENTS.md on every session wastes context tokens; use a thin navigation file plus on-demand docs (see [agentsmd/agents.md](https://github.com/agentsmd/agents.md)).
 
 ## Project context
 
@@ -10,7 +10,7 @@ Project knowledge lives in [`.agents/context/`](.agents/context/). Coding rules 
 
 **Before coding** — read selectively:
 
-1. [`.agents/context/activeContext.md`](.agents/context/activeContext.md) — always
+1. [`.agents/context/activeContext.md`](.agents/context/activeContext.md) — always (volatile; may conflict across parallel PRs — see file header)
 2. One stable file if needed:
    - architecture / module layout → [`systemPatterns.md`](.agents/context/systemPatterns.md)
    - toolchain / CI / local dev → [`techContext.md`](.agents/context/techContext.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,14 +120,17 @@ All commands must be called from project directory.
 ##### Only unit tests
 
 ```sh
-go test -race -tags fast ./... 
+go test -race ./...
 ```
+
+Integration tests live under `tests/integration/` with build tag `integration` and are excluded by default.
 
 ##### All tests
 
 ```sh
 docker run -itd --name ydb -dp 2135:2135 -dp 2136:2136 -dp 8765:8765 -v `pwd`/ydb_certs:/ydb_certs -e YDB_LOCAL_SURVIVE_RESTART=true -e YDB_USE_IN_MEMORY_PDISKS=true -h localhost ydbplatform/local-ydb:latest
-export YDB_CONNECTION_STRING="grpcs://localhost:2135/local"
+export YDB_CONNECTION_STRING="grpc://localhost:2136/local"
+export YDB_CONNECTION_STRING_SECURE="grpcs://localhost:2135/local"
 export YDB_SSL_ROOT_CERTIFICATES_FILE="`pwd`/ydb_certs/ca.pem"
 export YDB_SESSIONS_SHUTDOWN_URLS="http://localhost:8765/actors/kqp_proxy?force_shutdown=all"
 go test -race ./... 


### PR DESCRIPTION
## Summary

- Add `.agents/` workspace for AI coding agents, aligned with [ydb-rs-sdk #430](https://github.com/ydb-platform/ydb-rs-sdk/pull/430) and [ydb-pg-extension #257](https://github.com/ydb-platform/ydb-pg-extension/pull/257).
- `.agents/context/` — project knowledge (focus, progress, architecture, CI, API surface).
- `.agents/rules/` — Go-specific standards (coding, testing, changelog, workflow, environment).
- `AGENTS.md` — slimmed to lean root router; existing changelog/lint/dependency rules migrated to `.agents/rules/`.

## Structure

```
.agents/
├── README.md
├── context/
│   ├── activeContext.md
│   ├── progress.md
│   ├── projectBrief.md
│   ├── productContext.md
│   ├── systemPatterns.md
│   └── techContext.md
└── rules/
    ├── coding-standards.md
    ├── changelog.md
    ├── testing.md
    ├── workflow.md
    └── environment.md
```

## Test plan

- [ ] Verify `AGENTS.md` links resolve in GitHub UI
- [ ] Review knowledge tree against actual package layout (`table/`, `query/`, `internal/`, …)
- [ ] Confirm golangci-lint version in `environment.md` matches CI (`v2.11.4`)

Label `no changelog` — agent documentation only, no user-facing SDK changes.

Made with [Cursor](https://cursor.com)