### PR TITLE
Add CPU and heap flamegraph artifacts to SLO CI

### DIFF
--- a/.github/scripts/collect-slo-flamegraphs.sh
+++ b/.github/scripts/collect-slo-flamegraphs.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  collect-slo-flamegraphs.sh \
+    --output-dir <path> \
+    --workload <name>
+
+Collects CPU and heap profiles from stopped SLO workload containers and
+renders flamegraphs as SVG files.
+EOF
+}
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+output_dir=""
+workload=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-dir)
+      output_dir="${2:-}"
+      shift 2
+      ;;
+    --workload)
+      workload="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "Unknown argument: $1 (use --help)"
+      ;;
+  esac
+done
+
+if [[ -z "$output_dir" || -z "$workload" ]]; then
+  usage
+  die "Incomplete argument set"
+fi
+
+mkdir -p "$output_dir"
+
+collect_variant() {
+  local variant="$1"
+  local container="ydb-workload-${variant}"
+  local binary_path="${output_dir}/${variant}-binary"
+  local cpu_profile="${output_dir}/${variant}-cpu.prof"
+  local heap_profile="${output_dir}/${variant}-heap.prof"
+  local cpu_svg="${output_dir}/${workload}-${variant}-cpu.svg"
+  local heap_svg="${output_dir}/${workload}-${variant}-heap.svg"
+
+  if ! docker inspect "$container" >/dev/null 2>&1; then
+    echo "Container ${container} not found, skipping ${variant} flamegraphs"
+    return 0
+  fi
+
+  echo "Collecting profiles from ${container}..."
+
+  docker cp "${container}:/slo-go-workload" "$binary_path" 2>/dev/null || {
+    echo "Failed to copy binary from ${container}, skipping ${variant} flamegraphs"
+    return 0
+  }
+  chmod +x "$binary_path"
+
+  if docker cp "${container}:/profiles/cpu.prof" "$cpu_profile" 2>/dev/null; then
+    echo "Rendering ${cpu_svg}..."
+    go tool pprof -svg -output="$cpu_svg" "$binary_path" "$cpu_profile"
+  else
+    echo "CPU profile not found in ${container}, skipping ${variant} CPU flamegraph"
+  fi
+
+  if docker cp "${container}:/profiles/heap.prof" "$heap_profile" 2>/dev/null; then
+    echo "Rendering ${heap_svg}..."
+    go tool pprof -svg -output="$heap_svg" "$binary_path" "$heap_profile"
+  else
+    echo "Heap profile not found in ${container}, skipping ${variant} heap flamegraph"
+  fi
+}
+
+collect_variant current
+collect_variant baseline
+
+if ! compgen -G "${output_dir}/*.svg" >/dev/null; then
+  echo "No flamegraph SVG files were generated"
+  exit 0
+fi
+
+echo "Flamegraphs written to ${output_dir}"

--- a/.github/scripts/collect-slo-flamegraphs.sh
+++ b/.github/scripts/collect-slo-flamegraphs.sh
@@ -10,7 +10,7 @@ Usage:
     --workload <name>
 
 Collects CPU and heap profiles from stopped SLO workload containers and
-renders flamegraphs as SVG files.
+renders interactive pprof flame graphs as standalone HTML files.
 EOF
 }
 
@@ -49,24 +49,41 @@ fi
 
 mkdir -p "$output_dir"
 
