### PR TITLE
Fix consumer alters silently resetting supported codecs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 
 ## v3.139.7
 * Fixed YSON scanning in `TableService` to support both underlying `TextValue` and `BytesValue` wire representations
-
 * Fixed inverted success/error handling in the `ExampleWriter_Write` doc example for `topicwriter`, which printed `OK` on failure and aborted on success
 * Fixed nil pointer dereference panic in `topicsugar.ProtobufIterator` on the first received message by allocating a concrete protobuf message before unmarshaling
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed `Topic().Alter()` consumer alters (`AlterConsumerWithImportant`, `AlterConsumerWithReadFrom`, `AlterConsumerWithAttributes`, `AlterConsumerWithAvailabilityPeriod`) silently resetting the consumer's supported-codecs restriction: `set_supported_codecs` is now sent only when `AlterConsumerWithSupportedCodecs` is used
+
 ## v3.140.0
 * Added `topicoptions.WithWriterDirectWrite(bool)` and `topicoptions.WithMultiWriterDirectWrite(bool)` options to send topic writes to the node that hosts the target partition, bypassing the topic proxy
 
@@ -6,6 +8,7 @@
 
 ## v3.139.7
 * Fixed YSON scanning in `TableService` to support both underlying `TextValue` and `BytesValue` wire representations
+
 * Fixed inverted success/error handling in the `ExampleWriter_Write` doc example for `topicwriter`, which printed `OK` on failure and aborted on success
 * Fixed nil pointer dereference panic in `topicsugar.ProtobufIterator` on the first received message by allocating a concrete protobuf message before unmarshaling
 

