### PR TITLE
Mask access tokens in topic writer gRPC debug logs

### DIFF
--- a/.agents/context/techContext.md
+++ b/.agents/context/techContext.md
@@ -59,6 +59,18 @@ go test -race -tags integration ./tests/integration
 
 `no lint`, `no tests`, `no integration tests`, `no changelog`, `no examples`, `broken changes`
 
+## Changelog (unreleased)
+
+User-facing PRs add bullets **at the very top** of `CHANGELOG.md` — **before** any `## vX.Y.Z` header. Do **not** edit an existing version section; `publish.yml` assigns the version at release.
+
+```markdown
+* Fixed …
+
+## v3.139.7
+```
+
+Details: [`.agents/rules/changelog.md`](../rules/changelog.md).
+
 ## Dependencies
 
 Do not run `go mod tidy` or `go get` unless the task requires it.

--- a/.agents/rules/changelog.md
+++ b/.agents/rules/changelog.md
@@ -15,10 +15,15 @@ Internal refactoring, agent docs, or non-observable changes: add PR label **`no 
 2. **Insert at the very top** of `CHANGELOG.md`, before existing entries (including before `## v3.x.x` headers).
 3. **No version number** — versions are assigned at release (`.github/workflows/publish.yml`).
 
-Example:
+**Do not** append bullets under the latest `## v3.x.x` section — that section is already released.
+
+Example (file start):
 
 ```markdown
 * Added `query.WithLazyTx(bool)` option for `query.Client.DoTx` calls to enable/disable lazy transactions per operation
+
+## v3.139.7
+* …
 ```
 
 ## Release process (maintainer)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Masked access tokens in topic gRPC debug logs for `UpdateTokenRequest` messages
+
 ## v3.139.7
 * Fixed YSON scanning in `TableService` to support both underlying `TextValue` and `BytesValue` wire representations
 * Fixed inverted success/error handling in the `ExampleWriter_Write` doc example for `topicwriter`, which printed `OK` on failure and aborted on success

--- a/internal/secret/token.go
+++ b/internal/secret/token.go
@@ -8,6 +8,11 @@ import (
 
 const minTokenLength = 16
 
+// Token returns a redacted representation of token safe for logs and error messages.
+// Tokens longer than 16 bytes keep the first and last four characters with the middle
+// replaced by "****"; shorter tokens are fully replaced by "****".
+// A CRC-32c checksum of the original value is appended so identical tokens can be
+// correlated in logs without exposing the secret.
 func Token(token string) string {
 	var mask bytes.Buffer
 	if len(token) > minTokenLength {

--- a/log/topic.go
+++ b/log/topic.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/kv"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/secret"
 	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
 )
 
@@ -1316,9 +1317,14 @@ func (s lazyProtoStringifer) String() string {
 				}
 			}()
 		}
+		if updateToken, ok := writeRequest.GetClientMessage().(*Ydb_Topic.StreamWriteMessage_FromClient_UpdateTokenRequest); ok {
+			token := updateToken.UpdateTokenRequest.GetToken()
+			updateToken.UpdateTokenRequest.Token = secret.Token(token)
+			defer func() {
+				updateToken.UpdateTokenRequest.Token = token
+			}()
+		}
 	}
 
-	res := protojson.MarshalOptions{AllowPartial: true}.Format(s.message)
-
-	return res
+	return protojson.MarshalOptions{AllowPartial: true}.Format(s.message)
 }

--- a/log/topic.go
+++ b/log/topic.go
@@ -1317,7 +1317,9 @@ func (s lazyProtoStringifer) String() string {
 				}
 			}()
 		}
-		if updateToken, ok := writeRequest.GetClientMessage().(*Ydb_Topic.StreamWriteMessage_FromClient_UpdateTokenRequest); ok {
+		clientMessage := writeRequest.GetClientMessage()
+		updateToken, ok := clientMessage.(*Ydb_Topic.StreamWriteMessage_FromClient_UpdateTokenRequest)
+		if ok {
 			token := updateToken.UpdateTokenRequest.GetToken()
 			updateToken.UpdateTokenRequest.Token = secret.Token(token)
 			defer func() {

--- a/log/topic_test.go
+++ b/log/topic_test.go
@@ -1,0 +1,30 @@
+package log
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Topic"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/secret"
+)
+
+func TestLazyProtoStringiferUpdateTokenRequest(t *testing.T) {
+	const token = "3:serv:CMmNAXXXXXXSA"
+
+	message := &Ydb_Topic.StreamWriteMessage_FromClient{
+		ClientMessage: &Ydb_Topic.StreamWriteMessage_FromClient_UpdateTokenRequest{
+			UpdateTokenRequest: &Ydb_Topic.UpdateTokenRequest{
+				Token: token,
+			},
+		},
+	}
+
+	formatted := lazyProtoStringifer{message: message}.String()
+
+	require.NotContains(t, formatted, token)
+	require.Contains(t, formatted, secret.Token(token))
+	require.True(t, strings.Contains(formatted, "updateTokenRequest"))
+	require.Equal(t, token, message.GetUpdateTokenRequest().GetToken())
+}


### PR DESCRIPTION
## Summary
- Mask `UpdateTokenRequest.token` in topic writer gRPC trace logs via `secret.Token()` before protojson serialization
- Add unit test for `lazyProtoStringifer` and godoc for `secret.Token`
- Document unreleased `CHANGELOG.md` entry placement in agent docs

## Test plan
- [x] `go test -race ./log/... -run TestLazyProtoStringifer`
- [x] `go test -race ./internal/secret/...`


Made with [Cursor](https://cursor.com)