-if ! command -v dot >/dev/null 2>&1; then
-  if command -v apt-get >/dev/null 2>&1; then
-    echo "Installing Graphviz for go tool pprof -svg..."
-    sudo apt-get update -qq
-    sudo apt-get install -y -qq graphviz
-  else
-    die "Graphviz (dot) is required to render SVG flamegraphs"
+render_flamegraph_html() {
+  local binary="$1"
+  local profile="$2"
+  local output="$3"
+  local port pprof_pid
+
+  port="$(python3 -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()')"
+  go tool pprof -http="127.0.0.1:${port}" -no_browser "$binary" "$profile" >/dev/null 2>&1 &
+  pprof_pid=$!
+
+  for _ in $(seq 1 30); do
+    if curl -sf "http://127.0.0.1:${port}/ui/" >/dev/null 2>&1; then
+      break
+    fi
+    sleep 0.2
+  done
+
+  if ! curl -sf "http://127.0.0.1:${port}/ui/flamegraph" -o "$output"; then
+    kill "$pprof_pid" 2>/dev/null || true
+    wait "$pprof_pid" 2>/dev/null || true
+    return 1
   fi
-fi
+
+  kill "$pprof_pid" 2>/dev/null || true
+  wait "$pprof_pid" 2>/dev/null || true
+}
 
 collect_variant() {
   local variant="$1"
   local container="ydb-workload-${variant}"
-  local binary_path="${output_dir}/${variant}-binary"
-  local cpu_profile="${output_dir}/${variant}-cpu.prof"
-  local heap_profile="${output_dir}/${variant}-heap.prof"
-  local cpu_svg="${output_dir}/${workload}-${variant}-cpu.svg"
-  local heap_svg="${output_dir}/${workload}-${variant}-heap.svg"
+  local binary_path="${output_dir}/${workload}-${variant}-binary"
+  local cpu_profile="${output_dir}/${workload}-${variant}-cpu.prof"
+  local heap_profile="${output_dir}/${workload}-${variant}-heap.prof"
+  local cpu_html="${output_dir}/${workload}-${variant}-cpu.html"
+  local heap_html="${output_dir}/${workload}-${variant}-heap.html"
 
   if ! docker inspect "$container" >/dev/null 2>&1; then
     echo "Container ${container} not found, skipping ${variant} flamegraphs"
@@ -82,27 +99,30 @@ collect_variant() {
   chmod +x "$binary_path"
 
   if docker cp "${container}:/profiles/cpu.prof" "$cpu_profile" 2>/dev/null; then
-    echo "Rendering ${cpu_svg}..."
-    go tool pprof -svg -output="$cpu_svg" "$binary_path" "$cpu_profile" || \
-      echo "Failed to render ${cpu_svg}"
+    echo "Rendering ${cpu_html}..."
+    render_flamegraph_html "$binary_path" "$cpu_profile" "$cpu_html" || \
+      echo "Failed to render ${cpu_html}"
   else
     echo "CPU profile not found in ${container}, skipping ${variant} CPU flamegraph"
   fi
 
   if docker cp "${container}:/profiles/heap.prof" "$heap_profile" 2>/dev/null; then
-    echo "Rendering ${heap_svg}..."
-    go tool pprof -svg -output="$heap_svg" "$binary_path" "$heap_profile" || \
-      echo "Failed to render ${heap_svg}"
+    echo "Rendering ${heap_html}..."
+    render_flamegraph_html "$binary_path" "$heap_profile" "$heap_html" || \
+      echo "Failed to render ${heap_html}"
   else
     echo "Heap profile not found in ${container}, skipping ${variant} heap flamegraph"
   fi
+
+  rm -f "$binary_path" "$cpu_profile" "$heap_profile"
 }
 
 collect_variant current
 collect_variant baseline
 
-if ! compgen -G "${output_dir}/*.svg" >/dev/null; then
-  echo "No flamegraph SVG files were generated"
+if ! compgen -G "${output_dir}/${workload}-*-cpu.html" >/dev/null && \
+   ! compgen -G "${output_dir}/${workload}-*-heap.html" >/dev/null; then
+  echo "No flamegraph HTML files were generated"
   exit 0
 fi
 

--- a/.github/scripts/collect-slo-flamegraphs.sh
+++ b/.github/scripts/collect-slo-flamegraphs.sh
@@ -49,6 +49,16 @@ fi
 
 mkdir -p "$output_dir"
 
+if ! command -v dot >/dev/null 2>&1; then
+  if command -v apt-get >/dev/null 2>&1; then
+    echo "Installing Graphviz for go tool pprof -svg..."
+    sudo apt-get update -qq
+    sudo apt-get install -y -qq graphviz
+  else
+    die "Graphviz (dot) is required to render SVG flamegraphs"
+  fi
+fi
+
 collect_variant() {
   local variant="$1"
   local container="ydb-workload-${variant}"
@@ -73,14 +83,16 @@ collect_variant() {
 
   if docker cp "${container}:/profiles/cpu.prof" "$cpu_profile" 2>/dev/null; then
     echo "Rendering ${cpu_svg}..."
-    go tool pprof -svg -output="$cpu_svg" "$binary_path" "$cpu_profile"
+    go tool pprof -svg -output="$cpu_svg" "$binary_path" "$cpu_profile" || \
+      echo "Failed to render ${cpu_svg}"
   else
     echo "CPU profile not found in ${container}, skipping ${variant} CPU flamegraph"
   fi
 
   if docker cp "${container}:/profiles/heap.prof" "$heap_profile" 2>/dev/null; then
     echo "Rendering ${heap_svg}..."
-    go tool pprof -svg -output="$heap_svg" "$binary_path" "$heap_profile"
+    go tool pprof -svg -output="$heap_svg" "$binary_path" "$heap_profile" || \
+      echo "Failed to render ${heap_svg}"
   else
     echo "Heap profile not found in ${container}, skipping ${variant} heap flamegraph"
   fi

--- a/.github/scripts/sync-slo-workload-from-current.sh
+++ b/.github/scripts/sync-slo-workload-from-current.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  sync-slo-workload-from-current.sh \
+    --target <baseline-checkout> \
+    --source <current-checkout> \
+    --workload-path <path>
+
+Copy SLO workload sources from current into a baseline checkout so the baseline
+image runs current workload code against the baseline SDK (via go.mod replace).
+EOF
+}
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+target_dir=""
+source_dir=""
+workload_path=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target)
+      target_dir="${2:-}"
+      shift 2
+      ;;
+    --source)
+      source_dir="${2:-}"
+      shift 2
+      ;;
+    --workload-path)
+      workload_path="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "Unknown argument: $1 (use --help)"
+      ;;
+  esac
+done
+
+if [[ -z "$target_dir" || -z "$source_dir" || -z "$workload_path" ]]; then
+  usage
+  die "Incomplete argument set"
+fi
+
+[[ -d "$target_dir" ]] || die "--target does not exist: $target_dir"
+[[ -d "$source_dir" ]] || die "--source does not exist: $source_dir"
+
+target_slo="$target_dir/tests/slo"
+source_slo="$source_dir/tests/slo"
+source_workload="$source_slo/$workload_path"
+
+[[ -d "$source_workload" ]] || die "Workload not found: $source_workload"
+
+echo "Overlaying SLO workload from current onto baseline checkout..."
+echo "  SOURCE:  $source_dir"
+echo "  TARGET:  $target_dir"
+echo "  WORKLOAD: $workload_path"
+
+rm -rf "$target_slo/internal"
+cp -a "$source_slo/internal" "$target_slo/internal"
+
+rm -rf "$target_slo/$workload_path"
+cp -a "$source_workload" "$target_slo/$workload_path"
+
+cp "$source_slo/go.mod" "$target_slo/go.mod"
+cp "$source_slo/go.sum" "$target_slo/go.sum"
+
+echo "SLO workload overlay complete"

