### PR TITLE
fix: prevent nil pointer panic in topicsugar.ProtobufIterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 * Fixed inverted success/error handling in the `ExampleWriter_Write` doc example for `topicwriter`, which printed `OK` on failure and aborted on success
+* Fixed nil pointer dereference panic in `topicsugar.ProtobufIterator` on the first received message by allocating a concrete protobuf message before unmarshaling
 
 ## v3.139.6
 * Fixed panics in built-in trace handlers (`spans`, `log`, and `metrics`) when callback info contains typed-nil interfaces (for example, nil `SessionInfo` or `TxInfo`) or nil context pointers

--- a/topic/topicsugar/iterators.go
+++ b/topic/topicsugar/iterators.go
@@ -5,6 +5,7 @@ package topicsugar
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"slices"
 
 	"google.golang.org/protobuf/proto"
@@ -82,12 +83,32 @@ func JSONIterator[T any](
 
 // ProtobufIterator produce iterator over topic messages with Data is T, created unmarshalled from message
 //
+// T must be a concrete generated protobuf type (for example *examplepb.Message),
+// not the proto.Message interface itself, otherwise iteration yields an error.
+//
 // Experimental: https://github.com/ydb-platform/ydb-go-sdk/blob/master/VERSIONING.md#experimental
 func ProtobufIterator[T proto.Message](
 	ctx context.Context,
 	r TopicMessageReader,
 ) xiter.Seq2[*TypedTopicMessage[T], error] {
 	var unmarshalFunc TypedUnmarshalFunc[*T] = func(data []byte, dst *T) error {
+		// *dst is the zero value of T (a nil proto.Message), so a concrete
+		// message must be allocated before unmarshaling into it. Without this
+		// proto.Unmarshal dereferences the nil pointer and panics.
+		var zero T
+
+		// A non-concrete instantiation (T == proto.Message) has a nil interface
+		// zero value; calling ProtoReflect on it would panic, so reject it here.
+		if any(zero) == nil {
+			return fmt.Errorf("ydb: topicsugar: ProtobufIterator requires a concrete protobuf message type, got %T", zero)
+		}
+
+		msg, ok := zero.ProtoReflect().New().Interface().(T)
+		if !ok {
+			return fmt.Errorf("ydb: topicsugar: failed to allocate message of type %T", zero)
+		}
+		*dst = msg
+
 		return proto.Unmarshal(data, *dst)
 	}
 

--- a/topic/topicsugar/iterators_test.go
+++ b/topic/topicsugar/iterators_test.go
@@ -1,0 +1,139 @@
+//go:build go1.23
+
+package topicsugar
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/topic/topicreadercommon"
+	"github.com/ydb-platform/ydb-go-sdk/v3/topic/topicreader"
+)
+
+// messagesReader is a TopicMessageReader stub that yields the prepared messages
+// in order and then returns io.EOF.
+type messagesReader struct {
+	messages []*topicreader.Message
+	index    int
+}
+
+func (r *messagesReader) ReadMessage(context.Context) (*topicreader.Message, error) {
+	if r.index >= len(r.messages) {
+		return nil, io.EOF
+	}
+	msg := r.messages[r.index]
+	r.index++
+
+	return msg, nil
+}
+
+func messageWithData(t *testing.T, data []byte) *topicreader.Message {
+	t.Helper()
+
+	return topicreadercommon.NewPublicMessageBuilder().DataAndUncompressedSize(data).Build()
+}
+
+func TestProtobufIterator(t *testing.T) {
+	expected := timestamppb.New(time.Unix(1718000000, 0).UTC())
+	data, err := proto.Marshal(expected)
+	require.NoError(t, err)
+
+	reader := &messagesReader{
+		messages: []*topicreader.Message{messageWithData(t, data)},
+	}
+
+	var got *timestamppb.Timestamp
+	for msg, err := range ProtobufIterator[*timestamppb.Timestamp](context.Background(), reader) {
+		if err != nil {
+			require.ErrorIs(t, err, io.EOF)
+
+			break
+		}
+		got = msg.Data
+	}
+
+	require.NotNil(t, got)
+	require.True(t, proto.Equal(expected, got))
+}
+
+func TestProtobufIteratorMultipleMessages(t *testing.T) {
+	expected := []*timestamppb.Timestamp{
+		timestamppb.New(time.Unix(1718000000, 0).UTC()),
+		timestamppb.New(time.Unix(1719000000, 0).UTC()),
+		timestamppb.New(time.Unix(1720000000, 0).UTC()),
+	}
+
+	reader := &messagesReader{}
+	for _, ts := range expected {
+		data, err := proto.Marshal(ts)
+		require.NoError(t, err)
+		reader.messages = append(reader.messages, messageWithData(t, data))
+	}
+
+	var got []*timestamppb.Timestamp
+	for msg, err := range ProtobufIterator[*timestamppb.Timestamp](context.Background(), reader) {
+		if err != nil {
+			require.ErrorIs(t, err, io.EOF)
+
+			break
+		}
+		got = append(got, msg.Data)
+	}
+
+	require.Len(t, got, len(expected))
+	for i := range expected {
+		require.Truef(t, proto.Equal(expected[i], got[i]), "message %d mismatch", i)
+	}
+}
+
+func TestProtobufIteratorNonConcreteType(t *testing.T) {
+	data, err := proto.Marshal(timestamppb.New(time.Unix(1718000000, 0).UTC()))
+	require.NoError(t, err)
+
+	reader := &messagesReader{
+		messages: []*topicreader.Message{messageWithData(t, data)},
+	}
+
+	var iterErr error
+	for _, err := range ProtobufIterator[proto.Message](context.Background(), reader) {
+		if err != nil {
+			iterErr = err
+
+			break
+		}
+	}
+
+	require.Error(t, iterErr)
+}
+
+func TestProtobufIteratorMalformedData(t *testing.T) {
+	// 0x08 is the wire tag for field 1 as a varint, with no value following:
+	// proto.Unmarshal must fail rather than silently produce a message.
+	reader := &messagesReader{
+		messages: []*topicreader.Message{messageWithData(t, []byte{0x08})},
+	}
+
+	var (
+		iterErr error
+		yielded int
+	)
+	for msg, err := range ProtobufIterator[*timestamppb.Timestamp](context.Background(), reader) {
+		yielded++
+		if err != nil {
+			iterErr = err
+
+			break
+		}
+		_ = msg
+	}
+
+	require.Error(t, iterErr)
+	require.NotErrorIs(t, iterErr, io.EOF)
+	require.Equal(t, 1, yielded, "iterator must stop after the unmarshal error")
+}


### PR DESCRIPTION
<!--- Fix nil-message panic in ProtobufIterator and harden against non-concrete T -->

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

`ProtobufIterator[T]` unmarshaled each received message into the zero value of `T`. For a
`proto.Message` interface type, the zero value is a `nil` interface, and `proto.Unmarshal`
dereferences it via `Reset()` — so the iterator panicked on the very first received message.
Instantiating the iterator with the non-concrete `ProtobufIterator[proto.Message]` likewise
panicked on the nil interface receiver, with no usable error for the caller.

Issue Number: N/A

## What is the new behavior?

- A concrete message is now allocated via protobuf reflection before unmarshaling, so the
  happy path no longer panics on the first message.
- The non-concrete `ProtobufIterator[proto.Message]` instantiation is rejected with an error
  instead of panicking on the nil interface receiver.
- Documented that `T` must be a concrete generated message type.

## Other information

Adds the first tests for the `topicsugar` package, covering the happy path, multiple
messages, malformed data, and the non-concrete type rejection.
