### PR TITLE
docs: fix inverted success/error handling in ExampleWriter_Write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed inverted success/error handling in the `ExampleWriter_Write` doc example for `topicwriter`, which printed `OK` on failure and aborted on success
+
 ## v3.139.6
 * Fixed panics in built-in trace handlers (`spans`, `log`, and `metrics`) when callback info contains typed-nil interfaces (for example, nil `SessionInfo` or `TxInfo`) or nil context pointers
 

--- a/topic/topicwriter/topicwriter_test.go
+++ b/topic/topicwriter/topicwriter_test.go
@@ -29,8 +29,7 @@ func ExampleWriter_Write() {
 		topicwriter.Message{Data: strings.NewReader("3")},
 	)
 	if err != nil {
-		fmt.Println("OK")
-	} else {
-		log.Fatalf("failed write to stream")
+		log.Fatalf("failed write to stream: %v", err)
 	}
+	fmt.Println("OK")
 }


### PR DESCRIPTION
## Pull request type

<!-- Please try to limit your pull request to one types, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The `ExampleWriter_Write` doc example for `topicwriter` has its success/error branches inverted: it prints `"OK"` when `writer.Write` returns an error and calls `log.Fatalf("failed write to stream")` when the write succeeds. This example renders on pkg.go.dev, so users see misleading error-handling guidance.

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Fixed the inverted check in `ExampleWriter_Write`: it now calls `log.Fatalf` on error and prints `"OK"` on success
- Included the underlying error in the fatal message (`%v`) for better diagnostics
- Corrected the example shown on pkg.go.dev so it models correct error handling

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Documentation-only change; no functional or API changes.