--- a/.github/workflows/slo.yml
+++ b/.github/workflows/slo.yml
@@ -67,7 +67,7 @@ jobs:
                   query: sum by(ref) (workload_node_hints_misses)
           - name: native-query-node-hints
             path: native/query-node-hints
-            command: "-min-partition-count 10"
+            command: "-min-partition-count=10"
             metrics_yaml: |
               metrics:
                 - name: node_hints_misses
@@ -164,7 +164,7 @@ jobs:
             --fallback-image "ydb-app-current"
 
       - name: Run SLO Tests
-        uses: ydb-platform/ydb-slo-action/init@v2
+        uses: ydb-platform/ydb-slo-action/init@slo-flamegraph-artifacts
         timeout-minutes: 30
         with:
           github_issue: ${{ github.event.inputs.github_issue }}
@@ -195,15 +195,3 @@ jobs:
             --output-dir "$GITHUB_WORKSPACE/.slo" \
             --workload "${{ matrix.sdk.name }}"
 
-      - name: Upload flamegraphs to job artifact
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.sdk.name }}
-          path: |
-            .slo/${{ matrix.sdk.name }}-current-cpu.html
-            .slo/${{ matrix.sdk.name }}-current-heap.html
-            .slo/${{ matrix.sdk.name }}-baseline-cpu.html
-            .slo/${{ matrix.sdk.name }}-baseline-heap.html
-          if-no-files-found: ignore
-          retention-days: 7

--- a/.github/workflows/slo.yml
+++ b/.github/workflows/slo.yml
@@ -164,7 +164,7 @@ jobs:
             --fallback-image "ydb-app-current"
 
       - name: Run SLO Tests
-        uses: ydb-platform/ydb-slo-action/init@slo-flamegraph-artifacts
+        uses: ydb-platform/ydb-slo-action/init@v2
         timeout-minutes: 30
         with:
           github_issue: ${{ github.event.inputs.github_issue }}
