### PR TITLE
Fix SLO workflow triggers and build script error handling

### DIFF
--- a/.github/scripts/build-slo-image.sh
+++ b/.github/scripts/build-slo-image.sh
@@ -87,7 +87,8 @@ echo "  SRC_PATH:   $src_path"
     fi
 
     echo "Baseline build failed, using fallback image: $fallback_image"
-    docker tag "$fallback_image" "$tag"
+    docker tag "$fallback_image" "$tag" || die "Fallback docker tag failed"
+    exit_code=0
   fi
-  set -e
+  exit $exit_code
 )

--- a/.github/workflows/slo.yml
+++ b/.github/workflows/slo.yml
@@ -32,7 +32,10 @@ on:
 
 jobs:
   ydb-slo-action:
-    if: contains(github.event.pull_request.labels.*.name, 'SLO')
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push' ||
+      contains(github.event.pull_request.labels.*.name, 'SLO')
 
     name: Run YDB SLO Tests
     runs-on: "large-runner"

--- a/tests/slo/internal/framework/metrics.go
+++ b/tests/slo/internal/framework/metrics.go
@@ -241,38 +241,14 @@ func (m *Metrics) initInstruments() error {
 		for attrs, vals := range percentiles {
 			a := otelmetric.WithAttributes(attrs.ToSlice()...)
 			observer.ObserveFloat64(m.latencyP50, float64(vals[0])/1e6, a)
-		}
-
-		return nil
-	}, m.latencyP50)
-	if err != nil {
-		return fmt.Errorf("failed to register callback for latencyP50: %w", err)
-	}
-
-	_, err = m.meter.RegisterCallback(func(ctx context.Context, observer otelmetric.Observer) error {
-		percentiles := m.latency.GetPercentilesByAttrs()
-		for attrs, vals := range percentiles {
-			a := otelmetric.WithAttributes(attrs.ToSlice()...)
 			observer.ObserveFloat64(m.latencyP95, float64(vals[1])/1e6, a)
-		}
-
-		return nil
-	}, m.latencyP95)
-	if err != nil {
-		return fmt.Errorf("failed to register callback for latencyP95: %w", err)
-	}
-
-	_, err = m.meter.RegisterCallback(func(ctx context.Context, observer otelmetric.Observer) error {
-		percentiles := m.latency.GetPercentilesByAttrs()
-		for attrs, vals := range percentiles {
-			a := otelmetric.WithAttributes(attrs.ToSlice()...)
 			observer.ObserveFloat64(m.latencyP99, float64(vals[2])/1e6, a)
 		}
 
 		return nil
-	}, m.latencyP99)
+	}, m.latencyP50, m.latencyP95, m.latencyP99)
 	if err != nil {
-		return fmt.Errorf("failed to register callback for latencyP99: %w", err)
+		return fmt.Errorf("failed to register callback for latency percentiles: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

- Fix `slo.yml` job `if` condition so `push` and `workflow_dispatch` triggers actually run (previously only PR label `SLO` worked).
- Propagate failures from `docker tag` in `build-slo-image.sh` baseline fallback instead of silently exiting 0.
- Compute latency p50/p95/p99 in a single OTel callback (same histogram scan once per tick).

Found while implementing SLO for ydb-rs-sdk (PR ydb-platform/ydb-rs-sdk#454).

## Test plan

- [x] `go build` in `tests/slo/native/table`
- [ ] CI green


Made with [Cursor](https://cursor.com)