### PR TITLE
Drop query sessions when balancer bans a node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Added `config.WithOnConnBan` and `config.WithOnConnAllow` options to observe balancer connection pessimization and recovery by node ID
+
 ## v3.140.2
 * Added `topicwriter.ErrWriterClosed` sentinel error returned by `Writer.Write` when the writer has been closed due to a terminal error or an explicit `Close` call; use `errors.Is` to detect this condition and recreate the writer if needed
 

--- a/config/config.go
+++ b/config/config.go
@@ -36,6 +36,9 @@ type Config struct {
 	meta               *meta.Meta
 
 	excludeGRPCCodesForPessimization []grpcCodes.Code
+
+	onConnBan   func(nodeID uint32)
+	onConnAllow func(nodeID uint32)
 }
 
 func (c *Config) Credentials() credentials.Credentials {
@@ -330,6 +333,38 @@ func ExcludeGRPCCodesForPessimization(codes ...grpcCodes.Code) Option {
 			c.excludeGRPCCodesForPessimization,
 			codes...,
 		)
+	}
+}
+
+// NotifyConnBan invokes optional observer registered via WithOnConnBan.
+func (c *Config) NotifyConnBan(nodeID uint32) {
+	if c == nil || c.onConnBan == nil {
+		return
+	}
+
+	c.onConnBan(nodeID)
+}
+
+// NotifyConnAllow invokes optional observer registered via WithOnConnAllow.
+func (c *Config) NotifyConnAllow(nodeID uint32) {
+	if c == nil || c.onConnAllow == nil {
+		return
+	}
+
+	c.onConnAllow(nodeID)
+}
+
+// WithOnConnBan registers callback invoked after balancer pessimizes a connection.
+func WithOnConnBan(fn func(nodeID uint32)) Option {
+	return func(c *Config) {
+		c.onConnBan = fn
+	}
+}
+
+// WithOnConnAllow registers callback invoked after discovery unbans a connection.
+func WithOnConnAllow(fn func(nodeID uint32)) Option {
+	return func(c *Config) {
+		c.onConnAllow = fn
 	}
 }
 

--- a/driver.go
+++ b/driver.go
@@ -458,6 +458,25 @@ func (d *Driver) connect(ctx context.Context) error {
 		))
 	}
 
+	d.config.With(
+		config.WithOnConnBan(func(nodeID uint32) {
+			client, err := d.query.Get()
+			if err != nil {
+				return
+			}
+
+			client.OnConnBanned(xcontext.ValueOnly(ctx), nodeID)
+		}),
+		config.WithOnConnAllow(func(nodeID uint32) {
+			client, err := d.query.Get()
+			if err != nil {
+				return
+			}
+
+			client.OnConnAllowed(nodeID)
+		}),
+	)
+
 	if d.pool == nil {
 		d.pool = conn.NewPool(ctx, d.config)
 	}
@@ -503,25 +522,6 @@ func (d *Driver) connect(ctx context.Context) error {
 			),
 		)
 	})
