### PR TITLE
Make BulkUpsert non-idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-* Made client.BulkUpsert non-idempotent by default to mitigate unexpected CDC behavior.
+* Made client.BulkUpsert non-idempotent by default, so users may choose the behavior by themselves using `WithIdempotent`.
 
 ## v3.141.1
 * Added connection pessimization when creating table or query session fails with `OVERLOADED`, `UNAVAILABLE`, or client-side `context.DeadlineExceeded`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Made client.BulkUpsert non-idempotent by default to mitigate unexpected CDC behavior.
+
 ## v3.141.1
 * Added connection pessimization when creating table or query session fails with `OVERLOADED`, `UNAVAILABLE`, or client-side `context.DeadlineExceeded`
 

--- a/internal/table/client.go
+++ b/internal/table/client.go
@@ -388,7 +388,6 @@ func (c *Client) BulkUpsert(
 
 	attempts, config := 0, c.retryOptions(opts...)
 	config.RetryOptions = append(config.RetryOptions,
-		retry.WithIdempotent(true),
 		retry.WithTrace(&trace.Retry{
 			OnRetry: func(info trace.RetryLoopStartInfo) func(trace.RetryLoopDoneInfo) {
 				return func(info trace.RetryLoopDoneInfo) {


### PR DESCRIPTION
## Pull request type
Please check the type of change your PR introduces:

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Parallel BulkUpsert requests may fail with non-idempotent errors like state/UNDETERMINED and generate subsequent overwrites of each other visible both by querying the table in parallel and in CDC feed.

Issue Number: N/A

## Suggested behavior

BulkUpsert is not idempotent by default. Users may enable idempotent retries using `WithIdempotent()` option like in any other SDK query.
