### PR TITLE
database/sql: add prefetch query result parts option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-## v3.140.3
 * Added `ydb.WithPrefetchQueryResultParts(n)` connector option and `prefetch_query_result_parts` connection string parameter for the `database/sql` driver to enable `query.WithResponsePartPrefetch` on every query executed over Query Service
 
 ## v3.140.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v3.140.3
+* Added `ydb.WithPrefetchQueryResultParts(n)` connector option and `prefetch_query_result_parts` connection string parameter for the `database/sql` driver to enable `query.WithResponsePartPrefetch` on every query executed over Query Service
+
 ## v3.140.2
 * Added `topicwriter.ErrWriterClosed` sentinel error returned by `Writer.Write` when the writer has been closed due to a terminal error or an explicit `Close` call; use `errors.Is` to detect this condition and recreate the writer if needed
 

--- a/dsn.go
+++ b/dsn.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/balancers"
@@ -137,6 +138,15 @@ func parseConnectionString(dataSourceName string) (opts []Option, _ error) {
 			}
 		}
 		opts = append(opts, withConnectorOptions(binders...))
+	}
+	if prefetchQueryResultParts := info.Params.Get("prefetch_query_result_parts"); prefetchQueryResultParts != "" {
+		parts, err := strconv.Atoi(prefetchQueryResultParts)
+		if err != nil {
+			return nil, xerrors.WithStackTrace(fmt.Errorf(
+				"invalid prefetch_query_result_parts: %s", prefetchQueryResultParts,
+			))
+		}
+		opts = append(opts, withConnectorOptions(WithPrefetchQueryResultParts(parts)))
 	}
 
 	return opts, nil

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -194,6 +194,18 @@ func TestParse(t *testing.T) {
 			},
 			err: nil,
 		},