-
-	d.config.With(
-		config.WithOnConnBan(func(nodeID uint32) {
-			client, err := d.query.Get()
-			if err != nil {
-				return
-			}
-
-			client.OnConnBanned(xcontext.ValueOnly(ctx), nodeID)
-		}),
-		config.WithOnConnAllow(func(nodeID uint32) {
-			client, err := d.query.Get()
-			if err != nil {
-				return
-			}
-
-			client.OnConnAllowed(nodeID)
-		}),
-	)
 
 	d.scheme = xsync.OnceValue(func() (*internalScheme.Client, error) {
 		return internalScheme.New(xcontext.ValueOnly(ctx),

--- a/driver.go
+++ b/driver.go
@@ -504,6 +504,25 @@ func (d *Driver) connect(ctx context.Context) error {
 		)
 	})
 
+	d.config.With(
+		config.WithOnConnBan(func(nodeID uint32) {
+			client, err := d.query.Get()
+			if err != nil {
+				return
+			}
+
+			client.OnConnBanned(xcontext.ValueOnly(ctx), nodeID)
+		}),
+		config.WithOnConnAllow(func(nodeID uint32) {
+			client, err := d.query.Get()
+			if err != nil {
+				return
+			}
+
+			client.OnConnAllowed(nodeID)
+		}),
+	)
+
 	d.scheme = xsync.OnceValue(func() (*internalScheme.Client, error) {
 		return internalScheme.New(xcontext.ValueOnly(ctx),
 			d.metaBalancer,

--- a/internal/balancer/balancer_test.go
+++ b/internal/balancer/balancer_test.go
@@ -437,6 +437,107 @@ func TestPessimizationOnOverloaded(t *testing.T) {
 		require.NotEqual(t, state.Banned, cc1.GetState())
 	})
 
+	t.Run("BansConnectionOnUnavailableForSessionCreate", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		cc := mock.NewMockClientConnInterface(ctrl)
+		unavailableErr := xerrors.WithStackTrace(xerrors.Operation(
+			xerrors.WithStatusCode(Ydb.StatusIds_UNAVAILABLE),
+		))
+		cc.EXPECT().Invoke(
+			gomock.Any(),
+			gomock.Any(),
+			gomock.Any(),
+			gomock.Any(),
+		).DoAndReturn(func(context.Context, string, any, any, ...grpc.CallOption) error {
+			return unavailableErr
+		})
+
+		cc1 := &mock.Conn{
+			ClientConnInterface: cc,
+			AddrField:           "node1:2135",
+			NodeIDField:         1,
+			State:               state.Online,
+		}
+		cc2 := &mock.Conn{
+			ClientConnInterface: cc,
+			AddrField:           "node2:2135",
+			NodeIDField:         2,
+			State:               state.Online,
+		}
+
+		cfg := config.New()
+		pool := conn.NewPool(ctx, cfg)
+		defer func() { _ = pool.Release(ctx) }()
+
+		b := &Balancer{
+			driverConfig:   cfg,
+			pool:           pool,
+			balancerConfig: balancerConfig.Config{},
+		}
+		s := newConnectionsState([]conn.Conn{cc1, cc2}, nil, balancerConfig.Info{}, false)
+		b.connectionsState.Store(s)
+
+		invokeCtx := BanOnSessionCreate(endpoint.WithNodeID(ctx, cc1.NodeIDField))
+		err := b.Invoke(invokeCtx, "/Ydb.Query.V1.QueryService/CreateSession", nil, nil)
+		require.Error(t, err)
+		require.Equal(t, state.Banned, cc1.GetState())
+
+		for range 10 {
+			c, nextErr := b.nextConn(ctx)
+			require.NoError(t, nextErr)
+			require.Equal(t, cc2.AddrField, c.Endpoint().Address())
+		}
+	})
+
+	t.Run("BansConnectionOnContextDeadlineExceededForSessionCreate", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		cc := mock.NewMockClientConnInterface(ctrl)
+		cc.EXPECT().Invoke(
+			gomock.Any(),
+			gomock.Any(),
+			gomock.Any(),
+			gomock.Any(),
+		).DoAndReturn(func(context.Context, string, any, any, ...grpc.CallOption) error {
+			return context.DeadlineExceeded
+		})
+
+		cc1 := &mock.Conn{
+			ClientConnInterface: cc,
+			AddrField:           "node1:2135",
+			NodeIDField:         1,
+			State:               state.Online,
+		}
+		cc2 := &mock.Conn{
+			ClientConnInterface: cc,
+			AddrField:           "node2:2135",
+			NodeIDField:         2,
+			State:               state.Online,
+		}
+
+		cfg := config.New()
+		pool := conn.NewPool(ctx, cfg)
+		defer func() { _ = pool.Release(ctx) }()
+
+		b := &Balancer{
+			driverConfig:   cfg,
+			pool:           pool,
+			balancerConfig: balancerConfig.Config{},
+		}
+		s := newConnectionsState([]conn.Conn{cc1, cc2}, nil, balancerConfig.Info{}, false)
+		b.connectionsState.Store(s)
+
+		invokeCtx := BanOnSessionCreate(endpoint.WithNodeID(ctx, cc1.NodeIDField))
+		err := b.Invoke(invokeCtx, "/Ydb.Query.V1.QueryService/CreateSession", nil, nil)
+		require.Error(t, err)
+		require.Equal(t, state.Banned, cc1.GetState())
+
+		for range 10 {
+			c, nextErr := b.nextConn(ctx)
+			require.NoError(t, nextErr)
+			require.Equal(t, cc2.AddrField, c.Endpoint().Address())
+		}
+	})
+
 	t.Run("AllConnectionsPessimizedFallback", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		cc := mock.NewMockClientConnInterface(ctrl)

--- a/internal/balancer/errors.go
+++ b/internal/balancer/errors.go
@@ -88,11 +88,9 @@ func IsBadConn(ctx context.Context, err error, ignoreCodes ...grpcCodes.Code) bo
 		return true
 	}
 
-	banOnContextDeadlineExceeded, _ := ctx.Value(ctxBanOnContextDeadlineExceeded{}).(bool)
-	if banOnContextDeadlineExceeded {
-		if xerrors.Is(err, context.DeadlineExceeded) {
-			return true
-		}
+	banOnContextDeadlineExceeded, has := ctx.Value(ctxBanOnContextDeadlineExceeded{}).(bool)
+	if has && banOnContextDeadlineExceeded && xerrors.Is(err, context.DeadlineExceeded) {
+		return true
 	}
 
 	return false

--- a/internal/balancer/errors.go
+++ b/internal/balancer/errors.go
@@ -46,9 +46,9 @@ var (
 )
 
 type (
-	ctxBanOnOperationError            struct{}
-	ctxBanOnContextDeadlineExceeded   struct{}
-	operationErrorCodesType           []Ydb.StatusIds_StatusCode
+	ctxBanOnOperationError          struct{}
+	ctxBanOnContextDeadlineExceeded struct{}
+	operationErrorCodesType         []Ydb.StatusIds_StatusCode
 )
 
 func BanOnOperationError(ctx context.Context, codes ...Ydb.StatusIds_StatusCode) context.Context {
@@ -73,6 +73,7 @@ func BanOnContextDeadlineExceeded(ctx context.Context) context.Context {
 // overload, unavailability, or client-side deadline exceeded.
 func BanOnSessionCreate(ctx context.Context) context.Context {
 	ctx = BanOnOperationError(ctx, sessionCreateBanOperationCodes...)
+
 	return BanOnContextDeadlineExceeded(ctx)
 }
 
@@ -87,7 +88,8 @@ func IsBadConn(ctx context.Context, err error, ignoreCodes ...grpcCodes.Code) bo
 		return true
 	}
 
-	if banOnContextDeadlineExceeded, _ := ctx.Value(ctxBanOnContextDeadlineExceeded{}).(bool); banOnContextDeadlineExceeded {
+	banOnContextDeadlineExceeded, _ := ctx.Value(ctxBanOnContextDeadlineExceeded{}).(bool)
+	if banOnContextDeadlineExceeded {
 		if xerrors.Is(err, context.DeadlineExceeded) {
 			return true
 		}

--- a/internal/balancer/errors.go
+++ b/internal/balancer/errors.go
@@ -10,6 +10,12 @@ import (
 	"github.com/ydb-platform/ydb-go-sdk/v3/pkg/xslices"
 )
 
+// Session-create RPC status codes that indicate the target node should be pessimized.
+var sessionCreateBanOperationCodes = []Ydb.StatusIds_StatusCode{
+	Ydb.StatusIds_OVERLOADED,
+	Ydb.StatusIds_UNAVAILABLE,
+}
+
 var (
 	allCodes = map[grpcCodes.Code]struct{}{
 		grpcCodes.OK:                 {},
@@ -40,8 +46,9 @@ var (
 )
 
 type (
-	ctxBanOnOperationError  struct{}
-	operationErrorCodesType []Ydb.StatusIds_StatusCode
+	ctxBanOnOperationError            struct{}
+	ctxBanOnContextDeadlineExceeded   struct{}
+	operationErrorCodesType           []Ydb.StatusIds_StatusCode
 )
 
 func BanOnOperationError(ctx context.Context, codes ...Ydb.StatusIds_StatusCode) context.Context {
@@ -55,6 +62,20 @@ func BanOnOperationError(ctx context.Context, codes ...Ydb.StatusIds_StatusCode)
 	return context.WithValue(ctx, ctxBanOnOperationError{}, allCodes)
 }
 
+// BanOnContextDeadlineExceeded marks ctx so that context.DeadlineExceeded on the RPC
+// pessimizes the connection. Intended for driver-level probes (CreateSession, AttachSession),
+// not for query execution timeouts on otherwise healthy nodes.
+func BanOnContextDeadlineExceeded(ctx context.Context) context.Context {
+	return context.WithValue(ctx, ctxBanOnContextDeadlineExceeded{}, true)
+}
+
+// BanOnSessionCreate marks ctx for CreateSession/AttachSession RPCs: ban the connection on
+// overload, unavailability, or client-side deadline exceeded.
+func BanOnSessionCreate(ctx context.Context) context.Context {
+	ctx = BanOnOperationError(ctx, sessionCreateBanOperationCodes...)
+	return BanOnContextDeadlineExceeded(ctx)
+}
+
 func IsBadConn(ctx context.Context, err error, ignoreCodes ...grpcCodes.Code) bool {
 	if xerrors.IsTransportError(err, xslices.Subtract(badCodes, ignoreCodes)...) {
 		return true
@@ -64,6 +85,12 @@ func IsBadConn(ctx context.Context, err error, ignoreCodes ...grpcCodes.Code) bo
 
 	if len(operationErrorCodes) > 0 && xerrors.IsOperationError(err, operationErrorCodes...) {
 		return true
+	}
+
+	if banOnContextDeadlineExceeded, _ := ctx.Value(ctxBanOnContextDeadlineExceeded{}).(bool); banOnContextDeadlineExceeded {
+		if xerrors.Is(err, context.DeadlineExceeded) {
+			return true
+		}
 	}
 
 	return false

--- a/internal/balancer/errors_test.go
+++ b/internal/balancer/errors_test.go
@@ -165,4 +165,5 @@ func TestBanOnSessionCreate(t *testing.T) {
 		xerrors.Operation(xerrors.WithStatusCode(Ydb.StatusIds_NOT_FOUND))),
 	))
 	require.True(t, IsBadConn(ctx, context.DeadlineExceeded))
+	require.False(t, IsBadConn(ctx, context.Canceled))
 }

--- a/internal/balancer/errors_test.go
+++ b/internal/balancer/errors_test.go
@@ -1,6 +1,7 @@
 package balancer
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -137,4 +138,31 @@ func TestBanOnOperationError(t *testing.T) {
 	require.True(t, IsBadConn(ctx, xerrors.WithStackTrace(
 		xerrors.Operation(xerrors.WithStatusCode(Ydb.StatusIds_ABORTED))),
 	))
+}
+
+func TestBanOnContextDeadlineExceeded(t *testing.T) {
+	ctx := xtest.Context(t)
+
+	require.False(t, IsBadConn(ctx, context.DeadlineExceeded))
+	require.False(t, IsBadConn(ctx, xerrors.WithStackTrace(context.DeadlineExceeded)))
+
+	ctx = BanOnContextDeadlineExceeded(ctx)
+	require.False(t, IsBadConn(ctx, context.Canceled))
+	require.True(t, IsBadConn(ctx, context.DeadlineExceeded))
+	require.True(t, IsBadConn(ctx, xerrors.WithStackTrace(context.DeadlineExceeded)))
+}
+
+func TestBanOnSessionCreate(t *testing.T) {
+	ctx := BanOnSessionCreate(xtest.Context(t))
+
+	require.True(t, IsBadConn(ctx, xerrors.WithStackTrace(
+		xerrors.Operation(xerrors.WithStatusCode(Ydb.StatusIds_OVERLOADED))),
+	))
+	require.True(t, IsBadConn(ctx, xerrors.WithStackTrace(
+		xerrors.Operation(xerrors.WithStatusCode(Ydb.StatusIds_UNAVAILABLE))),
+	))
+	require.False(t, IsBadConn(ctx, xerrors.WithStackTrace(
+		xerrors.Operation(xerrors.WithStatusCode(Ydb.StatusIds_NOT_FOUND))),
+	))
+	require.True(t, IsBadConn(ctx, context.DeadlineExceeded))
 }

--- a/internal/conn/config.go
+++ b/internal/conn/config.go
@@ -13,4 +13,6 @@ type Config interface {
 	ConnectionTTL() time.Duration
 	Trace() *trace.Driver
 	GrpcDialOptions() []grpc.DialOption
+	NotifyConnBan(nodeID uint32)
+	NotifyConnAllow(nodeID uint32)
 }

--- a/internal/conn/pool.go
+++ b/internal/conn/pool.go
@@ -95,6 +95,8 @@ func (p *Pool) Ban(ctx context.Context, cc Conn, cause error) {
 		stack.FunctionID("github.com/ydb-platform/ydb-go-sdk/v3/internal/conn.(*Pool).Ban"),
 		cc.Endpoint().Copy(), cc.GetState(), cause,
 	)(cc.SetState(ctx, state.Banned))
+
+	p.config.NotifyConnBan(cc.Endpoint().NodeID())
 }
 
 func (p *Pool) Allow(ctx context.Context, cc Conn) {
@@ -114,6 +116,8 @@ func (p *Pool) Allow(ctx context.Context, cc Conn) {
 		stack.FunctionID("github.com/ydb-platform/ydb-go-sdk/v3/internal/conn.(*Pool).Allow"),
 		e, cc.GetState(),
 	)(cc.Unban(ctx))
+
+	p.config.NotifyConnAllow(e.NodeID())
 }
 
 func (p *Pool) Take(context.Context) error {

--- a/internal/conn/pool_test.go
+++ b/internal/conn/pool_test.go
@@ -42,6 +42,10 @@ func (m *mockConfig) GrpcDialOptions() []grpc.DialOption {
 	return m.grpcDialOpts
 }
 
+func (m *mockConfig) NotifyConnBan(uint32) {}
+
+func (m *mockConfig) NotifyConnAllow(uint32) {}
+
 func TestPool_Get(t *testing.T) {
 	t.Run("GetSameConnectionTwice", func(t *testing.T) {
 		ctx := context.Background()

--- a/internal/pool/container.go
+++ b/internal/pool/container.go
@@ -89,3 +89,25 @@ func (items *sliceContainer[PT, T]) PopByNodeID(nodeID uint32) (*itemInfo[PT, T]
 
 	return nil, errNothingIdleItems
 }
+
+func (items *sliceContainer[PT, T]) RemoveAllByNodeID(nodeID uint32) (removed []*itemInfo[PT, T]) {
+	items.mu.Lock()
+	defer items.mu.Unlock()
+
+	if len(items.data) == 0 {
+		return nil
+	}
+
+	kept := items.data[:0]
+	for _, info := range items.data {
+		if info.item.NodeID() == nodeID {
+			removed = append(removed, info)
+		} else {
+			kept = append(kept, info)
+		}
+	}
+
+	items.data = kept
+
+	return removed
+}

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -367,6 +367,40 @@ func (p *Pool[PT, T]) Stats() Stats {
 	}
 }
 
+// DropIdleByNodeID closes and removes all idle pool items bound to nodeID.
+// In-use items are dropped on return via mustDeleteItemFunc when the node is marked banned.
+func (p *Pool[PT, T]) DropIdleByNodeID(ctx context.Context, nodeID uint32) (dropped int, finalErr error) {
+	select {
+	case <-ctx.Done():
+		return 0, xerrors.WithStackTrace(ctx.Err())
+	case <-p.done:
+		return 0, xerrors.WithStackTrace(errClosedPool)
+	case _, ok := <-p.sema:
+		if !ok {
+			return 0, xerrors.WithStackTrace(errClosedPool)
+		}
+		defer func() {
+			p.sema <- struct{}{}
+		}()
+	}
+
+	removed := p.idle.RemoveAllByNodeID(nodeID)
+	if len(removed) == 0 {
+		return 0, nil
+	}
+
+	var batchChanges dynamicStats
+	batchChanges.Idle -= len(removed)
+
+	for _, info := range removed {
+		p.closeItem(ctx, info.item, &batchChanges)
+	}
+
+	p.applyBatchStats(&batchChanges)
+
+	return len(removed), nil
+}
+
 func (p *Pool[PT, T]) checkItemAndError(item PT, err error) error {
 	if !item.IsAlive() {
 		return errItemIsNotAlive
@@ -714,6 +748,8 @@ func (p *Pool[PT, T]) getItem(ctx context.Context, batchChanges *dynamicStats) (
 		}
 
 		switch {
+		case p.config.mustDeleteItemFunc(info.item, nil):
+			p.closeItem(ctx, info.item, batchChanges)
 		case needCloseItem(p.config, info):
 			p.closeItem(ctx, info.item, batchChanges)
 		default:

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -406,12 +406,16 @@ func (p *Pool[PT, T]) checkItemAndError(item PT, err error) error {
 		return errItemIsNotAlive
 	}
 
-	if err == nil {
-		return nil
+	if p.config.mustDeleteItemFunc(item, err) {
+		if err == nil {
+			return errItemIsNotAlive
+		}
+
+		return err
 	}
 
-	if p.config.mustDeleteItemFunc(item, err) {
-		return err
+	if err == nil {
+		return nil
 	}
 
 	if !xerrors.IsValid(err, item) {
@@ -748,8 +752,6 @@ func (p *Pool[PT, T]) getItem(ctx context.Context, batchChanges *dynamicStats) (
 		}
 
 		switch {
-		case p.config.mustDeleteItemFunc(info.item, nil):
-			p.closeItem(ctx, info.item, batchChanges)
 		case needCloseItem(p.config, info):
 			p.closeItem(ctx, info.item, batchChanges)
 		default:

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -2606,6 +2606,93 @@ func TestDropIdleByNodeID(t *testing.T) {
 	requirePoolStats(t, p, poolStats(3, nil))
 }
 
+func TestDropIdleByNodeIDSkipsOtherNodes(t *testing.T) {
+	ctx := t.Context()
+
+	var (
+		nextID atomic.Uint32
+		closed atomic.Int32
+	)
+
+	p := mustNewPool[*testItem, testItem](t,
+		WithLimit[*testItem, testItem](2),
+		WithCreateItemFunc(func(context.Context) (*testItem, error) {
+			id := nextID.Add(1)
+
+			return &testItem{
+				onNodeID: func() uint32 {
+					if id == 1 {
+						return 10
+					}
+
+					return 20
+				},
+				onClose: func() error {
+					closed.Add(1)
+
+					return nil
+				},
+			}, nil
+		}),
+		WithTrace[*testItem, testItem](defaultTrace[*testItem, testItem]()),
+	)
+	t.Cleanup(func() {
+		_ = p.Close(ctx)
+	})
+
+	info1 := mustGetItem(t, p)
+	info2 := mustGetItem(t, p)
+	mustPutItem(t, p, info1)
+	mustPutItem(t, p, info2)
+	requirePoolStats(t, p, poolStats(2, func(s *Stats) { s.Size = 2; s.Idle = 2 }))
+
+	dropped, err := p.DropIdleByNodeID(ctx, 10)
+	require.NoError(t, err)
+	require.Equal(t, 1, dropped)
+	require.Equal(t, int32(1), closed.Load())
+	requirePoolStats(t, p, poolStats(2, func(s *Stats) { s.Size = 1; s.Idle = 1 }))
+}
+
+func TestPoolDropSessionOnReturnWhenBannedNode(t *testing.T) {
+	ctx := t.Context()
+	const bannedNodeID uint32 = 10
+
+	var closed atomic.Int32
+
+	p := mustNewPool[*testItem, testItem](t,
+		WithLimit[*testItem, testItem](1),
+		WithCreateItemFunc(func(context.Context) (*testItem, error) {
+			return &testItem{
+				onNodeID: func() uint32 {
+					return bannedNodeID
+				},
+				onClose: func() error {
+					closed.Add(1)
+
+					return nil
+				},
+			}, nil
+		}),
+		WithMustDeleteItemFunc(func(item *testItem, err error) bool {
+			if item.NodeID() == bannedNodeID {
+				return true
+			}
+
+			return !item.IsAlive()
+		}),
+		WithTrace[*testItem, testItem](defaultTrace[*testItem, testItem]()),
+	)
+	t.Cleanup(func() {
+		_ = p.Close(ctx)
+	})
+
+	require.NoError(t, p.With(ctx, func(context.Context, *testItem) error {
+		return nil
+	}))
+	require.Equal(t, int32(1), closed.Load())
+	requirePoolStats(t, p, poolStats(1, nil))
+}
+
 // BenchmarkPoolWith/concurrency=510-12   848.5             1000.0           278750         982    19
 // BenchmarkPoolWith/concurrency=1000-12  1129              1958.0           1738541        982    19
 func BenchmarkPoolWith(b *testing.B) {

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -2568,6 +2568,44 @@ func benchmarkPoolWithConcurrency(b *testing.B, goroutines int) {
 // BenchmarkPoolWith/concurrency=250-12   740.1             959.0            195708         982    19
 // BenchmarkPoolWith/concurrency=490-12   744.6             959.0            207209         982    19
 // BenchmarkPoolWith/concurrency=500-12   744.9             959.0            207291         982    19
+func TestDropIdleByNodeID(t *testing.T) {
+	ctx := t.Context()
+
+	var closed atomic.Int32
+
+	p := mustNewPool[*testItem, testItem](t,
+		WithLimit[*testItem, testItem](3),
+		WithCreateItemFunc(func(context.Context) (*testItem, error) {
+			return &testItem{
+				v: 1,
+				onNodeID: func() uint32 {
+					return 10
+				},
+				onClose: func() error {
+					closed.Add(1)
+
+					return nil
+				},
+			}, nil
+		}),
+		WithTrace[*testItem, testItem](defaultTrace[*testItem, testItem]()),
+	)
+	t.Cleanup(func() {
+		_ = p.Close(ctx)
+	})
+
+	require.NoError(t, p.With(ctx, func(context.Context, *testItem) error {
+		return nil
+	}))
+	requirePoolStats(t, p, poolStats(3, func(s *Stats) { s.Size = 1; s.Idle = 1 }))
+
+	dropped, err := p.DropIdleByNodeID(ctx, 10)
+	require.NoError(t, err)
+	require.Equal(t, 1, dropped)
+	require.Equal(t, int32(1), closed.Load())
+	requirePoolStats(t, p, poolStats(3, nil))
+}
+
 // BenchmarkPoolWith/concurrency=510-12   848.5             1000.0           278750         982    19
 // BenchmarkPoolWith/concurrency=1000-12  1129              1958.0           1738541        982    19
 func BenchmarkPoolWith(b *testing.B) {

--- a/internal/query/client.go
+++ b/internal/query/client.go
@@ -60,7 +60,7 @@ type (
 
 		closed *xsync.Value[*closeState]
 
-		bannedNodes sync.Map // nodeID -> struct{}
+		bannedNodes sync.Map // nodeID -> struct{}; cleared on discovery unban via OnConnAllowed
 	}
 )
 

--- a/internal/query/client.go
+++ b/internal/query/client.go
@@ -60,7 +60,7 @@ type (
 
 		closed *xsync.Value[*closeState]
 
-	bannedNodes sync.Map // nodeID -> struct{}
+		bannedNodes sync.Map // nodeID -> struct{}
 	}
 )
 
@@ -769,7 +769,6 @@ func New(ctx context.Context, cc grpc.ClientConnInterface, cfg *config.Config) (
 	return newWithQueryServiceClient(ctx, client, cc, cfg)
 }
 
-//nolint:funlen
 func newWithQueryServiceClient(ctx context.Context,
 	client Ydb_Query_V1.QueryServiceClient,
 	cc grpc.ClientConnInterface,

--- a/internal/query/client.go
+++ b/internal/query/client.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/ydb-platform/ydb-go-genproto/Ydb_Query_V1"
@@ -58,6 +59,8 @@ type (
 		implicitSessionPool sessionPool
 
 		closed *xsync.Value[*closeState]
+
+	bannedNodes sync.Map // nodeID -> struct{}
 	}
 )
 
@@ -787,13 +790,7 @@ func newWithQueryServiceClient(ctx context.Context,
 		pool.WithTrace[*Session](poolTrace(cfg.Trace())),
 		pool.WithCreateItemTimeout[*Session](cfg.SessionCreateTimeout()),
 		pool.WithCloseItemTimeout[*Session](cfg.SessionDeleteTimeout()),
-		pool.WithMustDeleteItemFunc(func(s *Session, err error) bool {
-			if !s.IsAlive() {
-				return true
-			}
-
-			return err != nil && xerrors.MustDeleteTableOrQuerySession(err)
-		}),
+		pool.WithMustDeleteItemFunc(c.mustDeleteSession),
 		pool.WithIdleTimeToLive[*Session](cfg.SessionIdleTimeToLive()),
 		pool.WithCreateItemFunc(func(ctx context.Context) (_ *Session, err error) {
 			if !cfg.DisableSessionBalancer() {
@@ -831,6 +828,47 @@ func newWithQueryServiceClient(ctx context.Context,
 	c.implicitSessionPool = implicitSessionPool
 
 	return c, nil
+}
+
+// OnConnBanned drops idle query sessions on nodeID and marks in-use sessions for removal.
+func (c *Client) OnConnBanned(ctx context.Context, nodeID uint32) {
+	if c == nil || nodeID == 0 {
+		return
+	}
+
+	c.bannedNodes.Store(nodeID, struct{}{})
+	c.dropIdleSessionsByNodeID(ctx, nodeID)
+}
+
+// OnConnAllowed clears banned-node marker after discovery unbans the connection.
+func (c *Client) OnConnAllowed(nodeID uint32) {
+	if c == nil || nodeID == 0 {
+		return
+	}
+
+	c.bannedNodes.Delete(nodeID)
+}
+
+func (c *Client) mustDeleteSession(s *Session, err error) bool {
+	if !s.IsAlive() {
+		return true
+	}
+
+	if _, banned := c.bannedNodes.Load(s.NodeID()); banned {
+		return true
+	}
+
+	return err != nil && xerrors.MustDeleteTableOrQuerySession(err)
+}
+
+func (c *Client) dropIdleSessionsByNodeID(ctx context.Context, nodeID uint32) {
+	if p, ok := c.explicitSessionPool.(*pool.Pool[*Session, Session]); ok {
+		_, _ = p.DropIdleByNodeID(ctx, nodeID)
+	}
+
+	if p, ok := c.implicitSessionPool.(*pool.Pool[*Session, Session]); ok {
+		_, _ = p.DropIdleByNodeID(ctx, nodeID)
+	}
 }
 
 func poolTrace(t *trace.Query) *pool.Trace[*Session, Session] {

--- a/internal/query/client_banned_node_test.go
+++ b/internal/query/client_banned_node_test.go
@@ -1,0 +1,22 @@
+package query
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientMustDeleteSessionOnBannedNode(t *testing.T) {
+	client := &Client{}
+	const nodeID uint32 = 42
+
+	client.bannedNodes.Store(nodeID, struct{}{})
+
+	s := &Session{Core: &sessionCore{nodeID: nodeID}}
+	s.SetStatus(StatusIdle)
+
+	require.True(t, client.mustDeleteSession(s, nil))
+
+	client.OnConnAllowed(nodeID)
+	require.False(t, client.mustDeleteSession(s, nil))
+}

--- a/internal/query/session_core.go
+++ b/internal/query/session_core.go
@@ -261,6 +261,9 @@ func (core *sessionCore) listenAttachStream(attachStream Ydb_Query_V1.QueryServi
 	for core.IsAlive() {
 		msg, recvErr := attachStream.Recv()
 		if recvErr != nil {
+			if core.onNodeShutdown != nil {
+				core.onNodeShutdown(recvErr)
+			}
 			core.releaseSession()
 
 			return

--- a/internal/query/session_core.go
+++ b/internal/query/session_core.go
@@ -218,12 +218,9 @@ func (core *sessionCore) attach(ctx context.Context) (finalErr error) {
 		}
 	}()
 
-	attachStream, err := core.Client.AttachSession(
-		balancer.BanOnSessionCreate(attachCtx),
-		&Ydb_Query.AttachSessionRequest{
-			SessionId: core.id,
-		},
-	)
+	attachStream, err := core.Client.AttachSession(attachCtx, &Ydb_Query.AttachSessionRequest{
+		SessionId: core.id,
+	})```
 	if err != nil {
 		return xerrors.WithStackTrace(err)
 	}

--- a/internal/query/session_core.go
+++ b/internal/query/session_core.go
@@ -220,7 +220,7 @@ func (core *sessionCore) attach(ctx context.Context) (finalErr error) {
 
 	attachStream, err := core.Client.AttachSession(attachCtx, &Ydb_Query.AttachSessionRequest{
 		SessionId: core.id,
-	})```
+	})
 	if err != nil {
 		return xerrors.WithStackTrace(err)
 	}

--- a/internal/query/session_core.go
+++ b/internal/query/session_core.go
@@ -173,7 +173,7 @@ func Open(
 	}()
 
 	response, err := client.CreateSession(
-		balancer.BanOnOperationError(ctx, Ydb.StatusIds_OVERLOADED),
+		balancer.BanOnSessionCreate(ctx),
 		&Ydb_Query.CreateSessionRequest{},
 	)
 	if err != nil {
@@ -218,9 +218,12 @@ func (core *sessionCore) attach(ctx context.Context) (finalErr error) {
 		}
 	}()
 
-	attachStream, err := core.Client.AttachSession(attachCtx, &Ydb_Query.AttachSessionRequest{
-		SessionId: core.id,
-	})
+	attachStream, err := core.Client.AttachSession(
+		balancer.BanOnSessionCreate(attachCtx),
+		&Ydb_Query.AttachSessionRequest{
+			SessionId: core.id,
+		},
+	)
 	if err != nil {
 		return xerrors.WithStackTrace(err)
 	}

--- a/internal/query/session_core.go
+++ b/internal/query/session_core.go
@@ -261,7 +261,7 @@ func (core *sessionCore) listenAttachStream(attachStream Ydb_Query_V1.QueryServi
 	for core.IsAlive() {
 		msg, recvErr := attachStream.Recv()
 		if recvErr != nil {
-			if core.onNodeShutdown != nil {
+			if core.onNodeShutdown != nil && !core.closed.Load() && !xerrors.IsContextError(recvErr) {
 				core.onNodeShutdown(recvErr)
 			}
 			core.releaseSession()

--- a/internal/table/session.go
+++ b/internal/table/session.go
@@ -276,7 +276,7 @@ func newTableSession(
 	ctx context.Context, cc grpc.ClientConnInterface, config *config.Config,
 ) (*Session, error) {
 	response, err := Ydb_Table_V1.NewTableServiceClient(cc).CreateSession(
-		balancer.BanOnOperationError(ctx, Ydb.StatusIds_OVERLOADED),
+		balancer.BanOnSessionCreate(ctx),
 		&Ydb_Table.CreateSessionRequest{
 			OperationParams: operation.Params(
 				ctx,


### PR DESCRIPTION
## Summary
- Drop idle query pool sessions by `NodeID` when the driver pessimizes a connection
- Mark banned nodes so in-use sessions are removed on return to the pool; clear the marker on discovery unban
- Ban the connection when the session attach stream ends with a transport error

## Motivation
After `BanOnSessionCreate`, `native-query` still spikes retries during ip-blackhole because long-lived sessions in the pool keep serving requests until they fail through many retry attempts. Purging sessions on ban avoids reusing sessions bound to a dead node.

## Test plan
- [x] `go test ./internal/pool/... -run DropIdle`
- [x] `go test ./internal/query/... -run BannedNode`


Made with [Cursor](https://cursor.com)