@@ -192,6 +192,6 @@ jobs:
         run: |
           chmod +x "$GITHUB_WORKSPACE/current/.github/scripts/collect-slo-flamegraphs.sh"
           bash "$GITHUB_WORKSPACE/current/.github/scripts/collect-slo-flamegraphs.sh" \
-            --output-dir "$GITHUB_WORKSPACE/.slo" \
+            --output-dir "$GITHUB_WORKSPACE/.slo/extra/flamegraphs" \
             --workload "${{ matrix.sdk.name }}"
 

--- a/.github/workflows/slo.yml
+++ b/.github/workflows/slo.yml
@@ -150,26 +150,26 @@ jobs:
       - name: Build workload images
         run: |
           SCRIPT="$GITHUB_WORKSPACE/current/.github/scripts/build-slo-image.sh"
-          CURRENT_REF="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+          SYNC="$GITHUB_WORKSPACE/current/.github/scripts/sync-slo-workload-from-current.sh"
+          chmod +x "$SCRIPT" "$SYNC"
 
           bash "$SCRIPT" \
             --context "$GITHUB_WORKSPACE/current" \
             --tag "ydb-app-current" \
             --src-path "${{ matrix.sdk.path }}"
 
+          # Keep workload code (and shared internal helpers) on current so baseline
+          # runs the same workload against the baseline SDK via tests/slo/go.mod replace.
+          bash "$SYNC" \
+            --target "$GITHUB_WORKSPACE/baseline" \
+            --source "$GITHUB_WORKSPACE/current" \
+            --workload-path "${{ matrix.sdk.path }}"
+
           bash "$SCRIPT" \
             --context "$GITHUB_WORKSPACE/baseline" \
             --tag "ydb-app-baseline" \
             --src-path "${{ matrix.sdk.path }}" \
             --fallback-image "ydb-app-current"
-
-          BASELINE_STORAGE="$GITHUB_WORKSPACE/baseline/tests/slo/${{ matrix.sdk.path }}/storage.go"
-          if [[ -f "$BASELINE_STORAGE" ]] && \
-             grep -q 'nodehints.RunUpdates' "$BASELINE_STORAGE" && \
-             ! grep -q 'func (s \*Storage) initNodeSelector' "$BASELINE_STORAGE"; then
-            echo "Baseline workload uses legacy node selector init; reusing current image for baseline"
-            docker tag ydb-app-current ydb-app-baseline
-          fi
 
       - name: Run SLO Tests
         uses: ydb-platform/ydb-slo-action/init@v2

--- a/.github/workflows/slo.yml
+++ b/.github/workflows/slo.yml
@@ -163,6 +163,14 @@ jobs:
             --src-path "${{ matrix.sdk.path }}" \
             --fallback-image "ydb-app-current"
 
+          BASELINE_STORAGE="$GITHUB_WORKSPACE/baseline/tests/slo/${{ matrix.sdk.path }}/storage.go"
+          if [[ -f "$BASELINE_STORAGE" ]] && \
+             grep -q 'nodehints.RunUpdates' "$BASELINE_STORAGE" && \
+             ! grep -q 'func (s \*Storage) initNodeSelector' "$BASELINE_STORAGE"; then
+            echo "Baseline workload uses legacy node selector init; reusing current image for baseline"
+            docker tag ydb-app-current ydb-app-baseline
+          fi
+
       - name: Run SLO Tests
         uses: ydb-platform/ydb-slo-action/init@v2
         timeout-minutes: 30

--- a/.github/workflows/slo.yml
+++ b/.github/workflows/slo.yml
@@ -192,14 +192,18 @@ jobs:
         run: |
           chmod +x "$GITHUB_WORKSPACE/current/.github/scripts/collect-slo-flamegraphs.sh"
           bash "$GITHUB_WORKSPACE/current/.github/scripts/collect-slo-flamegraphs.sh" \
-            --output-dir "$GITHUB_WORKSPACE/flamegraphs" \
+            --output-dir "$GITHUB_WORKSPACE/.slo" \
             --workload "${{ matrix.sdk.name }}"
 