+		{
+			dsn: "grpc://localhost:2135/local?prefetch_query_result_parts=3",
+			opts: []config.Option{
+				config.WithSecure(false),
+				config.WithEndpoint("localhost:2135"),
+				config.WithDatabase("/local"),
+			},
+			connectorOpts: []xsql.Option{
+				xsql.WithQueryOptions(xquery.WithResponsePartPrefetch(3)),
+			},
+			err: nil,
+		},
 	} {
 		t.Run("", func(t *testing.T) {
 			opts, err := parseConnectionString(tt.dsn)
@@ -221,6 +233,12 @@ func TestParse(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestParseInvalidPrefetchQueryResultParts(t *testing.T) {
+	_, err := parseConnectionString("grpc://localhost:2135/local?prefetch_query_result_parts=bad")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "invalid prefetch_query_result_parts: bad")
 }
 
 func TestExtractTablePathPrefixFromBinderName(t *testing.T) {

--- a/example_test.go
+++ b/example_test.go
@@ -168,6 +168,102 @@ func Example_databaseSQLBindNumericArgs() {
 }
 
 //nolint:testableexamples
+func Example_databaseSQLPrefetchQueryResultPartsConnectionString() {
+	db, err := sql.Open("ydb", "grpc://localhost:2136/local?prefetch_query_result_parts=1")
+	if err != nil {
+		panic(err)
+	}
+	defer db.Close()
+
+	// numeric args
+	rows, err := db.QueryContext(context.TODO(),
+		"SELECT $p1; SELECT $p2",
+		sql.Named("p1", 42),
+		sql.Named("p2", "my string"),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	if !rows.NextResultSet() {
+		panic("first result set not exists")
+	}
+
+	var id int32 // required value
+	if err := rows.Scan(&id); err != nil {
+		panic(err)
+	} else {
+		log.Printf("id=%v\n", id)
+	}
+
+	if !rows.NextResultSet() {
+		panic("second result set not exists")
+	}
+
+	var myStr string // optional value
+	if err := rows.Scan(&myStr); err != nil {
+		panic(err)
+	} else {
+		log.Printf("myStr='%s'\n", myStr)
+	}
+
+	if err := rows.Close(); err != nil {
+		panic(err)
+	}
+}
+
+//nolint:testableexamples
+func Example_databaseSQLPrefetchQueryResultParts() {
+	var (
+		ctx          = context.TODO()
+		nativeDriver = ydb.MustOpen(ctx, "grpc://localhost:2136/local")
+		db           = sql.OpenDB(
+			ydb.MustConnector(nativeDriver,
+				ydb.WithPrefetchQueryResultParts(1),
+			),
+		)
+	)
+	defer nativeDriver.Close(ctx) // cleanup resources
+	defer db.Close()
+
+	// numeric args
+	rows, err := db.QueryContext(context.TODO(),
+		"SELECT $p1; SELECT $p2",
+		sql.Named("p1", 42),
+		sql.Named("p2", "my string"),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	if !rows.NextResultSet() {
+		panic("first result set not exists")
+	}
+
+	var id int32 // required value
+	if err := rows.Scan(&id); err != nil {
+		panic(err)
+	} else {
+		log.Printf("id=%v\n", id)
+	}
+
+	if !rows.NextResultSet() {
+		panic("second result set not exists")
+	}
+
+	var myStr string // optional value
+	if err := rows.Scan(&myStr); err != nil {
+		panic(err)
+	} else {
+		log.Printf("myStr='%s'\n", myStr)
+	}
+
+	if err := rows.Close(); err != nil {
+		panic(err)
+	}
+}
+
+//nolint:testableexamples
 func Example_databaseSQLBindNumericArgsOverConnector() {
 	var (
 		ctx          = context.TODO()

--- a/example_test.go
+++ b/example_test.go
@@ -184,6 +184,11 @@ func Example_databaseSQLPrefetchQueryResultPartsConnectionString() {
 	if err != nil {
 		panic(err)
 	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			panic(err)
+		}
+	}()
 
 	if !rows.NextResultSet() {
 		panic("first result set not exists")
@@ -192,9 +197,9 @@ func Example_databaseSQLPrefetchQueryResultPartsConnectionString() {
 	var id int32 // required value
 	if err := rows.Scan(&id); err != nil {
 		panic(err)
-	} else {
-		log.Printf("id=%v\n", id)
 	}
+
+	log.Printf("id=%v\n", id)
 
 	if !rows.NextResultSet() {
 		panic("second result set not exists")
@@ -203,11 +208,11 @@ func Example_databaseSQLPrefetchQueryResultPartsConnectionString() {
 	var myStr string // optional value
 	if err := rows.Scan(&myStr); err != nil {
 		panic(err)
-	} else {
-		log.Printf("myStr='%s'\n", myStr)
 	}
 
-	if err := rows.Close(); err != nil {
+	log.Printf("myStr='%s'\n", myStr)
+
+	if err := rows.Err(); err != nil {
 		panic(err)
 	}
 }
@@ -235,6 +240,11 @@ func Example_databaseSQLPrefetchQueryResultParts() {
 	if err != nil {
 		panic(err)
 	}
+	defer func() {
+		if err := rows.Close(); err != nil {
+			panic(err)
+		}
+	}()
 
 	if !rows.NextResultSet() {
 		panic("first result set not exists")
@@ -243,9 +253,9 @@ func Example_databaseSQLPrefetchQueryResultParts() {
 	var id int32 // required value
 	if err := rows.Scan(&id); err != nil {
 		panic(err)
-	} else {
-		log.Printf("id=%v\n", id)
 	}
+
+	log.Printf("id=%v\n", id)
 
 	if !rows.NextResultSet() {
 		panic("second result set not exists")
@@ -254,11 +264,11 @@ func Example_databaseSQLPrefetchQueryResultParts() {
 	var myStr string // optional value
 	if err := rows.Scan(&myStr); err != nil {
 		panic(err)
-	} else {
-		log.Printf("myStr='%s'\n", myStr)
 	}
 
-	if err := rows.Close(); err != nil {
+	log.Printf("myStr='%s'\n", myStr)
+
+	if err := rows.Err(); err != nil {
 		panic(err)
 	}
 }

--- a/internal/mock/server.go
+++ b/internal/mock/server.go
@@ -474,10 +474,10 @@ func withResultSetPayload(rs *Ydb.ResultSet, payload []byte) *Ydb.ResultSet {
 		return rs
 	}
 
-	cloned := proto.Clone(rs).(*Ydb.ResultSet)
+	cloned := proto.Clone(rs).(*Ydb.ResultSet) //nolint:forcetypeassert
 	col, val := bytesColumn("payload", payload)
 	cloned.Columns = append(cloned.Columns, col)
-	for _, row := range cloned.Rows {
+	for _, row := range cloned.GetRows() {
 		row.Items = append(row.Items, val)
 	}
 

--- a/internal/mock/server.go
+++ b/internal/mock/server.go
@@ -3,12 +3,14 @@
 package mock
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net"
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -39,6 +41,14 @@ func WithClusterNodes(nodeIDs ...uint32) ServerOption {
 	}
 }
 
+// WithExecuteQueryPartDelay inserts a sleep before each ExecuteQuery response
+// part is sent. Useful for benchmarks that compare query result prefetch.
+func WithExecuteQueryPartDelay(delay time.Duration) ServerOption {
+	return func(m *server) {
+		m.executeQueryPartDelay = delay
+	}
+}
+
 // server is a local gRPC mock (Discovery + Table + Query).
 type server struct {
 	listener   net.Listener
@@ -63,6 +73,13 @@ type server struct {
 	executeQueryBehavior executeQueryBehavior
 	commitQueryCalls     atomic.Uint64
 	queryTxID            atomic.Uint64
+
+	// executeQueryPartDelay is inserted before each ExecuteQuery response part
+	// send to simulate network latency between stream parts in benchmarks.
+	executeQueryPartDelay time.Duration
+
+	executeQueryPayloadOnce sync.Once
+	executeQueryPayload     []byte
 }
 
 // TriggerNodeShutdown makes one AttachSession handler send a
@@ -301,10 +318,16 @@ func (m *querySrv) ExecuteQuery(
 	resultSets := resultSetsForQuery(req.GetQueryContent().GetText())
 
 	for i, rs := range resultSets {
+		rsToSend := rs
+		if delay := m.mock.executeQueryPartDelay; delay > 0 {
+			time.Sleep(delay)
+			rsToSend = withResultSetPayload(rs, m.mock.executeQueryPadding())
+		}
+
 		err := stream.Send(&Ydb_Query.ExecuteQueryResponsePart{
 			Status:         Ydb.StatusIds_SUCCESS,
 			ResultSetIndex: int64(i),
-			ResultSet:      rs,
+			ResultSet:      rsToSend,
 		})
 		if err != nil {
 			return err
@@ -430,6 +453,35 @@ func select42ResultSet() *Ydb.ResultSet {
 		Columns: []*Ydb.Column{col},
 		Rows:    []*Ydb.Value{{Items: []*Ydb.Value{val}}},
 	}
+}
+
+const executeQueryBenchmarkPayloadBytes = 256 * 1024
+
+func (m *server) executeQueryPadding() []byte {
+	if m.executeQueryPartDelay <= 0 {
+		return nil
+	}
+
+	m.executeQueryPayloadOnce.Do(func() {
+		m.executeQueryPayload = bytes.Repeat([]byte{'x'}, executeQueryBenchmarkPayloadBytes)
+	})
+
+	return m.executeQueryPayload
+}
+
+func withResultSetPayload(rs *Ydb.ResultSet, payload []byte) *Ydb.ResultSet {
+	if len(payload) == 0 {
+		return rs
+	}
+
+	cloned := proto.Clone(rs).(*Ydb.ResultSet)
+	col, val := bytesColumn("payload", payload)
+	cloned.Columns = append(cloned.Columns, col)
+	for _, row := range cloned.Rows {
+		row.Items = append(row.Items, val)
+	}
+
+	return cloned
 }
 
 func discoveryEndpoints(host string, port uint32, nodeIDs []uint32) []*Ydb_Discovery.EndpointInfo {

--- a/internal/xsql/test/bench_test.go
+++ b/internal/xsql/test/bench_test.go
@@ -288,8 +288,8 @@ func warmUpMockPrefetchBench(ctx context.Context, t testing.TB, db *sql.DB) {
 // cpu: Apple M3 Pro
 // go test -bench=BenchmarkDatabaseSQLPrefetchQueryResultParts -benchtime=3s ./internal/xsql/test
 //
-// BenchmarkDatabaseSQLPrefetchQueryResultParts/no_prefetch-12          985   3716708 ns/op
-// BenchmarkDatabaseSQLPrefetchQueryResultParts/prefetch_1-12          1065   3349349 ns/op
+// BenchmarkDatabaseSQLPrefetchQueryResultParts/no_prefetch-12   3592737 ns/op    5970899 B/op   1379 allocs/op
+// BenchmarkDatabaseSQLPrefetchQueryResultParts/prefetch_1-12    3376459 ns/op    7006089 B/op   1421 allocs/op
 func BenchmarkDatabaseSQLPrefetchQueryResultParts(b *testing.B) {
 	ctx := b.Context()
 

--- a/internal/xsql/test/bench_test.go
+++ b/internal/xsql/test/bench_test.go
@@ -3,8 +3,12 @@ package test
 import (
 	"context"
 	"database/sql"
+	"fmt"
+	"strconv"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -148,4 +152,168 @@ func warmUpMock(ctx context.Context, t testing.TB, db *sql.DB) {
 	}
 
 	wg.Wait()
+}
+
+const (
+	prefetchBenchParts       = 8
+	prefetchBenchNetDelay    = 200 * time.Microsecond
+	prefetchBenchWorkBetween = 300 * time.Microsecond
+)
+
+func prefetchBenchSQL(parts int) string {
+	queries := make([]string, parts)
+	for i := range parts {
+		queries[i] = "SELECT " + strconv.Itoa(i+1)
+	}
+
+	return strings.Join(queries, "; ")
+}
+
+func drainMultiResultSetRows(rows *sql.Rows, workBetween time.Duration) error {
+	for rsIdx := 0; ; rsIdx++ {
+		if rsIdx > 0 {
+			if !rows.NextResultSet() {
+				break
+			}
+		}
+
+		for rows.Next() {
+			cols, err := rows.Columns()
+			if err != nil {
+				return err
+			}
+
+			switch len(cols) {
+			case 1:
+				var v int32
+				if err := rows.Scan(&v); err != nil {
+					return err
+				}
+			case 2:
+				var (
+					v       int32
+					payload []byte
+				)
+				if err := rows.Scan(&v, &payload); err != nil {
+					return err
+				}
+			default:
+				return fmt.Errorf("unexpected column count: %d", len(cols))
+			}
+
+			if workBetween > 0 {
+				time.Sleep(workBetween)
+			}
+		}
+	}
+
+	return rows.Err()
+}
+
+func benchmarkDatabaseSQLPrefetchQueryResultParts(b *testing.B, nativeDriver *ydb.Driver, prefetchParts int) {
+	b.Helper()
+
+	connector, err := ydb.Connector(nativeDriver,
+		ydb.WithQueryService(true),
+		ydb.WithPrefetchQueryResultParts(prefetchParts),
+	)
+	require.NoError(b, err)
+
+	defer func() {
+		_ = connector.Close()
+	}()
+
+	db := sql.OpenDB(connector)
+	defer func() {
+		_ = db.Close()
+	}()
+
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+
+	warmUpMockPrefetchBench(b.Context(), b, db)
+
+	query := prefetchBenchSQL(prefetchBenchParts)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for b.Loop() {
+		rows, err := db.QueryContext(b.Context(), query)
+		if err != nil {
+			b.Fatal(err)
+		}
+
+		if err := drainMultiResultSetRows(rows, prefetchBenchWorkBetween); err != nil {
+			_ = rows.Close()
+			b.Fatal(err)
+		}
+
+		if err := rows.Close(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func warmUpMockPrefetchBench(ctx context.Context, t testing.TB, db *sql.DB) {
+	t.Helper()
+
+	query := prefetchBenchSQL(prefetchBenchParts)
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		rows, err := db.QueryContext(ctx, query)
+		if !assert.NoError(t, err) {
+			return
+		}
+		defer func() {
+			assert.NoError(t, rows.Close())
+		}()
+
+		assert.NoError(t, drainMultiResultSetRows(rows, 0))
+	}()
+
+	wg.Wait()
+}
+
+// BenchmarkDatabaseSQLPrefetchQueryResultParts compares database/sql Query Service
+// throughput when draining a multi-part ExecuteQuery stream with and without
+// response-part prefetch enabled on the connector.
+//
+// The mock server paces stream parts with a per-part delay and large payloads so
+// gRPC flow control prevents buffering the whole stream ahead of the client.
+//
+// cpu: Apple M3 Pro
+// go test -bench=BenchmarkDatabaseSQLPrefetchQueryResultParts -benchtime=3s ./internal/xsql/test
+//
+// BenchmarkDatabaseSQLPrefetchQueryResultParts/no_prefetch-12          985   3716708 ns/op
+// BenchmarkDatabaseSQLPrefetchQueryResultParts/prefetch_1-12          1065   3349349 ns/op
+func BenchmarkDatabaseSQLPrefetchQueryResultParts(b *testing.B) {
+	ctx := b.Context()
+
+	mockSrv := mock.Server(b, mock.WithExecuteQueryPartDelay(prefetchBenchNetDelay))
+
+	nativeDriver, err := ydb.Open(ctx, mockSrv.ConnString(),
+		ydb.WithAnonymousCredentials(),
+		ydb.WithSessionPoolSizeLimit(sessionPoolSize),
+	)
+	require.NoError(b, err)
+
+	defer func() {
+		_ = nativeDriver.Close(ctx)
+	}()
+
+	for _, tc := range []struct {
+		name          string
+		prefetchParts int
+	}{
+		{name: "no_prefetch", prefetchParts: 0},
+		{name: "prefetch_1", prefetchParts: 1},
+	} {
+		b.Run(tc.name, func(b *testing.B) {
+			benchmarkDatabaseSQLPrefetchQueryResultParts(b, nativeDriver, tc.prefetchParts)
+		})
+	}
 }

--- a/internal/xsql/test/bench_test.go
+++ b/internal/xsql/test/bench_test.go
@@ -244,7 +244,7 @@ func benchmarkDatabaseSQLPrefetchQueryResultParts(b *testing.B, nativeDriver *yd
 		}
 
 		if err := drainMultiResultSetRows(rows, prefetchBenchWorkBetween); err != nil {
-			_ = rows.Close()
+			_ = rows.Close() //nolint:sqlclosecheck
 			b.Fatal(err)
 		}
 

--- a/internal/xsql/test/bench_test.go
+++ b/internal/xsql/test/bench_test.go
@@ -156,7 +156,7 @@ func warmUpMock(ctx context.Context, t testing.TB, db *sql.DB) {
 
 const (
 	prefetchBenchParts       = 8
-	prefetchBenchNetDelay    = 200 * time.Microsecond
+	prefetchBenchNetDelay    = 2 * time.Microsecond
 	prefetchBenchWorkBetween = 300 * time.Microsecond
 )
 
@@ -288,8 +288,8 @@ func warmUpMockPrefetchBench(ctx context.Context, t testing.TB, db *sql.DB) {
 // cpu: Apple M3 Pro
 // go test -bench=BenchmarkDatabaseSQLPrefetchQueryResultParts -benchtime=3s ./internal/xsql/test
 //
-// BenchmarkDatabaseSQLPrefetchQueryResultParts/no_prefetch-12   3592737 ns/op    5970899 B/op   1379 allocs/op
-// BenchmarkDatabaseSQLPrefetchQueryResultParts/prefetch_1-12    3376459 ns/op    7006089 B/op   1421 allocs/op
+// BenchmarkDatabaseSQLPrefetchQueryResultParts/no_prefetch-12   3572107 ns/op    5421094 B/op   1292 allocs/op
+// BenchmarkDatabaseSQLPrefetchQueryResultParts/prefetch_1-12    3319621 ns/op    5657165 B/op   1309 allocs/op
 func BenchmarkDatabaseSQLPrefetchQueryResultParts(b *testing.B) {
 	ctx := b.Context()
 

--- a/internal/xsql/xquery/conn.go
+++ b/internal/xsql/xquery/conn.go
@@ -23,6 +23,8 @@ type Conn struct {
 	onClose []func()
 	closed  atomic.Bool
 	fakeTx  bool
+
+	responsePartPrefetch int
 }
 
 func (c *Conn) NodeID() uint32 {
@@ -61,6 +63,7 @@ func (c *Conn) Exec(ctx context.Context, sql string, params *params.Params) (
 	r := &resultWithStats{}
 	sm := stats.ModeCallbackFromContextWith(ctx, stats.ModeBasic, r.onQueryStats)
 	opts = append(opts, options.WithStatsMode(options.StatsMode(sm.Mode), sm.Callback))
+	opts = c.appendResponsePartPrefetch(opts)
 
 	err := c.session.Exec(ctx, sql, opts...)
 	if err != nil {
@@ -95,6 +98,8 @@ func (c *Conn) Query(ctx context.Context, sql string, params *params.Params) (
 	if sm := stats.ModeCallbackFromContext(ctx); sm != nil {
 		opts = append(opts, options.WithStatsMode(options.StatsMode(sm.Mode), sm.Callback))
 	}
+
+	opts = c.appendResponsePartPrefetch(opts)
 
 	result, err := c.session.Query(ctx, sql, opts...)
 	if err != nil {
@@ -143,6 +148,14 @@ func New(s *query.Session, opts ...Option) *Conn {
 
 func (c *Conn) isReady() bool {
 	return c.session.Status() == query.StatusIdle.String()
+}
+
+func (c *Conn) appendResponsePartPrefetch(opts []options.Execute) []options.Execute {
+	if c.responsePartPrefetch <= 0 {
+		return opts
+	}
+
+	return append(opts, options.WithResponsePartPrefetch(c.responsePartPrefetch))
 }
 
 func (c *Conn) beginTx(ctx context.Context, txOptions driver.TxOptions) (tx common.Tx, finalErr error) {

--- a/internal/xsql/xquery/options.go
+++ b/internal/xsql/xquery/options.go
@@ -13,3 +13,13 @@ func WithFakeTx() Option {
 		c.fakeTx = true
 	}
 }
+
+func WithResponsePartPrefetch(parts int) Option {
+	if parts <= 0 {
+		parts = 0
+	}
+
+	return func(c *Conn) {
+		c.responsePartPrefetch = parts
+	}
+}

--- a/internal/xsql/xquery/options_test.go
+++ b/internal/xsql/xquery/options_test.go
@@ -1,0 +1,46 @@
+package xquery
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/query/options"
+)
+
+func TestWithResponsePartPrefetch(t *testing.T) {
+	t.Run("Positive", func(t *testing.T) {
+		conn := &Conn{}
+		WithResponsePartPrefetch(3)(conn)
+		require.Equal(t, 3, conn.responsePartPrefetch)
+	})
+
+	t.Run("Zero", func(t *testing.T) {
+		conn := &Conn{}
+		WithResponsePartPrefetch(0)(conn)
+		require.Equal(t, 0, conn.responsePartPrefetch)
+	})
+
+	t.Run("Negative", func(t *testing.T) {
+		conn := &Conn{}
+		WithResponsePartPrefetch(-1)(conn)
+		require.Equal(t, 0, conn.responsePartPrefetch)
+	})
+}
+
+func TestAppendResponsePartPrefetch(t *testing.T) {
+	t.Run("Disabled", func(t *testing.T) {
+		conn := &Conn{}
+		opts := conn.appendResponsePartPrefetch(nil)
+		require.Empty(t, opts)
+	})
+
+	t.Run("Enabled", func(t *testing.T) {
+		conn := &Conn{responsePartPrefetch: 2}
+		opts := conn.appendResponsePartPrefetch(nil)
+		require.Len(t, opts, 1)
+
+		settings := options.ExecuteSettings(opts...)
+		require.Equal(t, 2, settings.ResponsePartPrefetch())
+	})
+}

--- a/internal/xsql/xquery/tx.go
+++ b/internal/xsql/xquery/tx.go
@@ -43,6 +43,7 @@ func (t *transaction) Exec(ctx context.Context, sql string, params *params.Param
 	r := &resultWithStats{}
 	sm := stats.ModeCallbackFromContextWith(ctx, stats.ModeBasic, r.onQueryStats)
 	opts = append(opts, options.WithStatsMode(options.StatsMode(sm.Mode), sm.Callback))
+	opts = t.conn.appendResponsePartPrefetch(opts)
 
 	err := t.tx.Exec(ctx, sql, opts...)
 	if err != nil {
@@ -72,6 +73,8 @@ func (t *transaction) Query(ctx context.Context, sql string, params *params.Para
 	if sm := stats.ModeCallbackFromContext(ctx); sm != nil {
 		opts = append(opts, options.WithStatsMode(options.StatsMode(sm.Mode), sm.Callback))
 	}
+
+	opts = t.conn.appendResponsePartPrefetch(opts)
 
 	result, err := t.tx.Query(ctx, sql, opts...)
 	if err != nil {

--- a/sql.go
+++ b/sql.go
@@ -269,6 +269,15 @@ func WithDisableServerBalancer() ConnectorOption {
 	return xsql.WithDisableServerBalancer()
 }
 
+// WithPrefetchQueryResultParts enables prefetching of ExecuteQuery response parts
+// for all queries executed through database/sql over Query Service.
+//
+// The value is passed to query.WithResponsePartPrefetch under the hood.
+// Zero disables prefetch (the default).
+func WithPrefetchQueryResultParts(parts int) ConnectorOption {
+	return xsql.WithQueryOptions(xquery.WithResponsePartPrefetch(parts))
+}
+
 type SQLConnector interface {
 	driver.Connector
 


### PR DESCRIPTION
## Summary
- Added `ydb.WithPrefetchQueryResultParts(n)` connector option for the `database/sql` driver; it applies `query.WithResponsePartPrefetch` to every Query Service query (including transactions).
- Added `prefetch_query_result_parts` connection string parameter for `sql.Open("ydb", ...)`.
- Documented usage in `example_test.go` and added unit tests for option wiring and DSN parsing.

## Test plan
- [x] `go test ./internal/xsql/xquery/...`
- [x] `go test -run 'TestParse|TestParseInvalidPrefetchQueryResultParts' .`


Made with [Cursor](https://cursor.com)