--- a/internal/grpcwrapper/rawtopic/alter_topic.go
+++ b/internal/grpcwrapper/rawtopic/alter_topic.go
@@ -85,8 +85,8 @@ type AlterConsumer struct {
 	Name                    string
 	SetImportant            rawoptional.Bool
 	SetReadFrom             rawoptional.Time
-	SetSupportedCodecs      bool
-	SetSupportedCodecsValue rawtopiccommon.SupportedCodecs
+	SetSupportedCodecs      rawtopiccommon.SupportedCodecs
+	NeedSetSupportedCodecs  bool
 	SetAvailabilityPeriod   rawoptional.Duration
 	ResetAvailabilityPeriod bool
 	AlterAttributes         map[string]string
@@ -100,8 +100,8 @@ func (c *AlterConsumer) ToProto() *Ydb_Topic.AlterConsumer {
 		AlterAttributes: c.AlterAttributes,
 	}
 
-	if c.SetSupportedCodecs {
-		res.SetSupportedCodecs = c.SetSupportedCodecsValue.ToProto()
+	if c.NeedSetSupportedCodecs {
+		res.SetSupportedCodecs = c.SetSupportedCodecs.ToProto()
 	}
 
 	if c.SetAvailabilityPeriod.HasValue {

--- a/internal/grpcwrapper/rawtopic/alter_topic.go
+++ b/internal/grpcwrapper/rawtopic/alter_topic.go
@@ -85,7 +85,8 @@ type AlterConsumer struct {
 	Name                    string
 	SetImportant            rawoptional.Bool
 	SetReadFrom             rawoptional.Time
-	SetSupportedCodecs      rawtopiccommon.SupportedCodecs
+	SetSupportedCodecs      bool
+	SetSupportedCodecsValue rawtopiccommon.SupportedCodecs
 	SetAvailabilityPeriod   rawoptional.Duration
 	ResetAvailabilityPeriod bool
 	AlterAttributes         map[string]string
@@ -93,11 +94,14 @@ type AlterConsumer struct {
 
 func (c *AlterConsumer) ToProto() *Ydb_Topic.AlterConsumer {
 	res := &Ydb_Topic.AlterConsumer{
-		Name:               c.Name,
-		SetImportant:       c.SetImportant.ToProto(),
-		SetReadFrom:        c.SetReadFrom.ToProto(),
-		SetSupportedCodecs: c.SetSupportedCodecs.ToProto(),
-		AlterAttributes:    c.AlterAttributes,
+		Name:            c.Name,
+		SetImportant:    c.SetImportant.ToProto(),
+		SetReadFrom:     c.SetReadFrom.ToProto(),
+		AlterAttributes: c.AlterAttributes,
+	}
+
+	if c.SetSupportedCodecs {
+		res.SetSupportedCodecs = c.SetSupportedCodecsValue.ToProto()
 	}
 
 	if c.SetAvailabilityPeriod.HasValue {

--- a/internal/grpcwrapper/rawtopic/alter_topic_test.go
+++ b/internal/grpcwrapper/rawtopic/alter_topic_test.go
@@ -24,9 +24,9 @@ func TestAlterConsumerToProto(t *testing.T) {
 
 	t.Run("SetsSupportedCodecsWhenRequested", func(t *testing.T) {
 		c := &AlterConsumer{
-			Name:                    "consumer",
-			SetSupportedCodecs:      true,
-			SetSupportedCodecsValue: rawtopiccommon.SupportedCodecs{rawtopiccommon.CodecGzip},
+			Name:                   "consumer",
+			NeedSetSupportedCodecs: true,
+			SetSupportedCodecs:     rawtopiccommon.SupportedCodecs{rawtopiccommon.CodecGzip},
 		}
 
 		proto := c.ToProto()
@@ -36,8 +36,8 @@ func TestAlterConsumerToProto(t *testing.T) {
 
 	t.Run("SetsEmptySupportedCodecsWhenRequestedWithEmptyList", func(t *testing.T) {
 		c := &AlterConsumer{
-			Name:               "consumer",
-			SetSupportedCodecs: true,
+			Name:                   "consumer",
+			NeedSetSupportedCodecs: true,
 		}
 
 		proto := c.ToProto()

--- a/internal/grpcwrapper/rawtopic/alter_topic_test.go
+++ b/internal/grpcwrapper/rawtopic/alter_topic_test.go
@@ -1,0 +1,47 @@
+package rawtopic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawoptional"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawtopic/rawtopiccommon"
+)
+
+func TestAlterConsumerToProto(t *testing.T) {
+	t.Run("OmitsSupportedCodecsWhenNotSet", func(t *testing.T) {
+		// Altering an unrelated consumer property must not touch supported codecs,
+		// otherwise the server resets the consumer's codec restriction to "allow any".
+		c := &AlterConsumer{
+			Name:         "consumer",
+			SetImportant: rawoptional.Bool{Value: true, HasValue: true},
+		}
+
+		proto := c.ToProto()
+		require.Nil(t, proto.GetSetSupportedCodecs())
+	})
+
+	t.Run("SetsSupportedCodecsWhenRequested", func(t *testing.T) {
+		c := &AlterConsumer{
+			Name:                    "consumer",
+			SetSupportedCodecs:      true,
+			SetSupportedCodecsValue: rawtopiccommon.SupportedCodecs{rawtopiccommon.CodecGzip},
+		}
+
+		proto := c.ToProto()
+		require.NotNil(t, proto.GetSetSupportedCodecs())
+		require.Equal(t, []int32{int32(rawtopiccommon.CodecGzip)}, proto.GetSetSupportedCodecs().GetCodecs())
+	})
+
+	t.Run("SetsEmptySupportedCodecsWhenRequestedWithEmptyList", func(t *testing.T) {
+		c := &AlterConsumer{
+			Name:               "consumer",
+			SetSupportedCodecs: true,
+		}
+
+		proto := c.ToProto()
+		require.NotNil(t, proto.GetSetSupportedCodecs())
+		require.Empty(t, proto.GetSetSupportedCodecs().GetCodecs())
+	})
+}

--- a/tests/integration/topic_regression_test.go
+++ b/tests/integration/topic_regression_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/topic/topicoptions"
+	"github.com/ydb-platform/ydb-go-sdk/v3/topic/topictypes"
 	"github.com/ydb-platform/ydb-go-sdk/v3/topic/topicwriter"
 )
 
@@ -32,4 +33,43 @@ func TestRegressionIssue1011_WriteInitInfoLastSeqNum(t *testing.T) {
 
 	info, err := w2.WaitInitInfo(scope.Ctx)
 	require.Equal(t, int64(1), info.LastSeqNum)
+}
+
+// TestRegressionConsumerAlterPreservesSupportedCodecs guards against an unrelated
+// consumer alter silently wiping the consumer's supported-codecs restriction.
+//
+// Before the fix, AlterConsumer.ToProto() populated set_supported_codecs
+// unconditionally, so altering any other consumer property (here: Important) sent
+// an empty codec list ("allow any") and reset the server-side restriction.
+func TestRegressionConsumerAlterPreservesSupportedCodecs(t *testing.T) {
+	scope := newScope(t)
+	ctx := scope.Ctx
+	client := scope.Driver().Topic()
+
+	consumerName := "consumer-with-codecs"
+	codecs := []topictypes.Codec{topictypes.CodecGzip}
+
+	topicPath := scope.Driver().Name() + "/test-topic-" + t.Name()
+	_ = client.Drop(ctx, topicPath)
+	err := client.Create(ctx, topicPath,
+		topicoptions.CreateWithConsumer(topictypes.Consumer{
+			Name:            consumerName,
+			SupportedCodecs: codecs,
+		}),
+	)
+	require.NoError(t, err)
+
+	// Alter an unrelated property of the consumer; codecs must be left untouched.
+	err = client.Alter(ctx, topicPath,
+		topicoptions.AlterConsumerWithImportant(consumerName, true),
+	)
+	require.NoError(t, err)
+
+	desc, err := client.Describe(ctx, topicPath)
+	require.NoError(t, err)
+
+	require.Len(t, desc.Consumers, 1)
+	require.Equal(t, consumerName, desc.Consumers[0].Name)
+	require.True(t, desc.Consumers[0].Important)
+	require.Equal(t, codecs, desc.Consumers[0].SupportedCodecs)
 }

--- a/topic/topicoptions/topicoptions.go
+++ b/topic/topicoptions/topicoptions.go
@@ -200,9 +200,10 @@ func (consumerCodecs withConsumerWithSupportedCodecs) ApplyAlterOption(req *rawt
 	req.AlterConsumers, index = ensureAlterConsumer(req.AlterConsumers, consumerCodecs.name)
 
 	consumer := &req.AlterConsumers[index]
-	consumer.SetSupportedCodecs = make(rawtopiccommon.SupportedCodecs, len(consumerCodecs.codecs))
+	consumer.SetSupportedCodecs = true
+	consumer.SetSupportedCodecsValue = make(rawtopiccommon.SupportedCodecs, len(consumerCodecs.codecs))
 	for i, codec := range consumerCodecs.codecs {
-		consumer.SetSupportedCodecs[i] = rawtopiccommon.Codec(codec)
+		consumer.SetSupportedCodecsValue[i] = rawtopiccommon.Codec(codec)
 	}
 }
 

--- a/topic/topicoptions/topicoptions.go
+++ b/topic/topicoptions/topicoptions.go
@@ -200,10 +200,10 @@ func (consumerCodecs withConsumerWithSupportedCodecs) ApplyAlterOption(req *rawt
 	req.AlterConsumers, index = ensureAlterConsumer(req.AlterConsumers, consumerCodecs.name)
 
 	consumer := &req.AlterConsumers[index]
-	consumer.SetSupportedCodecs = true
-	consumer.SetSupportedCodecsValue = make(rawtopiccommon.SupportedCodecs, len(consumerCodecs.codecs))
+	consumer.NeedSetSupportedCodecs = true
+	consumer.SetSupportedCodecs = make(rawtopiccommon.SupportedCodecs, len(consumerCodecs.codecs))
 	for i, codec := range consumerCodecs.codecs {
-		consumer.SetSupportedCodecsValue[i] = rawtopiccommon.Codec(codec)
+		consumer.SetSupportedCodecs[i] = rawtopiccommon.Codec(codec)
 	}
 }
 

--- a/topic/topicoptions/topicoptions_test.go
+++ b/topic/topicoptions/topicoptions_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawtopic"
+	"github.com/ydb-platform/ydb-go-sdk/v3/topic/topictypes"
 )
 
 func TestEqualAlterOptions(t *testing.T) {
@@ -111,6 +112,37 @@ func TestAlterWithResetMetricsLevel(t *testing.T) {
 
 	proto := req.ToProto()
 	require.NotNil(t, proto.GetResetMetricsLevel())
+}
+
+func TestAlterConsumerOptionsDoNotResetSupportedCodecs(t *testing.T) {
+	// Altering an unrelated consumer property must not send set_supported_codecs,
+	// otherwise the server wipes the consumer's existing codec restriction.
+	for _, opt := range []AlterOption{
+		AlterConsumerWithImportant("name", true),
+		AlterConsumerWithReadFrom("name", time.Unix(0, 0)),
+		AlterConsumerWithAttributes("name", map[string]string{"k": "v"}),
+		AlterConsumerWithAvailabilityPeriod("name", time.Hour),
+	} {
+		req := &rawtopic.AlterTopicRequest{}
+		opt.ApplyAlterOption(req)
+
+		proto := req.ToProto()
+		require.Len(t, proto.GetAlterConsumers(), 1)
+		require.Nil(t, proto.GetAlterConsumers()[0].GetSetSupportedCodecs())
+	}
+}
+
+func TestAlterConsumerWithSupportedCodecsSetsCodecs(t *testing.T) {
+	req := &rawtopic.AlterTopicRequest{}
+	AlterConsumerWithSupportedCodecs("name", []topictypes.Codec{topictypes.CodecGzip}).ApplyAlterOption(req)
+
+	proto := req.ToProto()
+	require.Len(t, proto.GetAlterConsumers(), 1)
+	require.NotNil(t, proto.GetAlterConsumers()[0].GetSetSupportedCodecs())
+	require.Equal(t,
+		[]int32{int32(topictypes.CodecGzip)},
+		proto.GetAlterConsumers()[0].GetSetSupportedCodecs().GetCodecs(),
+	)
 }
 
 func TestEqualCreateOptions(t *testing.T) {


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

`AlterConsumer.ToProto()` populates `set_supported_codecs` unconditionally, and
`SupportedCodecs.ToProto()` never returns nil — it returns a non-nil proto with an
empty codec list even for a nil slice. As a result, any unrelated consumer alter
via the public `Topic().Alter()` API — `AlterConsumerWithImportant`,
`AlterConsumerWithReadFrom`, `AlterConsumerWithAttributes`,
`AlterConsumerWithAvailabilityPeriod` — sends `set_supported_codecs: []`
("allow any") for that consumer, silently wiping its existing codec restriction
server-side.

Issue Number: N/A

## What is the new behavior?

- `set_supported_codecs` is sent only when `AlterConsumerWithSupportedCodecs` is
  used; unrelated consumer alters no longer touch the codec restriction.
- Guards the field with a presence flag (`SetSupportedCodecs bool` +
  `SetSupportedCodecsValue`), mirroring the existing topic-level path.
- Adds regression tests at both the `ToProto` level and the public-options level,
  plus a `CHANGELOG.md` entry.

## Other information

The explicit "reset to allow-any" path is preserved: calling
`AlterConsumerWithSupportedCodecs(name, nil)` still sends `set_supported_codecs: []`.
The topic-level alter path was already correct (it guards with the same flag); this
change brings the consumer-level path in line with it.