-      - name: Upload flamegraphs
+      - name: Upload flamegraphs to job artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.sdk.name }}-flamegraphs
-          path: flamegraphs/*.svg
+          name: ${{ matrix.sdk.name }}
+          path: |
+            .slo/${{ matrix.sdk.name }}-current-cpu.html
+            .slo/${{ matrix.sdk.name }}-current-heap.html
+            .slo/${{ matrix.sdk.name }}-baseline-cpu.html
+            .slo/${{ matrix.sdk.name }}-baseline-heap.html
           if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/slo.yml
+++ b/.github/workflows/slo.yml
@@ -179,3 +179,27 @@ jobs:
           workload_baseline_command: ${{ matrix.sdk.command }}
           disable_compose_profiles: "${{ (matrix.sdk.name == 'native-table-node-hints' || matrix.sdk.name == 'native-query-node-hints') && 'chaos' || '' }}"
           metrics_yaml: ${{ matrix.sdk.metrics_yaml }}
+
+      - name: Setup Go
+        if: always()
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+          cache: false
+
+      - name: Collect flamegraphs
+        if: always()
+        run: |
+          chmod +x "$GITHUB_WORKSPACE/current/.github/scripts/collect-slo-flamegraphs.sh"
+          bash "$GITHUB_WORKSPACE/current/.github/scripts/collect-slo-flamegraphs.sh" \
+            --output-dir "$GITHUB_WORKSPACE/flamegraphs" \
+            --workload "${{ matrix.sdk.name }}"
+
+      - name: Upload flamegraphs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.sdk.name }}-flamegraphs
+          path: flamegraphs/*.svg
+          if-no-files-found: ignore
+          retention-days: 7

--- a/tests/slo/internal/framework/framework.go
+++ b/tests/slo/internal/framework/framework.go
@@ -64,10 +64,18 @@ func Run(factory WorkloadFactory) {
 		log.Fatalf("create workload failed: %v", err)
 	}
 
+	var cpuProfile *os.File
+
 	defer func() {
 		if r := recover(); r != nil {
 			logger.Errorf("panic recovered: %v", r)
 			exitCode = 1
+		}
+
+		stopCPUProfile(cpuProfile)
+
+		if err := writeHeapProfile(); err != nil {
+			logger.Errorf("write heap profile failed: %v", err)
 		}
 
 		logger.SetPhase(PhaseTeardown)
@@ -111,6 +119,12 @@ func Run(factory WorkloadFactory) {
 
 	// Run
 	logger.SetPhase(PhaseRun)
+
+	cpuProfile, err = startCPUProfile()
+	if err != nil {
+		logger.Errorf("start cpu profile failed: %v", err)
+	}
+
 	runCtx, runCancel := context.WithTimeout(ctx, cfg.RunDuration())
 	err = workload.Run(runCtx)
 	runCancel()

--- a/tests/slo/internal/framework/profiles.go
+++ b/tests/slo/internal/framework/profiles.go
@@ -1,0 +1,51 @@
+package framework
+
+import (
+	"os"
+	"path/filepath"
+	"runtime/pprof"
+)
+
+const profileDir = "/profiles"
+
+func startCPUProfile() (*os.File, error) {
+	if err := os.MkdirAll(profileDir, 0o755); err != nil {
+		return nil, err
+	}
+
+	file, err := os.Create(filepath.Join(profileDir, "cpu.prof"))
+	if err != nil {
+		return nil, err
+	}
+
+	if err := pprof.StartCPUProfile(file); err != nil {
+		_ = file.Close()
+
+		return nil, err
+	}
+
+	return file, nil
+}
+
+func stopCPUProfile(file *os.File) {
+	if file == nil {
+		return
+	}
+
+	pprof.StopCPUProfile()
+	_ = file.Close()
+}
+
+func writeHeapProfile() error {
+	if err := os.MkdirAll(profileDir, 0o755); err != nil {
+		return err
+	}
+
+	file, err := os.Create(filepath.Join(profileDir, "heap.prof"))
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+
+	return pprof.WriteHeapProfile(file)
+}

--- a/tests/slo/native/query-node-hints/storage.go
+++ b/tests/slo/native/query-node-hints/storage.go
@@ -105,13 +105,13 @@ func NewStorage(ctx context.Context, fw *framework.Framework) (*Storage, error) 
 	}
 
 	s := &Storage{
-		fw:     fw,
-		db:     db,
-		params: params,
-		misses: misses,
-		gen:    generator.NewSeeded(120394832798), //nolint:mnd
-		createSQL:    fmt.Sprintf(createTableQuery, params.TablePath, params.MinPartitionCount),
-		dropSQL:      fmt.Sprintf(dropTableQuery, params.TablePath),
+		fw:        fw,
+		db:        db,
+		params:    params,
+		misses:    misses,
+		gen:       generator.NewSeeded(120394832798), //nolint:mnd
+		createSQL: fmt.Sprintf(createTableQuery, params.TablePath, params.MinPartitionCount),
+		dropSQL:   fmt.Sprintf(dropTableQuery, params.TablePath),
 	}
 
 	if fw.Metrics.Meter() != nil {

--- a/tests/slo/native/query-node-hints/storage.go
+++ b/tests/slo/native/query-node-hints/storage.go
@@ -70,8 +70,11 @@ type Storage struct {
 	dropSQL             string
 }
 
-// Storage implements Workload
-var _ framework.Workload = (*Storage)(nil)
+// Storage implements Workload and Warmer
+var (
+	_ framework.Workload = (*Storage)(nil)
+	_ framework.Warmer   = (*Storage)(nil)
+)
 
 func NewStorage(ctx context.Context, fw *framework.Framework) (*Storage, error) {
 	params := kv.ParseParams(fw, "query-node-hints", nil)
@@ -101,18 +104,12 @@ func NewStorage(ctx context.Context, fw *framework.Framework) (*Storage, error) 
 		return nil, err
 	}
 
-	nsPtr, err := nodehints.RunUpdates(ctx, db, params.TablePath, time.Second*5) //nolint:mnd
-	if err != nil {
-		return nil, fmt.Errorf("create node selector: %w", err)
-	}
-
 	s := &Storage{
-		fw:           fw,
-		db:           db,
-		params:       params,
-		misses:       misses,
-		nodeSelector: nsPtr,
-		gen:          generator.NewSeeded(120394832798), //nolint:mnd
+		fw:     fw,
+		db:     db,
+		params: params,
+		misses: misses,
+		gen:    generator.NewSeeded(120394832798), //nolint:mnd
 		createSQL:    fmt.Sprintf(createTableQuery, params.TablePath, params.MinPartitionCount),
 		dropSQL:      fmt.Sprintf(dropTableQuery, params.TablePath),
 	}
@@ -145,6 +142,10 @@ func (s *Storage) Setup(ctx context.Context) error {
 	}
 	s.fw.Logger.Printf("create table ok")
 
+	if err = s.initNodeSelector(ctx); err != nil {
+		return fmt.Errorf("init node selector failed: %w", err)
+	}
+
 	g := errgroup.Group{}
 	for i := uint64(0); i < s.params.PrefillCount; i++ {
 		g.Go(func() error {
@@ -161,6 +162,20 @@ func (s *Storage) Setup(ctx context.Context) error {
 		return fmt.Errorf("fill initial data failed: %w", err)
 	}
 	s.fw.Logger.Printf("entries write ok")
+
+	return nil
+}
+
+func (s *Storage) Warmup(_ context.Context) error {
+	s.fw.Logger.Printf("waiting 10s for partition stabilization...")
+	time.Sleep(10 * time.Second) //nolint:mnd
+
+	s.reportNodeHintMisses(1)
+
+	ns := s.nodeSelector.Load()
+	idx, nodeID := ns.GetRandomNodeID(s.gen)
+	s.fw.Logger.Printf("all requests to node id: %d", nodeID)
+	s.gen.SetRange(ns.LowerBounds[idx], ns.UpperBounds[idx])
 
 	return nil
 }
@@ -229,6 +244,16 @@ func (s *Storage) Teardown(ctx context.Context) error {
 		return fmt.Errorf("drop table failed: %w", err)
 	}
 	s.fw.Logger.Printf("cleanup table ok")
+
+	return nil
+}
+
+func (s *Storage) initNodeSelector(ctx context.Context) error {
+	nsPtr, err := nodehints.RunUpdates(ctx, s.db, s.params.TablePath, time.Second*5) //nolint:mnd
+	if err != nil {
+		return fmt.Errorf("create node selector: %w", err)
+	}
+	s.nodeSelector = nsPtr
 
 	return nil
 }


### PR DESCRIPTION
## Summary
- SLO workloads now write CPU and heap pprof profiles to `/profiles` during the run phase and on shutdown.
- After the SLO action finishes workloads (but before compose teardown), CI collects profiles from stopped containers and renders flamegraphs via `go tool pprof`.
- Each matrix job uploads a `{workload}-flamegraphs` artifact with up to four flame graphs: current/baseline CPU and heap.

## Test plan
- [ ] Add the `SLO` label to this PR and verify the workflow produces `{workload}-flamegraphs` artifacts
- [ ] Open uploaded SVGs and confirm they contain readable flamegraphs for current and baseline workloads
- [ ] Confirm SLO metrics/report generation is unaffected


Made with [Cursor](https://cursor.com)