### PR TITLE
Deprecate WithConcurrentResultSets and always enable it in Query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v3.141.3
+* Deprecated `query.WithConcurrentResultSets`: the option is now a no-op; `Client.Query` always enables concurrent result sets internally because it materializes the full response
+
 ## v3.141.2
 * Option `table.WithIdempotent()` allowed single optional `bool` argument now 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-## v3.141.3
 * Deprecated `query.WithConcurrentResultSets`: the option is now a no-op; `Client.Query` always enables concurrent result sets internally because it materializes the full response
 
 ## v3.141.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-* Deprecated `query.WithConcurrentResultSets`: the option is now a no-op; `Client.Query` always enables concurrent result sets internally because it materializes the full response
+* Deprecated `query.WithConcurrentResultSets`: the option is now a no-op; `Client.Query` always enables concurrent result sets internally because it materializes the full response. Session, transaction, and other streaming paths always send `concurrent_result_sets=false`
 
 ## v3.141.2
 * Option `table.WithIdempotent()` allowed single optional `bool` argument now 

--- a/internal/query/client.go
+++ b/internal/query/client.go
@@ -547,6 +547,7 @@ func clientQuery(ctx context.Context, pool sessionPool, q string, opts ...option
 	r query.Result, err error,
 ) {
 	settings := options.ExecuteSettings(opts...)
+	options.EnableConcurrentResultSets(settings)
 
 	if err := validateTxControl(settings); err != nil {
 		return nil, err

--- a/internal/query/client.go
+++ b/internal/query/client.go
@@ -495,7 +495,7 @@ func clientExec(ctx context.Context, pool sessionPool, q string, opts ...options
 	}
 
 	err := do(ctx, pool, func(ctx context.Context, s *Session) (err error) {
-		streamResult, err := s.execute(ctx, q, settings, options.OrderedResultSets,
+		streamResult, err := s.execute(ctx, q, settings, options.ResultSetsTypeOrdered,
 			withStreamResultTrace(s.trace), withIssuesHandler(settings.IssuesOpts()))
 		if err != nil {
 			return xerrors.WithStackTrace(err)
@@ -553,7 +553,7 @@ func clientQuery(ctx context.Context, pool sessionPool, q string, opts ...option
 	}
 
 	err = do(ctx, pool, func(ctx context.Context, s *Session) (err error) {
-		streamResult, err := s.execute(ctx, q, settings, options.ConcurrentResultSets,
+		streamResult, err := s.execute(ctx, q, settings, options.ResultSetsTypeConcurrent,
 			withStreamResultTrace(s.trace), withIssuesHandler(settings.IssuesOpts()))
 		if err != nil {
 			return xerrors.WithStackTrace(err)
@@ -608,7 +608,7 @@ func clientQueryResultSet(
 	}
 
 	err := do(ctx, pool, func(ctx context.Context, s *Session) error {
-		streamResult, err := s.execute(ctx, q, settings, options.OrderedResultSets, resultOpts...)
+		streamResult, err := s.execute(ctx, q, settings, options.ResultSetsTypeOrdered, resultOpts...)
 		if err != nil {
 			return xerrors.WithStackTrace(err)
 		}

--- a/internal/query/client.go
+++ b/internal/query/client.go
@@ -495,7 +495,7 @@ func clientExec(ctx context.Context, pool sessionPool, q string, opts ...options
 	}
 
 	err := do(ctx, pool, func(ctx context.Context, s *Session) (err error) {
-		streamResult, err := s.execute(ctx, q, settings,
+		streamResult, err := s.execute(ctx, q, settings, false,
 			withStreamResultTrace(s.trace), withIssuesHandler(settings.IssuesOpts()))
 		if err != nil {
 			return xerrors.WithStackTrace(err)
@@ -543,14 +543,6 @@ func (c *Client) Exec(ctx context.Context, q string, opts ...options.Execute) (f
 	return nil
 }
 
-type executeSettingsWithConcurrentResultSets struct {
-	executeSettings
-}
-
-func (executeSettingsWithConcurrentResultSets) ConcurrentResultSets() bool {
-	return true
-}
-
 func clientQuery(ctx context.Context, pool sessionPool, q string, opts ...options.Execute) (
 	r query.Result, err error,
 ) {
@@ -562,7 +554,7 @@ func clientQuery(ctx context.Context, pool sessionPool, q string, opts ...option
 
 	err = do(ctx, pool, func(ctx context.Context, s *Session) (err error) {
 		streamResult, err := s.execute(ctx, q,
-			executeSettingsWithConcurrentResultSets{settings},
+			settings, true,
 			withStreamResultTrace(s.trace), withIssuesHandler(settings.IssuesOpts()))
 		if err != nil {
 			return xerrors.WithStackTrace(err)
@@ -617,7 +609,7 @@ func clientQueryResultSet(
 	}
 
 	err := do(ctx, pool, func(ctx context.Context, s *Session) error {
-		streamResult, err := s.execute(ctx, q, settings, resultOpts...)
+		streamResult, err := s.execute(ctx, q, settings, false, resultOpts...)
 		if err != nil {
 			return xerrors.WithStackTrace(err)
 		}

--- a/internal/query/client.go
+++ b/internal/query/client.go
@@ -553,8 +553,7 @@ func clientQuery(ctx context.Context, pool sessionPool, q string, opts ...option
 	}
 
 	err = do(ctx, pool, func(ctx context.Context, s *Session) (err error) {
-		streamResult, err := s.execute(ctx, q,
-			settings, true,
+		streamResult, err := s.execute(ctx, q, settings, true,
 			withStreamResultTrace(s.trace), withIssuesHandler(settings.IssuesOpts()))
 		if err != nil {
 			return xerrors.WithStackTrace(err)

--- a/internal/query/client.go
+++ b/internal/query/client.go
@@ -543,11 +543,11 @@ func (c *Client) Exec(ctx context.Context, q string, opts ...options.Execute) (f
 	return nil
 }
 
-type executeSettingsWithConurrentResultSets struct {
+type executeSettingsWithConcurrentResultSets struct {
 	executeSettings
 }
 
-func (executeSettingsWithConurrentResultSets) ConcurrentResultSets() bool {
+func (executeSettingsWithConcurrentResultSets) ConcurrentResultSets() bool {
 	return true
 }
 
@@ -562,7 +562,7 @@ func clientQuery(ctx context.Context, pool sessionPool, q string, opts ...option
 
 	err = do(ctx, pool, func(ctx context.Context, s *Session) (err error) {
 		streamResult, err := s.execute(ctx, q,
-			executeSettingsWithConurrentResultSets{settings},
+			executeSettingsWithConcurrentResultSets{settings},
 			withStreamResultTrace(s.trace), withIssuesHandler(settings.IssuesOpts()))
 		if err != nil {
 			return xerrors.WithStackTrace(err)

--- a/internal/query/client.go
+++ b/internal/query/client.go
@@ -495,7 +495,7 @@ func clientExec(ctx context.Context, pool sessionPool, q string, opts ...options
 	}
 
 	err := do(ctx, pool, func(ctx context.Context, s *Session) (err error) {
-		streamResult, err := s.execute(ctx, q, settings, false,
+		streamResult, err := s.execute(ctx, q, settings, options.ORDERED_RESULT_SETS,
 			withStreamResultTrace(s.trace), withIssuesHandler(settings.IssuesOpts()))
 		if err != nil {
 			return xerrors.WithStackTrace(err)
@@ -553,7 +553,7 @@ func clientQuery(ctx context.Context, pool sessionPool, q string, opts ...option
 	}
 
 	err = do(ctx, pool, func(ctx context.Context, s *Session) (err error) {
-		streamResult, err := s.execute(ctx, q, settings, true,
+		streamResult, err := s.execute(ctx, q, settings, options.CONCURRENT_RESULT_SETS,
 			withStreamResultTrace(s.trace), withIssuesHandler(settings.IssuesOpts()))
 		if err != nil {
 			return xerrors.WithStackTrace(err)
@@ -608,7 +608,7 @@ func clientQueryResultSet(
 	}
 
 	err := do(ctx, pool, func(ctx context.Context, s *Session) error {
-		streamResult, err := s.execute(ctx, q, settings, false, resultOpts...)
+		streamResult, err := s.execute(ctx, q, settings, options.ORDERED_RESULT_SETS, resultOpts...)
 		if err != nil {
 			return xerrors.WithStackTrace(err)
 		}

--- a/internal/query/client.go
+++ b/internal/query/client.go
@@ -543,18 +543,26 @@ func (c *Client) Exec(ctx context.Context, q string, opts ...options.Execute) (f
 	return nil
 }
 
+type executeSettingsWithConurrentResultSets struct {
+	executeSettings
+}
+
+func (executeSettingsWithConurrentResultSets) ConcurrentResultSets() bool {
+	return true
+}
+
 func clientQuery(ctx context.Context, pool sessionPool, q string, opts ...options.Execute) (
 	r query.Result, err error,
 ) {
 	settings := options.ExecuteSettings(opts...)
-	options.EnableConcurrentResultSets(settings)
 
 	if err := validateTxControl(settings); err != nil {
 		return nil, err
 	}
 
 	err = do(ctx, pool, func(ctx context.Context, s *Session) (err error) {
-		streamResult, err := s.execute(ctx, q, settings,
+		streamResult, err := s.execute(ctx, q,
+			executeSettingsWithConurrentResultSets{settings},
 			withStreamResultTrace(s.trace), withIssuesHandler(settings.IssuesOpts()))
 		if err != nil {
 			return xerrors.WithStackTrace(err)

--- a/internal/query/client.go
+++ b/internal/query/client.go
@@ -495,7 +495,7 @@ func clientExec(ctx context.Context, pool sessionPool, q string, opts ...options
 	}
 
 	err := do(ctx, pool, func(ctx context.Context, s *Session) (err error) {
-		streamResult, err := s.execute(ctx, q, settings, options.ORDERED_RESULT_SETS,
+		streamResult, err := s.execute(ctx, q, settings, options.OrderedResultSets,
 			withStreamResultTrace(s.trace), withIssuesHandler(settings.IssuesOpts()))
 		if err != nil {
 			return xerrors.WithStackTrace(err)
@@ -553,7 +553,7 @@ func clientQuery(ctx context.Context, pool sessionPool, q string, opts ...option
 	}
 
 	err = do(ctx, pool, func(ctx context.Context, s *Session) (err error) {
-		streamResult, err := s.execute(ctx, q, settings, options.CONCURRENT_RESULT_SETS,
+		streamResult, err := s.execute(ctx, q, settings, options.ConcurrentResultSets,
 			withStreamResultTrace(s.trace), withIssuesHandler(settings.IssuesOpts()))
 		if err != nil {
 			return xerrors.WithStackTrace(err)
@@ -608,7 +608,7 @@ func clientQueryResultSet(
 	}
 
 	err := do(ctx, pool, func(ctx context.Context, s *Session) error {
-		streamResult, err := s.execute(ctx, q, settings, options.ORDERED_RESULT_SETS, resultOpts...)
+		streamResult, err := s.execute(ctx, q, settings, options.OrderedResultSets, resultOpts...)
 		if err != nil {
 			return xerrors.WithStackTrace(err)
 		}

--- a/internal/query/client_test.go
+++ b/internal/query/client_test.go
@@ -1128,7 +1128,7 @@ func TestClient(t *testing.T) {
 				require.Nil(t, row)
 			}
 		})
-		t.Run("ConcurrentResultSets", func(t *testing.T) {
+		t.Run("ConcurrentResultSetsType", func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 
 			colsAB := []*Ydb.Column{

--- a/internal/query/client_test.go
+++ b/internal/query/client_test.go
@@ -1128,7 +1128,7 @@ func TestClient(t *testing.T) {
 				require.Nil(t, row)
 			}
 		})
-		t.Run("ConcurrentResultSetsType", func(t *testing.T) {
+		t.Run("ResultSetsType", func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 
 			colsAB := []*Ydb.Column{

--- a/internal/query/client_test.go
+++ b/internal/query/client_test.go
@@ -1189,7 +1189,7 @@ func TestClient(t *testing.T) {
 
 			r, err := clientQuery(ctx, testPool(t, func(context.Context) (*Session, error) {
 				return newTestSessionWithClient("123", client, true), nil
-			}), "", query.WithConcurrentResultSets(true))
+			}), "")
 			require.NoError(t, err)
 
 			{
@@ -1269,7 +1269,7 @@ func TestClient(t *testing.T) {
 
 			_, err := clientQuery(executeCtx, testPool(t, func(context.Context) (*Session, error) {
 				return newTestSessionWithClient("123", client, true), nil
-			}), "", query.WithConcurrentResultSets(true))
+			}), "")
 
 			require.ErrorIs(t, err, context.Canceled)
 		})
@@ -1300,7 +1300,7 @@ func TestClient(t *testing.T) {
 
 			r, err := clientQuery(ctx, testPool(t, func(context.Context) (*Session, error) {
 				return newTestSessionWithClient("123", client, true), nil
-			}), "", query.WithConcurrentResultSets(true))
+			}), "")
 			require.NoError(t, err)
 
 			rs, err := r.NextResultSet(ctx)

--- a/internal/query/concurrent_result_sets_test.go
+++ b/internal/query/concurrent_result_sets_test.go
@@ -57,8 +57,8 @@ func TestClientConcurrentResultSets(t *testing.T) {
 	})
 
 	t.Run("WithConcurrentResultSetsNoop", func(t *testing.T) {
-		require.NotNil(t, query.WithConcurrentResultSets(true))
-		require.NotNil(t, query.WithConcurrentResultSets(false))
+		require.NotNil(t, query.WithConcurrentResultSets(true))  //nolint:staticcheck
+		require.NotNil(t, query.WithConcurrentResultSets(false)) //nolint:staticcheck
 	})
 
 	t.Run("ClientQueryMaterializesInterleavedResultSets", func(t *testing.T) {
@@ -175,9 +175,7 @@ func executeQueryChecker(
 	wantConcurrentResultSets bool,
 	ctrl *gomock.Controller,
 ) func(
-	context.Context,
-	*Ydb_Query.ExecuteQueryRequest,
-	...grpc.CallOption,
+	context.Context, *Ydb_Query.ExecuteQueryRequest, ...grpc.CallOption,
 ) (Ydb_Query_V1.QueryService_ExecuteQueryClient, error) {
 	t.Helper()
 

--- a/internal/query/concurrent_result_sets_test.go
+++ b/internal/query/concurrent_result_sets_test.go
@@ -55,6 +55,69 @@ func TestClientConcurrentResultSets(t *testing.T) {
 		})
 		require.NoError(t, err)
 	})
+
+	t.Run("WithConcurrentResultSetsNoop", func(t *testing.T) {
+		require.NotNil(t, query.WithConcurrentResultSets(true))
+		require.NotNil(t, query.WithConcurrentResultSets(false))
+	})
+
+	t.Run("ClientQueryMaterializesInterleavedResultSets", func(t *testing.T) {
+		ctx := t.Context()
+		ctrl := gomock.NewController(t)
+
+		queryService := NewMockQueryServiceClient(ctrl)
+		queryService.EXPECT().
+			ExecuteQuery(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(
+				_ context.Context,
+				req *Ydb_Query.ExecuteQueryRequest,
+				_ ...grpc.CallOption,
+			) (Ydb_Query_V1.QueryService_ExecuteQueryClient, error) {
+				require.True(t, req.GetConcurrentResultSets())
+
+				return interleavedMultiResultSetStream(ctrl), nil
+			})
+
+		client, err := newWithQueryServiceClient(ctx, queryService, nil, implicitSessionConfig())
+		require.NoError(t, err)
+
+		r, err := client.Query(ctx, "SELECT 1; SELECT 2")
+		require.NoError(t, err)
+		defer func() { _ = r.Close(ctx) }()
+
+		rs0, err := r.NextResultSet(ctx)
+		require.NoError(t, err)
+		require.Equal(t, 0, rs0.Index())
+
+		for _, want := range []int64{10, 11} {
+			row, err := rs0.NextRow(ctx)
+			require.NoError(t, err)
+
+			var got int64
+			require.NoError(t, row.Scan(&got))
+			require.Equal(t, want, got)
+		}
+		_, err = rs0.NextRow(ctx)
+		require.ErrorIs(t, err, io.EOF)
+
+		rs1, err := r.NextResultSet(ctx)
+		require.NoError(t, err)
+		require.Equal(t, 1, rs1.Index())
+
+		for _, want := range []int64{20, 21} {
+			row, err := rs1.NextRow(ctx)
+			require.NoError(t, err)
+
+			var got int64
+			require.NoError(t, row.Scan(&got))
+			require.Equal(t, want, got)
+		}
+		_, err = rs1.NextRow(ctx)
+		require.ErrorIs(t, err, io.EOF)
+
+		_, err = r.NextResultSet(ctx)
+		require.ErrorIs(t, err, io.EOF)
+	})
 }
 
 func implicitSessionConfig() *config.Config {
@@ -137,6 +200,42 @@ func singleRowExecuteQueryStream(ctrl *gomock.Controller) *MockQueryService_Exec
 			Rows: []*Ydb.Value{{}},
 		},
 	}, nil)
+	stream.EXPECT().Recv().Return(nil, io.EOF)
+
+	return stream
+}
+
+func interleavedMultiResultSetStream(ctrl *gomock.Controller) *MockQueryService_ExecuteQueryClient {
+	int64Type := &Ydb.Type{Type: &Ydb.Type_TypeId{TypeId: Ydb.Type_INT64}}
+	int64Col := func(name string) *Ydb.Column {
+		return &Ydb.Column{Name: name, Type: int64Type}
+	}
+	int64Row := func(v int64) *Ydb.Value {
+		return &Ydb.Value{Items: []*Ydb.Value{{
+			Value: &Ydb.Value_Int64Value{Int64Value: v},
+		}}}
+	}
+	respPart := func(idx int64, columns []*Ydb.Column, rows []*Ydb.Value) *Ydb_Query.ExecuteQueryResponsePart {
+		return &Ydb_Query.ExecuteQueryResponsePart{
+			Status:         Ydb.StatusIds_SUCCESS,
+			ResultSetIndex: idx,
+			ResultSet: &Ydb.ResultSet{
+				Columns: columns,
+				Rows:    rows,
+			},
+		}
+	}
+
+	stream := newExecuteQueryStreamMock(ctrl)
+	parts := []*Ydb_Query.ExecuteQueryResponsePart{
+		respPart(0, []*Ydb.Column{int64Col("a")}, []*Ydb.Value{int64Row(10)}),
+		respPart(1, []*Ydb.Column{int64Col("b")}, []*Ydb.Value{int64Row(20)}),
+		respPart(0, nil, []*Ydb.Value{int64Row(11)}),
+		respPart(1, nil, []*Ydb.Value{int64Row(21)}),
+	}
+	for _, part := range parts {
+		stream.EXPECT().Recv().Return(part, nil)
+	}
 	stream.EXPECT().Recv().Return(nil, io.EOF)
 
 	return stream

--- a/internal/query/concurrent_result_sets_test.go
+++ b/internal/query/concurrent_result_sets_test.go
@@ -1,0 +1,143 @@
+package query
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/ydb-platform/ydb-go-genproto/Ydb_Query_V1"
+	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb"
+	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Query"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/query/config"
+	"github.com/ydb-platform/ydb-go-sdk/v3/query"
+)
+
+func TestClientConcurrentResultSets(t *testing.T) {
+	ctx := t.Context()
+
+	t.Run("ClientQuery", func(t *testing.T) {
+		client := newMockClientCheckingConcurrentResultSets(t, implicitSessionConfig(), true)
+
+		r, err := client.Query(ctx, "SELECT 1")
+		require.NoError(t, err)
+		require.NoError(t, r.Close(ctx))
+	})
+
+	t.Run("ClientQueryResultSet", func(t *testing.T) {
+		client := newMockClientCheckingConcurrentResultSets(t, implicitSessionConfig(), false)
+
+		rs, err := client.QueryResultSet(ctx, "SELECT 1")
+		require.NoError(t, err)
+		require.NoError(t, rs.Close(ctx))
+	})
+
+	t.Run("ClientQueryRow", func(t *testing.T) {
+		client := newMockClientCheckingConcurrentResultSets(t, implicitSessionConfig(), false)
+
+		_, err := client.QueryRow(ctx, "SELECT 1")
+		require.NoError(t, err)
+	})
+
+	t.Run("DoSessionQuery", func(t *testing.T) {
+		client := newMockClientCheckingConcurrentResultSets(t, explicitSessionConfig(), false)
+
+		err := client.Do(ctx, func(ctx context.Context, s query.Session) error {
+			r, err := s.Query(ctx, "SELECT 1")
+			if err != nil {
+				return err
+			}
+
+			return r.Close(ctx)
+		})
+		require.NoError(t, err)
+	})
+}
+
+func implicitSessionConfig() *config.Config {
+	return config.New(config.AllowImplicitSessions())
+}
+
+func explicitSessionConfig() *config.Config {
+	return config.New()
+}
+
+func newMockClientCheckingConcurrentResultSets(
+	t *testing.T,
+	cfg *config.Config,
+	wantConcurrentResultSets bool,
+) *Client {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	queryService := NewMockQueryServiceClient(ctrl)
+
+	if cfg.AllowImplicitSessions() {
+		queryService.EXPECT().
+			ExecuteQuery(gomock.Any(), gomock.Any()).
+			DoAndReturn(executeQueryChecker(t, wantConcurrentResultSets, ctrl)).
+			Times(1)
+	} else {
+		attachStream := NewMockQueryService_AttachSessionClient(ctrl)
+		stubAttachStreamContext(attachStream)
+		attachStream.EXPECT().Recv().Return(&Ydb_Query.SessionState{
+			Status: Ydb.StatusIds_SUCCESS,
+		}, nil).AnyTimes()
+
+		queryService.EXPECT().CreateSession(gomock.Any(), gomock.Any()).Return(&Ydb_Query.CreateSessionResponse{
+			Status:    Ydb.StatusIds_SUCCESS,
+			SessionId: "test-session",
+		}, nil)
+		queryService.EXPECT().AttachSession(gomock.Any(), gomock.Any()).Return(attachStream, nil)
+		queryService.EXPECT().DeleteSession(gomock.Any(), gomock.Any()).Return(&Ydb_Query.DeleteSessionResponse{
+			Status: Ydb.StatusIds_SUCCESS,
+		}, nil).AnyTimes()
+		queryService.EXPECT().
+			ExecuteQuery(gomock.Any(), gomock.Any()).
+			DoAndReturn(executeQueryChecker(t, wantConcurrentResultSets, ctrl)).
+			Times(1)
+	}
+
+	client, err := newWithQueryServiceClient(t.Context(), queryService, nil, cfg)
+	require.NoError(t, err)
+
+	return client
+}
+
+func executeQueryChecker(
+	t *testing.T,
+	wantConcurrentResultSets bool,
+	ctrl *gomock.Controller,
+) func(
+	context.Context,
+	*Ydb_Query.ExecuteQueryRequest,
+	...grpc.CallOption,
+) (Ydb_Query_V1.QueryService_ExecuteQueryClient, error) {
+	t.Helper()
+
+	return func(
+		_ context.Context,
+		req *Ydb_Query.ExecuteQueryRequest,
+		_ ...grpc.CallOption,
+	) (Ydb_Query_V1.QueryService_ExecuteQueryClient, error) {
+		require.Equal(t, wantConcurrentResultSets, req.GetConcurrentResultSets())
+
+		return singleRowExecuteQueryStream(ctrl), nil
+	}
+}
+
+func singleRowExecuteQueryStream(ctrl *gomock.Controller) *MockQueryService_ExecuteQueryClient {
+	stream := newExecuteQueryStreamMock(ctrl)
+	stream.EXPECT().Recv().Return(&Ydb_Query.ExecuteQueryResponsePart{
+		Status: Ydb.StatusIds_SUCCESS,
+		ResultSet: &Ydb.ResultSet{
+			Rows: []*Ydb.Value{{}},
+		},
+	}, nil)
+	stream.EXPECT().Recv().Return(nil, io.EOF)
+
+	return stream
+}

--- a/internal/query/concurrent_result_sets_test.go
+++ b/internal/query/concurrent_result_sets_test.go
@@ -56,6 +56,41 @@ func TestClientConcurrentResultSets(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("DoTxQuery", func(t *testing.T) {
+		ctx := t.Context()
+		ctrl := gomock.NewController(t)
+		queryService := NewMockQueryServiceClient(ctrl)
+		setupExplicitSessionQueryService(t, ctrl, queryService)
+
+		queryService.EXPECT().BeginTransaction(gomock.Any(), gomock.Any()).Return(&Ydb_Query.BeginTransactionResponse{
+			Status: Ydb.StatusIds_SUCCESS,
+			TxMeta: &Ydb_Query.TransactionMeta{Id: "tx-1"},
+		}, nil)
+		queryService.EXPECT().
+			ExecuteQuery(gomock.Any(), gomock.Any()).
+			DoAndReturn(executeQueryChecker(t, false, ctrl)).
+			Times(1)
+		queryService.EXPECT().CommitTransaction(gomock.Any(), gomock.Any()).Return(&Ydb_Query.CommitTransactionResponse{
+			Status: Ydb.StatusIds_SUCCESS,
+		}, nil)
+		queryService.EXPECT().RollbackTransaction(gomock.Any(), gomock.Any()).Return(&Ydb_Query.RollbackTransactionResponse{
+			Status: Ydb.StatusIds_SUCCESS,
+		}, nil).AnyTimes()
+
+		client, err := newWithQueryServiceClient(ctx, queryService, nil, explicitSessionConfig())
+		require.NoError(t, err)
+
+		err = client.DoTx(ctx, func(ctx context.Context, tx query.TxActor) error {
+			r, err := tx.Query(ctx, "SELECT 1")
+			if err != nil {
+				return err
+			}
+
+			return r.Close(ctx)
+		})
+		require.NoError(t, err)
+	})
+
 	t.Run("WithConcurrentResultSetsNoop", func(t *testing.T) {
 		require.NotNil(t, query.WithConcurrentResultSets(true))  //nolint:staticcheck
 		require.NotNil(t, query.WithConcurrentResultSets(false)) //nolint:staticcheck
@@ -144,20 +179,7 @@ func newMockClientCheckingConcurrentResultSets(
 			DoAndReturn(executeQueryChecker(t, wantConcurrentResultSets, ctrl)).
 			Times(1)
 	} else {
-		attachStream := NewMockQueryService_AttachSessionClient(ctrl)
-		stubAttachStreamContext(attachStream)
-		attachStream.EXPECT().Recv().Return(&Ydb_Query.SessionState{
-			Status: Ydb.StatusIds_SUCCESS,
-		}, nil).AnyTimes()
-
-		queryService.EXPECT().CreateSession(gomock.Any(), gomock.Any()).Return(&Ydb_Query.CreateSessionResponse{
-			Status:    Ydb.StatusIds_SUCCESS,
-			SessionId: "test-session",
-		}, nil)
-		queryService.EXPECT().AttachSession(gomock.Any(), gomock.Any()).Return(attachStream, nil)
-		queryService.EXPECT().DeleteSession(gomock.Any(), gomock.Any()).Return(&Ydb_Query.DeleteSessionResponse{
-			Status: Ydb.StatusIds_SUCCESS,
-		}, nil).AnyTimes()
+		setupExplicitSessionQueryService(t, ctrl, queryService)
 		queryService.EXPECT().
 			ExecuteQuery(gomock.Any(), gomock.Any()).
 			DoAndReturn(executeQueryChecker(t, wantConcurrentResultSets, ctrl)).
@@ -168,6 +190,29 @@ func newMockClientCheckingConcurrentResultSets(
 	require.NoError(t, err)
 
 	return client
+}
+
+func setupExplicitSessionQueryService(
+	t *testing.T,
+	ctrl *gomock.Controller,
+	queryService *MockQueryServiceClient,
+) {
+	t.Helper()
+
+	attachStream := NewMockQueryService_AttachSessionClient(ctrl)
+	stubAttachStreamContext(attachStream)
+	attachStream.EXPECT().Recv().Return(&Ydb_Query.SessionState{
+		Status: Ydb.StatusIds_SUCCESS,
+	}, nil).AnyTimes()
+
+	queryService.EXPECT().CreateSession(gomock.Any(), gomock.Any()).Return(&Ydb_Query.CreateSessionResponse{
+		Status:    Ydb.StatusIds_SUCCESS,
+		SessionId: "test-session",
+	}, nil)
+	queryService.EXPECT().AttachSession(gomock.Any(), gomock.Any()).Return(attachStream, nil)
+	queryService.EXPECT().DeleteSession(gomock.Any(), gomock.Any()).Return(&Ydb_Query.DeleteSessionResponse{
+		Status: Ydb.StatusIds_SUCCESS,
+	}, nil).AnyTimes()
 }
 
 func executeQueryChecker(

--- a/internal/query/execute_query.go
+++ b/internal/query/execute_query.go
@@ -75,7 +75,7 @@ func executeQueryScriptRequest(q string, cfg executeScriptConfig) (
 }
 
 func executeQueryRequest(
-	sessionID, q string, cfg executeSettings, concurrentResultSets options.ConcurrentResultSetsType,
+	sessionID, q string, cfg executeSettings, concurrentResultSets options.ResultSetsType,
 ) (
 	*Ydb_Query.ExecuteQueryRequest, []grpc.CallOption, error,
 ) {
@@ -96,7 +96,7 @@ func executeQueryRequest(
 		},
 		Parameters:             params,
 		StatsMode:              Ydb_Query.StatsMode(cfg.StatsMode()),
-		ConcurrentResultSets:   concurrentResultSets.Flag,
+		ConcurrentResultSets:   concurrentResultSets == options.ResultSetsTypeConcurrent,
 		PoolId:                 cfg.ResourcePool(),
 		ResponsePartLimitBytes: cfg.ResponsePartLimitSizeBytes(),
 	}
@@ -113,7 +113,7 @@ func queryQueryContent(syntax Ydb_Query.Syntax, q string) *Ydb_Query.QueryConten
 
 func execute(
 	ctx context.Context, sessionID string, c Ydb_Query_V1.QueryServiceClient,
-	q string, settings executeSettings, concurrentResultSets options.ConcurrentResultSetsType, opts ...resultOption,
+	q string, settings executeSettings, concurrentResultSets options.ResultSetsType, opts ...resultOption,
 ) (
 	_ *streamResult, finalErr error,
 ) {

--- a/internal/query/execute_query.go
+++ b/internal/query/execute_query.go
@@ -96,7 +96,7 @@ func executeQueryRequest(
 		},
 		Parameters:             params,
 		StatsMode:              Ydb_Query.StatsMode(cfg.StatsMode()),
-		ConcurrentResultSets:   bool(concurrentResultSets),
+		ConcurrentResultSets:   concurrentResultSets.Flag,
 		PoolId:                 cfg.ResourcePool(),
 		ResponsePartLimitBytes: cfg.ResponsePartLimitSizeBytes(),
 	}

--- a/internal/query/execute_query.go
+++ b/internal/query/execute_query.go
@@ -33,7 +33,6 @@ type executeSettings interface {
 	ResourcePool() string
 	ResponsePartLimitSizeBytes() int64
 	Label() string
-	ConcurrentResultSets() bool
 	UserProvidedTxControl() bool
 	IssuesOpts() func([]*Ydb_Issue.IssueMessage)
 	ResponsePartPrefetch() int
@@ -75,10 +74,10 @@ func executeQueryScriptRequest(q string, cfg executeScriptConfig) (
 	return request, cfg.CallOptions(), nil
 }
 
-func executeQueryRequest(sessionID, q string, cfg executeSettings) (
-	*Ydb_Query.ExecuteQueryRequest,
-	[]grpc.CallOption,
-	error,
+func executeQueryRequest(
+	sessionID, q string, cfg executeSettings, concurrentResultSets bool,
+) (
+	*Ydb_Query.ExecuteQueryRequest, []grpc.CallOption, error,
 ) {
 	params, err := cfg.Params().ToYDB()
 	if err != nil {
@@ -97,7 +96,7 @@ func executeQueryRequest(sessionID, q string, cfg executeSettings) (
 		},
 		Parameters:             params,
 		StatsMode:              Ydb_Query.StatsMode(cfg.StatsMode()),
-		ConcurrentResultSets:   cfg.ConcurrentResultSets(),
+		ConcurrentResultSets:   concurrentResultSets,
 		PoolId:                 cfg.ResourcePool(),
 		ResponsePartLimitBytes: cfg.ResponsePartLimitSizeBytes(),
 	}
@@ -114,11 +113,11 @@ func queryQueryContent(syntax Ydb_Query.Syntax, q string) *Ydb_Query.QueryConten
 
 func execute(
 	ctx context.Context, sessionID string, c Ydb_Query_V1.QueryServiceClient,
-	q string, settings executeSettings, opts ...resultOption,
+	q string, settings executeSettings, concurrentResultSets bool, opts ...resultOption,
 ) (
 	_ *streamResult, finalErr error,
 ) {
-	request, callOptions, err := executeQueryRequest(sessionID, q, settings)
+	request, callOptions, err := executeQueryRequest(sessionID, q, settings, concurrentResultSets)
 	if err != nil {
 		return nil, xerrors.WithStackTrace(err)
 	}

--- a/internal/query/execute_query.go
+++ b/internal/query/execute_query.go
@@ -75,7 +75,7 @@ func executeQueryScriptRequest(q string, cfg executeScriptConfig) (
 }
 
 func executeQueryRequest(
-	sessionID, q string, cfg executeSettings, concurrentResultSets bool,
+	sessionID, q string, cfg executeSettings, concurrentResultSets options.ConcurrentResultSets,
 ) (
 	*Ydb_Query.ExecuteQueryRequest, []grpc.CallOption, error,
 ) {
@@ -96,7 +96,7 @@ func executeQueryRequest(
 		},
 		Parameters:             params,
 		StatsMode:              Ydb_Query.StatsMode(cfg.StatsMode()),
-		ConcurrentResultSets:   concurrentResultSets,
+		ConcurrentResultSets:   bool(concurrentResultSets),
 		PoolId:                 cfg.ResourcePool(),
 		ResponsePartLimitBytes: cfg.ResponsePartLimitSizeBytes(),
 	}
@@ -113,7 +113,7 @@ func queryQueryContent(syntax Ydb_Query.Syntax, q string) *Ydb_Query.QueryConten
 
 func execute(
 	ctx context.Context, sessionID string, c Ydb_Query_V1.QueryServiceClient,
-	q string, settings executeSettings, concurrentResultSets bool, opts ...resultOption,
+	q string, settings executeSettings, concurrentResultSets options.ConcurrentResultSets, opts ...resultOption,
 ) (
 	_ *streamResult, finalErr error,
 ) {

--- a/internal/query/execute_query.go
+++ b/internal/query/execute_query.go
@@ -75,7 +75,7 @@ func executeQueryScriptRequest(q string, cfg executeScriptConfig) (
 }
 
 func executeQueryRequest(
-	sessionID, q string, cfg executeSettings, concurrentResultSets options.ConcurrentResultSets,
+	sessionID, q string, cfg executeSettings, concurrentResultSets options.ConcurrentResultSetsType,
 ) (
 	*Ydb_Query.ExecuteQueryRequest, []grpc.CallOption, error,
 ) {
@@ -113,7 +113,7 @@ func queryQueryContent(syntax Ydb_Query.Syntax, q string) *Ydb_Query.QueryConten
 
 func execute(
 	ctx context.Context, sessionID string, c Ydb_Query_V1.QueryServiceClient,
-	q string, settings executeSettings, concurrentResultSets options.ConcurrentResultSets, opts ...resultOption,
+	q string, settings executeSettings, concurrentResultSets options.ConcurrentResultSetsType, opts ...resultOption,
 ) (
 	_ *streamResult, finalErr error,
 ) {

--- a/internal/query/execute_query_test.go
+++ b/internal/query/execute_query_test.go
@@ -31,7 +31,7 @@ func TestExecute(t *testing.T) {
 		client := NewMockQueryServiceClient(ctrl)
 		client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
 		var txID string
-		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(),
+		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), false,
 			onTxMeta(func(txMeta *Ydb_Query.TransactionMeta) {
 				txID = txMeta.GetId()
 			}),
@@ -145,7 +145,7 @@ func TestExecute(t *testing.T) {
 			client := NewMockQueryServiceClient(ctrl)
 			client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(nil, grpcStatus.Error(grpcCodes.Unavailable, ""))
 			t.Log("execute")
-			_, err := execute(ctx, "123", client, "", options.ExecuteSettings())
+			_, err := execute(ctx, "123", client, "", options.ExecuteSettings(), false)
 			require.Error(t, err)
 			require.True(t, xerrors.IsTransportError(err, grpcCodes.Unavailable))
 		})
@@ -250,7 +250,7 @@ func TestExecute(t *testing.T) {
 			client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
 			t.Log("execute")
 			var txID string
-			r, err := execute(ctx, "123", client, "", options.ExecuteSettings(),
+			r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), false,
 				onTxMeta(func(txMeta *Ydb_Query.TransactionMeta) {
 					txID = txMeta.GetId()
 				}),
@@ -314,7 +314,7 @@ func TestExecute(t *testing.T) {
 			client := NewMockQueryServiceClient(ctrl)
 			client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
 			t.Log("execute")
-			_, err := execute(ctx, "123", client, "", options.ExecuteSettings())
+			_, err := execute(ctx, "123", client, "", options.ExecuteSettings(), false)
 			require.Error(t, err)
 			require.True(t, xerrors.IsOperationError(err, Ydb.StatusIds_UNAVAILABLE))
 		})
@@ -391,7 +391,7 @@ func TestExecute(t *testing.T) {
 			client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
 			t.Log("execute")
 			var txID string
-			r, err := execute(ctx, "123", client, "", options.ExecuteSettings(),
+			r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), false,
 				onTxMeta(func(txMeta *Ydb_Query.TransactionMeta) {
 					txID = txMeta.GetId()
 				}),
@@ -458,7 +458,7 @@ func TestExecute(t *testing.T) {
 				})
 
 			// When execute() with context, cancelled in progress
-			_, err := execute(ctx, "123", client, "", options.ExecuteSettings())
+			_, err := execute(ctx, "123", client, "", options.ExecuteSettings(), false)
 
 			// Then context cancellation error is returned
 			require.ErrorIs(t, err, context.Canceled)
@@ -481,7 +481,7 @@ func TestExecute(t *testing.T) {
 				})
 
 			executeCtx, cancelExecuteCtx := context.WithCancel(t.Context())
-			r, err := execute(executeCtx, "123", client, "", options.ExecuteSettings())
+			r, err := execute(executeCtx, "123", client, "", options.ExecuteSettings(), false)
 			require.NoError(t, err)
 
 			cancelExecuteCtx()
@@ -544,7 +544,7 @@ func TestExecute(t *testing.T) {
 					})
 
 				_, err := execute(xcontext.WithIdempotent(ctx, true),
-					"123", client, "", options.ExecuteSettings(),
+					"123", client, "", options.ExecuteSettings(), false,
 				)
 				require.Error(t, err)
 				require.ErrorIs(t, err, context.Canceled)
@@ -575,7 +575,7 @@ func TestExecute(t *testing.T) {
 					})
 
 				_, err := execute(ctx, // xcontext.WithIdempotent(ctx, false),
-					"123", client, "", options.ExecuteSettings(),
+					"123", client, "", options.ExecuteSettings(), false,
 				)
 				require.Error(t, err)
 				require.ErrorIs(t, err, context.Canceled)
@@ -607,7 +607,7 @@ func TestExecute(t *testing.T) {
 					return stream, nil
 				})
 
-			r, err := execute(t.Context(), "123", client, "", options.ExecuteSettings())
+			r, err := execute(t.Context(), "123", client, "", options.ExecuteSettings(), false)
 			require.NoError(t, err)
 
 			callCtx, callCancel := context.WithCancel(t.Context())
@@ -657,7 +657,7 @@ func TestExecute(t *testing.T) {
 					return stream, nil
 				})
 
-			r, err := execute(t.Context(), "123", client, "", options.ExecuteSettings(),
+			r, err := execute(t.Context(), "123", client, "", options.ExecuteSettings(), false,
 				withStreamResultCloseTimeout(50*time.Millisecond),
 			)
 			require.NoError(t, err)
@@ -1000,7 +1000,7 @@ func TestExecuteQueryRequest(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			request, callOptions, err := executeQueryRequest(tt.name, tt.name, options.ExecuteSettings(tt.opts...))
+			request, callOptions, err := executeQueryRequest(tt.name, tt.name, options.ExecuteSettings(tt.opts...), false)
 			require.NoError(t, err)
 			require.Equal(t, request.String(), tt.request.String())
 			require.Equal(t, tt.callOptions, callOptions)

--- a/internal/query/execute_query_test.go
+++ b/internal/query/execute_query_test.go
@@ -31,7 +31,7 @@ func TestExecute(t *testing.T) {
 		client := NewMockQueryServiceClient(ctrl)
 		client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
 		var txID string
-		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.OrderedResultSets,
+		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.ResultSetsTypeOrdered,
 			onTxMeta(func(txMeta *Ydb_Query.TransactionMeta) {
 				txID = txMeta.GetId()
 			}),
@@ -145,7 +145,7 @@ func TestExecute(t *testing.T) {
 			client := NewMockQueryServiceClient(ctrl)
 			client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(nil, grpcStatus.Error(grpcCodes.Unavailable, ""))
 			t.Log("execute")
-			_, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.OrderedResultSets)
+			_, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.ResultSetsTypeOrdered)
 			require.Error(t, err)
 			require.True(t, xerrors.IsTransportError(err, grpcCodes.Unavailable))
 		})
@@ -250,7 +250,7 @@ func TestExecute(t *testing.T) {
 			client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
 			t.Log("execute")
 			var txID string
-			r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.OrderedResultSets,
+			r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.ResultSetsTypeOrdered,
 				onTxMeta(func(txMeta *Ydb_Query.TransactionMeta) {
 					txID = txMeta.GetId()
 				}),
@@ -314,7 +314,7 @@ func TestExecute(t *testing.T) {
 			client := NewMockQueryServiceClient(ctrl)
 			client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
 			t.Log("execute")
-			_, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.OrderedResultSets)
+			_, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.ResultSetsTypeOrdered)
 			require.Error(t, err)
 			require.True(t, xerrors.IsOperationError(err, Ydb.StatusIds_UNAVAILABLE))
 		})
@@ -391,7 +391,7 @@ func TestExecute(t *testing.T) {
 			client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
 			t.Log("execute")
 			var txID string
-			r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.OrderedResultSets,
+			r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.ResultSetsTypeOrdered,
 				onTxMeta(func(txMeta *Ydb_Query.TransactionMeta) {
 					txID = txMeta.GetId()
 				}),
@@ -458,7 +458,7 @@ func TestExecute(t *testing.T) {
 				})
 
 			// When execute() with context, cancelled in progress
-			_, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.OrderedResultSets)
+			_, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.ResultSetsTypeOrdered)
 
 			// Then context cancellation error is returned
 			require.ErrorIs(t, err, context.Canceled)
@@ -481,7 +481,7 @@ func TestExecute(t *testing.T) {
 				})
 
 			executeCtx, cancelExecuteCtx := context.WithCancel(t.Context())
-			r, err := execute(executeCtx, "123", client, "", options.ExecuteSettings(), options.OrderedResultSets)
+			r, err := execute(executeCtx, "123", client, "", options.ExecuteSettings(), options.ResultSetsTypeOrdered)
 			require.NoError(t, err)
 
 			cancelExecuteCtx()
@@ -544,7 +544,7 @@ func TestExecute(t *testing.T) {
 					})
 
 				_, err := execute(xcontext.WithIdempotent(ctx, true),
-					"123", client, "", options.ExecuteSettings(), options.OrderedResultSets,
+					"123", client, "", options.ExecuteSettings(), options.ResultSetsTypeOrdered,
 				)
 				require.Error(t, err)
 				require.ErrorIs(t, err, context.Canceled)
@@ -575,7 +575,7 @@ func TestExecute(t *testing.T) {
 					})
 
 				_, err := execute(ctx,
-					"123", client, "", options.ExecuteSettings(), options.ConcurrentResultSets,
+					"123", client, "", options.ExecuteSettings(), options.ResultSetsTypeConcurrent,
 				)
 				require.Error(t, err)
 				require.ErrorIs(t, err, context.Canceled)
@@ -607,7 +607,7 @@ func TestExecute(t *testing.T) {
 					return stream, nil
 				})
 
-			r, err := execute(t.Context(), "123", client, "", options.ExecuteSettings(), options.ConcurrentResultSets)
+			r, err := execute(t.Context(), "123", client, "", options.ExecuteSettings(), options.ResultSetsTypeConcurrent)
 			require.NoError(t, err)
 
 			callCtx, callCancel := context.WithCancel(t.Context())
@@ -657,7 +657,7 @@ func TestExecute(t *testing.T) {
 					return stream, nil
 				})
 
-			r, err := execute(t.Context(), "123", client, "", options.ExecuteSettings(), options.ConcurrentResultSets,
+			r, err := execute(t.Context(), "123", client, "", options.ExecuteSettings(), options.ResultSetsTypeConcurrent,
 				withStreamResultCloseTimeout(50*time.Millisecond),
 			)
 			require.NoError(t, err)
@@ -1001,7 +1001,7 @@ func TestExecuteQueryRequest(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			request, callOptions, err := executeQueryRequest(
-				tt.name, tt.name, options.ExecuteSettings(tt.opts...), options.OrderedResultSets,
+				tt.name, tt.name, options.ExecuteSettings(tt.opts...), options.ResultSetsTypeOrdered,
 			)
 			require.NoError(t, err)
 			require.Equal(t, request.String(), tt.request.String())

--- a/internal/query/execute_query_test.go
+++ b/internal/query/execute_query_test.go
@@ -31,7 +31,7 @@ func TestExecute(t *testing.T) {
 		client := NewMockQueryServiceClient(ctrl)
 		client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
 		var txID string
-		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), false,
+		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.ORDERED_RESULT_SETS,
 			onTxMeta(func(txMeta *Ydb_Query.TransactionMeta) {
 				txID = txMeta.GetId()
 			}),
@@ -145,7 +145,7 @@ func TestExecute(t *testing.T) {
 			client := NewMockQueryServiceClient(ctrl)
 			client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(nil, grpcStatus.Error(grpcCodes.Unavailable, ""))
 			t.Log("execute")
-			_, err := execute(ctx, "123", client, "", options.ExecuteSettings(), false)
+			_, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.ORDERED_RESULT_SETS)
 			require.Error(t, err)
 			require.True(t, xerrors.IsTransportError(err, grpcCodes.Unavailable))
 		})
@@ -250,7 +250,7 @@ func TestExecute(t *testing.T) {
 			client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
 			t.Log("execute")
 			var txID string
-			r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), false,
+			r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.ORDERED_RESULT_SETS,
 				onTxMeta(func(txMeta *Ydb_Query.TransactionMeta) {
 					txID = txMeta.GetId()
 				}),
@@ -314,7 +314,7 @@ func TestExecute(t *testing.T) {
 			client := NewMockQueryServiceClient(ctrl)
 			client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
 			t.Log("execute")
-			_, err := execute(ctx, "123", client, "", options.ExecuteSettings(), false)
+			_, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.ORDERED_RESULT_SETS)
 			require.Error(t, err)
 			require.True(t, xerrors.IsOperationError(err, Ydb.StatusIds_UNAVAILABLE))
 		})
@@ -391,7 +391,7 @@ func TestExecute(t *testing.T) {
 			client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
 			t.Log("execute")
 			var txID string
-			r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), false,
+			r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.ORDERED_RESULT_SETS,
 				onTxMeta(func(txMeta *Ydb_Query.TransactionMeta) {
 					txID = txMeta.GetId()
 				}),
@@ -458,7 +458,7 @@ func TestExecute(t *testing.T) {
 				})
 
 			// When execute() with context, cancelled in progress
-			_, err := execute(ctx, "123", client, "", options.ExecuteSettings(), false)
+			_, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.ORDERED_RESULT_SETS)
 
 			// Then context cancellation error is returned
 			require.ErrorIs(t, err, context.Canceled)
@@ -481,7 +481,7 @@ func TestExecute(t *testing.T) {
 				})
 
 			executeCtx, cancelExecuteCtx := context.WithCancel(t.Context())
-			r, err := execute(executeCtx, "123", client, "", options.ExecuteSettings(), false)
+			r, err := execute(executeCtx, "123", client, "", options.ExecuteSettings(), options.ORDERED_RESULT_SETS)
 			require.NoError(t, err)
 
 			cancelExecuteCtx()
@@ -544,7 +544,7 @@ func TestExecute(t *testing.T) {
 					})
 
 				_, err := execute(xcontext.WithIdempotent(ctx, true),
-					"123", client, "", options.ExecuteSettings(), false,
+					"123", client, "", options.ExecuteSettings(), options.ORDERED_RESULT_SETS,
 				)
 				require.Error(t, err)
 				require.ErrorIs(t, err, context.Canceled)
@@ -574,8 +574,8 @@ func TestExecute(t *testing.T) {
 						return stream, nil
 					})
 
-				_, err := execute(ctx, // xcontext.WithIdempotent(ctx, false),
-					"123", client, "", options.ExecuteSettings(), false,
+				_, err := execute(ctx,
+					"123", client, "", options.ExecuteSettings(), options.CONCURRENT_RESULT_SETS,
 				)
 				require.Error(t, err)
 				require.ErrorIs(t, err, context.Canceled)
@@ -607,7 +607,7 @@ func TestExecute(t *testing.T) {
 					return stream, nil
 				})
 
-			r, err := execute(t.Context(), "123", client, "", options.ExecuteSettings(), false)
+			r, err := execute(t.Context(), "123", client, "", options.ExecuteSettings(), options.CONCURRENT_RESULT_SETS)
 			require.NoError(t, err)
 
 			callCtx, callCancel := context.WithCancel(t.Context())
@@ -657,7 +657,7 @@ func TestExecute(t *testing.T) {
 					return stream, nil
 				})
 
-			r, err := execute(t.Context(), "123", client, "", options.ExecuteSettings(), false,
+			r, err := execute(t.Context(), "123", client, "", options.ExecuteSettings(), options.CONCURRENT_RESULT_SETS,
 				withStreamResultCloseTimeout(50*time.Millisecond),
 			)
 			require.NoError(t, err)

--- a/internal/query/execute_query_test.go
+++ b/internal/query/execute_query_test.go
@@ -1000,7 +1000,9 @@ func TestExecuteQueryRequest(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			request, callOptions, err := executeQueryRequest(tt.name, tt.name, options.ExecuteSettings(tt.opts...), false)
+			request, callOptions, err := executeQueryRequest(
+				tt.name, tt.name, options.ExecuteSettings(tt.opts...), options.ORDERED_RESULT_SETS,
+			)
 			require.NoError(t, err)
 			require.Equal(t, request.String(), tt.request.String())
 			require.Equal(t, tt.callOptions, callOptions)

--- a/internal/query/execute_query_test.go
+++ b/internal/query/execute_query_test.go
@@ -31,7 +31,7 @@ func TestExecute(t *testing.T) {
 		client := NewMockQueryServiceClient(ctrl)
 		client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
 		var txID string
-		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.ORDERED_RESULT_SETS,
+		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.OrderedResultSets,
 			onTxMeta(func(txMeta *Ydb_Query.TransactionMeta) {
 				txID = txMeta.GetId()
 			}),
@@ -145,7 +145,7 @@ func TestExecute(t *testing.T) {
 			client := NewMockQueryServiceClient(ctrl)
 			client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(nil, grpcStatus.Error(grpcCodes.Unavailable, ""))
 			t.Log("execute")
-			_, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.ORDERED_RESULT_SETS)
+			_, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.OrderedResultSets)
 			require.Error(t, err)
 			require.True(t, xerrors.IsTransportError(err, grpcCodes.Unavailable))
 		})
@@ -250,7 +250,7 @@ func TestExecute(t *testing.T) {
 			client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
 			t.Log("execute")
 			var txID string
-			r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.ORDERED_RESULT_SETS,
+			r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.OrderedResultSets,
 				onTxMeta(func(txMeta *Ydb_Query.TransactionMeta) {
 					txID = txMeta.GetId()
 				}),
@@ -314,7 +314,7 @@ func TestExecute(t *testing.T) {
 			client := NewMockQueryServiceClient(ctrl)
 			client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
 			t.Log("execute")
-			_, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.ORDERED_RESULT_SETS)
+			_, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.OrderedResultSets)
 			require.Error(t, err)
 			require.True(t, xerrors.IsOperationError(err, Ydb.StatusIds_UNAVAILABLE))
 		})
@@ -391,7 +391,7 @@ func TestExecute(t *testing.T) {
 			client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
 			t.Log("execute")
 			var txID string
-			r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.ORDERED_RESULT_SETS,
+			r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.OrderedResultSets,
 				onTxMeta(func(txMeta *Ydb_Query.TransactionMeta) {
 					txID = txMeta.GetId()
 				}),
@@ -458,7 +458,7 @@ func TestExecute(t *testing.T) {
 				})
 
 			// When execute() with context, cancelled in progress
-			_, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.ORDERED_RESULT_SETS)
+			_, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.OrderedResultSets)
 
 			// Then context cancellation error is returned
 			require.ErrorIs(t, err, context.Canceled)
@@ -481,7 +481,7 @@ func TestExecute(t *testing.T) {
 				})
 
 			executeCtx, cancelExecuteCtx := context.WithCancel(t.Context())
-			r, err := execute(executeCtx, "123", client, "", options.ExecuteSettings(), options.ORDERED_RESULT_SETS)
+			r, err := execute(executeCtx, "123", client, "", options.ExecuteSettings(), options.OrderedResultSets)
 			require.NoError(t, err)
 
 			cancelExecuteCtx()
@@ -544,7 +544,7 @@ func TestExecute(t *testing.T) {
 					})
 
 				_, err := execute(xcontext.WithIdempotent(ctx, true),
-					"123", client, "", options.ExecuteSettings(), options.ORDERED_RESULT_SETS,
+					"123", client, "", options.ExecuteSettings(), options.OrderedResultSets,
 				)
 				require.Error(t, err)
 				require.ErrorIs(t, err, context.Canceled)
@@ -575,7 +575,7 @@ func TestExecute(t *testing.T) {
 					})
 
 				_, err := execute(ctx,
-					"123", client, "", options.ExecuteSettings(), options.CONCURRENT_RESULT_SETS,
+					"123", client, "", options.ExecuteSettings(), options.ConcurrentResultSets,
 				)
 				require.Error(t, err)
 				require.ErrorIs(t, err, context.Canceled)
@@ -607,7 +607,7 @@ func TestExecute(t *testing.T) {
 					return stream, nil
 				})
 
-			r, err := execute(t.Context(), "123", client, "", options.ExecuteSettings(), options.CONCURRENT_RESULT_SETS)
+			r, err := execute(t.Context(), "123", client, "", options.ExecuteSettings(), options.ConcurrentResultSets)
 			require.NoError(t, err)
 
 			callCtx, callCancel := context.WithCancel(t.Context())
@@ -657,7 +657,7 @@ func TestExecute(t *testing.T) {
 					return stream, nil
 				})
 
-			r, err := execute(t.Context(), "123", client, "", options.ExecuteSettings(), options.CONCURRENT_RESULT_SETS,
+			r, err := execute(t.Context(), "123", client, "", options.ExecuteSettings(), options.ConcurrentResultSets,
 				withStreamResultCloseTimeout(50*time.Millisecond),
 			)
 			require.NoError(t, err)
@@ -1001,7 +1001,7 @@ func TestExecuteQueryRequest(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			request, callOptions, err := executeQueryRequest(
-				tt.name, tt.name, options.ExecuteSettings(tt.opts...), options.ORDERED_RESULT_SETS,
+				tt.name, tt.name, options.ExecuteSettings(tt.opts...), options.OrderedResultSets,
 			)
 			require.NoError(t, err)
 			require.Equal(t, request.String(), tt.request.String())

--- a/internal/query/options/constants.go
+++ b/internal/query/options/constants.go
@@ -1,10 +1,8 @@
 package options
 
-type ConcurrentResultSetsType struct {
-	Flag bool
-}
+type ResultSetsType uint8
 
-var (
-	ConcurrentResultSets = ConcurrentResultSetsType{true}
-	OrderedResultSets    = ConcurrentResultSetsType{false}
+const (
+	ResultSetsTypeOrdered = ResultSetsType(iota)
+	ResultSetsTypeConcurrent
 )

--- a/internal/query/options/constants.go
+++ b/internal/query/options/constants.go
@@ -1,0 +1,9 @@
+package options
+
+type ConcurrentResultSets bool
+
+//nolint:revive
+const (
+	CONCURRENT_RESULT_SETS = ConcurrentResultSets(true)
+	ORDERED_RESULT_SETS    = ConcurrentResultSets(false)
+)

--- a/internal/query/options/constants.go
+++ b/internal/query/options/constants.go
@@ -1,9 +1,11 @@
 package options
 
-type ConcurrentResultSets bool
+type ConcurrentResultSets struct {
+	Flag bool
+}
 
 //nolint:revive
-const (
-	CONCURRENT_RESULT_SETS = ConcurrentResultSets(true)
-	ORDERED_RESULT_SETS    = ConcurrentResultSets(false)
+var (
+	CONCURRENT_RESULT_SETS = ConcurrentResultSets{true}
+	ORDERED_RESULT_SETS    = ConcurrentResultSets{false}
 )

--- a/internal/query/options/constants.go
+++ b/internal/query/options/constants.go
@@ -1,11 +1,10 @@
 package options
 
-type ConcurrentResultSets struct {
+type ConcurrentResultSetsType struct {
 	Flag bool
 }
 
-//nolint:revive
 var (
-	CONCURRENT_RESULT_SETS = ConcurrentResultSets{true}
-	ORDERED_RESULT_SETS    = ConcurrentResultSets{false}
+	ConcurrentResultSets = ConcurrentResultSetsType{true}
+	OrderedResultSets    = ConcurrentResultSetsType{false}
 )

--- a/internal/query/options/execute.go
+++ b/internal/query/options/execute.go
@@ -301,7 +301,7 @@ func WithCallOptions(opts ...grpc.CallOption) callOptionsOption {
 	return opts
 }
 
-func NOP() nopOption {
+func Nop() nopOption {
 	return nopOption{}
 }
 

--- a/internal/query/options/execute.go
+++ b/internal/query/options/execute.go
@@ -219,10 +219,6 @@ func (s *executeSettings) Label() string {
 	return s.label
 }
 
-func (s *executeSettings) ConcurrentResultSets() bool {
-	return false
-}
-
 func (s *executeSettings) ResponsePartPrefetch() int {
 	return s.responsePartPrefetch
 }

--- a/internal/query/options/execute.go
+++ b/internal/query/options/execute.go
@@ -142,8 +142,8 @@ func (opts issuesOption) applyExecuteOption(s *executeSettings) {
 	s.issueCallback = opts.callback
 }
 
-func (opt concurrentResultSets) applyExecuteOption(s *executeSettings) {
-	s.concurrentResultSets = bool(opt)
+func (opt concurrentResultSets) applyExecuteOption(*executeSettings) {
+	// deprecated, no-op
 }
 
 func (n responsePartPrefetch) applyExecuteOption(s *executeSettings) {
@@ -267,8 +267,17 @@ func WithResponsePartLimitSizeBytes(size int64) responsePartLimitBytes {
 	return responsePartLimitBytes(size)
 }
 
+// WithConcurrentResultSets is deprecated and has no effect.
+// Use Client.Query, which always enables concurrent result sets internally.
+//
+// Deprecated: WithConcurrentResultSets is deprecated and has no effect.
 func WithConcurrentResultSets(isEnabled bool) concurrentResultSets {
 	return concurrentResultSets(isEnabled)
+}
+
+// EnableConcurrentResultSets forces concurrent result set delivery on the wire.
+func EnableConcurrentResultSets(s *executeSettings) {
+	s.concurrentResultSets = true
 }
 
 // WithResponsePartPrefetch sets how many ExecuteQuery response parts the client

--- a/internal/query/options/execute.go
+++ b/internal/query/options/execute.go
@@ -20,7 +20,7 @@ var (
 	_ Execute = statsModeOption{}
 	_ Execute = execModeOption(0)
 	_ Execute = responsePartPrefetch(0)
-	_ Execute = concurrentResultSetsOption{}
+	_ Execute = nopOption{}
 )
 
 type (
@@ -83,7 +83,7 @@ type (
 		callback func([]*Ydb_Issue.IssueMessage)
 	}
 	responsePartPrefetch int
-	concurrentResultSetsOption struct{}
+	nopOption            struct{}
 )
 
 func (poolID resourcePool) applyExecuteOption(s *executeSettings) {
@@ -305,14 +305,11 @@ func WithCallOptions(opts ...grpc.CallOption) callOptionsOption {
 	return opts
 }
 
-// WithConcurrentResultSets is deprecated and has no effect.
-//
-// Deprecated: WithConcurrentResultSets is deprecated and has no effect.
-func WithConcurrentResultSets(_ bool) concurrentResultSetsOption {
-	return concurrentResultSetsOption{}
+func NOP() nopOption {
+	return nopOption{}
 }
 
-func (concurrentResultSetsOption) applyExecuteOption(*executeSettings) {}
+func (nopOption) applyExecuteOption(*executeSettings) {}
 
 func WithTxControl(txControl *tx.Control) *txControlOption {
 	return (*txControlOption)(txControl)

--- a/internal/query/options/execute.go
+++ b/internal/query/options/execute.go
@@ -20,6 +20,7 @@ var (
 	_ Execute = statsModeOption{}
 	_ Execute = execModeOption(0)
 	_ Execute = responsePartPrefetch(0)
+	_ Execute = concurrentResultSetsOption{}
 )
 
 type (
@@ -82,6 +83,7 @@ type (
 		callback func([]*Ydb_Issue.IssueMessage)
 	}
 	responsePartPrefetch int
+	concurrentResultSetsOption struct{}
 )
 
 func (poolID resourcePool) applyExecuteOption(s *executeSettings) {
@@ -302,6 +304,15 @@ func WithIssuesHandler(callback func(issues []*Ydb_Issue.IssueMessage)) issuesOp
 func WithCallOptions(opts ...grpc.CallOption) callOptionsOption {
 	return opts
 }
+
+// WithConcurrentResultSets is deprecated and has no effect.
+//
+// Deprecated: WithConcurrentResultSets is deprecated and has no effect.
+func WithConcurrentResultSets(_ bool) concurrentResultSetsOption {
+	return concurrentResultSetsOption{}
+}
+
+func (concurrentResultSetsOption) applyExecuteOption(*executeSettings) {}
 
 func WithTxControl(txControl *tx.Control) *txControlOption {
 	return (*txControlOption)(txControl)

--- a/internal/query/options/execute.go
+++ b/internal/query/options/execute.go
@@ -82,7 +82,7 @@ type (
 	issuesOption           struct {
 		callback func([]*Ydb_Issue.IssueMessage)
 	}
-	concurrentResultSets bool
+	concurrentResultSets struct{}
 	responsePartPrefetch int
 )
 
@@ -268,11 +268,12 @@ func WithResponsePartLimitSizeBytes(size int64) responsePartLimitBytes {
 }
 
 // WithConcurrentResultSets is deprecated and has no effect.
+//
 // Use Client.Query, which always enables concurrent result sets internally.
 //
 // Deprecated: WithConcurrentResultSets is deprecated and has no effect.
-func WithConcurrentResultSets(isEnabled bool) concurrentResultSets {
-	return concurrentResultSets(isEnabled)
+func WithConcurrentResultSets(bool) concurrentResultSets {
+	return concurrentResultSets{}
 }
 
 // EnableConcurrentResultSets forces concurrent result set delivery on the wire.

--- a/internal/query/options/execute.go
+++ b/internal/query/options/execute.go
@@ -48,7 +48,6 @@ type (
 		issueCallback          func(issues []*Ydb_Issue.IssueMessage)
 		responsePartLimitBytes int64
 		label                  string
-		concurrentResultSets   bool
 		// responsePartPrefetch is how many stream parts to read ahead of the
 		// consumer (0 disables prefetch and is the default).
 		responsePartPrefetch int
@@ -82,7 +81,6 @@ type (
 	issuesOption           struct {
 		callback func([]*Ydb_Issue.IssueMessage)
 	}
-	concurrentResultSets struct{}
 	responsePartPrefetch int
 )
 
@@ -140,10 +138,6 @@ func (mode ExecMode) applyExecuteOption(s *executeSettings) {
 
 func (opts issuesOption) applyExecuteOption(s *executeSettings) {
 	s.issueCallback = opts.callback
-}
-
-func (opt concurrentResultSets) applyExecuteOption(*executeSettings) {
-	// deprecated, no-op
 }
 
 func (n responsePartPrefetch) applyExecuteOption(s *executeSettings) {
@@ -224,7 +218,7 @@ func (s *executeSettings) Label() string {
 }
 
 func (s *executeSettings) ConcurrentResultSets() bool {
-	return s.concurrentResultSets
+	return false
 }
 
 func (s *executeSettings) ResponsePartPrefetch() int {
@@ -265,20 +259,6 @@ func WithExecMode(mode ExecMode) execModeOption {
 
 func WithResponsePartLimitSizeBytes(size int64) responsePartLimitBytes {
 	return responsePartLimitBytes(size)
-}
-
-// WithConcurrentResultSets is deprecated and has no effect.
-//
-// Use Client.Query, which always enables concurrent result sets internally.
-//
-// Deprecated: WithConcurrentResultSets is deprecated and has no effect.
-func WithConcurrentResultSets(bool) concurrentResultSets {
-	return concurrentResultSets{}
-}
-
-// EnableConcurrentResultSets forces concurrent result set delivery on the wire.
-func EnableConcurrentResultSets(s *executeSettings) {
-	s.concurrentResultSets = true
 }
 
 // WithResponsePartPrefetch sets how many ExecuteQuery response parts the client

--- a/internal/query/row_test.go
+++ b/internal/query/row_test.go
@@ -223,7 +223,7 @@ func TestReadRow(t *testing.T) {
 		client := NewMockQueryServiceClient(ctrl)
 		client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
 
-		r, err := execute(ctx, "123", client, "", options.ExecuteSettings())
+		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), false)
 		require.NoError(t, err)
 
 		row, err := readRow(ctx, r)
@@ -276,7 +276,7 @@ func TestReadRow(t *testing.T) {
 		client := NewMockQueryServiceClient(ctrl)
 		client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
 
-		r, err := execute(ctx, "123", client, "", options.ExecuteSettings())
+		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), false)
 		require.NoError(t, err)
 
 		_, err = readRow(ctx, r)
@@ -313,7 +313,7 @@ func TestReadRow(t *testing.T) {
 		client := NewMockQueryServiceClient(ctrl)
 		client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
 
-		r, err := execute(ctx, "123", client, "", options.ExecuteSettings())
+		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), false)
 		require.NoError(t, err)
 
 		_, err = readRow(ctx, r)
@@ -376,7 +376,7 @@ func TestReadRow(t *testing.T) {
 		client := NewMockQueryServiceClient(ctrl)
 		client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
 
-		r, err := execute(ctx, "123", client, "", options.ExecuteSettings())
+		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), false)
 		require.NoError(t, err)
 
 		_, err = readRow(ctx, r)

--- a/internal/query/row_test.go
+++ b/internal/query/row_test.go
@@ -223,7 +223,7 @@ func TestReadRow(t *testing.T) {
 		client := NewMockQueryServiceClient(ctrl)
 		client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
 
-		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.CONCURRENT_RESULT_SETS)
+		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.ConcurrentResultSets)
 		require.NoError(t, err)
 
 		row, err := readRow(ctx, r)
@@ -276,7 +276,7 @@ func TestReadRow(t *testing.T) {
 		client := NewMockQueryServiceClient(ctrl)
 		client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
 
-		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.CONCURRENT_RESULT_SETS)
+		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.ConcurrentResultSets)
 		require.NoError(t, err)
 
 		_, err = readRow(ctx, r)
@@ -313,7 +313,7 @@ func TestReadRow(t *testing.T) {
 		client := NewMockQueryServiceClient(ctrl)
 		client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
 
-		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.CONCURRENT_RESULT_SETS)
+		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.ConcurrentResultSets)
 		require.NoError(t, err)
 
 		_, err = readRow(ctx, r)
@@ -376,7 +376,7 @@ func TestReadRow(t *testing.T) {
 		client := NewMockQueryServiceClient(ctrl)
 		client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
 
-		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.CONCURRENT_RESULT_SETS)
+		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.ConcurrentResultSets)
 		require.NoError(t, err)
 
 		_, err = readRow(ctx, r)

--- a/internal/query/row_test.go
+++ b/internal/query/row_test.go
@@ -223,7 +223,7 @@ func TestReadRow(t *testing.T) {
 		client := NewMockQueryServiceClient(ctrl)
 		client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
 
-		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), false)
+		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.CONCURRENT_RESULT_SETS)
 		require.NoError(t, err)
 
 		row, err := readRow(ctx, r)
@@ -276,7 +276,7 @@ func TestReadRow(t *testing.T) {
 		client := NewMockQueryServiceClient(ctrl)
 		client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
 
-		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), false)
+		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.CONCURRENT_RESULT_SETS)
 		require.NoError(t, err)
 
 		_, err = readRow(ctx, r)
@@ -313,7 +313,7 @@ func TestReadRow(t *testing.T) {
 		client := NewMockQueryServiceClient(ctrl)
 		client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
 
-		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), false)
+		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.CONCURRENT_RESULT_SETS)
 		require.NoError(t, err)
 
 		_, err = readRow(ctx, r)
@@ -376,7 +376,7 @@ func TestReadRow(t *testing.T) {
 		client := NewMockQueryServiceClient(ctrl)
 		client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
 
-		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), false)
+		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.CONCURRENT_RESULT_SETS)
 		require.NoError(t, err)
 
 		_, err = readRow(ctx, r)

--- a/internal/query/row_test.go
+++ b/internal/query/row_test.go
@@ -223,7 +223,7 @@ func TestReadRow(t *testing.T) {
 		client := NewMockQueryServiceClient(ctrl)
 		client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
 
-		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.ConcurrentResultSets)
+		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.ResultSetsTypeConcurrent)
 		require.NoError(t, err)
 
 		row, err := readRow(ctx, r)
@@ -276,7 +276,7 @@ func TestReadRow(t *testing.T) {
 		client := NewMockQueryServiceClient(ctrl)
 		client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
 
-		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.ConcurrentResultSets)
+		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.ResultSetsTypeConcurrent)
 		require.NoError(t, err)
 
 		_, err = readRow(ctx, r)
@@ -313,7 +313,7 @@ func TestReadRow(t *testing.T) {
 		client := NewMockQueryServiceClient(ctrl)
 		client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
 
-		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.ConcurrentResultSets)
+		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.ResultSetsTypeConcurrent)
 		require.NoError(t, err)
 
 		_, err = readRow(ctx, r)
@@ -376,7 +376,7 @@ func TestReadRow(t *testing.T) {
 		client := NewMockQueryServiceClient(ctrl)
 		client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
 
-		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.ConcurrentResultSets)
+		r, err := execute(ctx, "123", client, "", options.ExecuteSettings(), options.ResultSetsTypeConcurrent)
 		require.NoError(t, err)
 
 		_, err = readRow(ctx, r)

--- a/internal/query/session.go
+++ b/internal/query/session.go
@@ -47,7 +47,7 @@ func (s *Session) QueryResultSet(
 		onDone(finalErr)
 	}()
 
-	r, err := s.execute(ctx, q, settings, options.OrderedResultSets,
+	r, err := s.execute(ctx, q, settings, options.ResultSetsTypeOrdered,
 		withStreamResultTrace(s.trace),
 		withIssuesHandler(settings.IssuesOpts()),
 	)
@@ -66,7 +66,7 @@ func (s *Session) QueryResultSet(
 func (s *Session) queryRow(
 	ctx context.Context, q string, settings executeSettings, resultOpts ...resultOption,
 ) (row query.Row, finalErr error) {
-	r, err := s.execute(ctx, q, settings, options.OrderedResultSets, resultOpts...)
+	r, err := s.execute(ctx, q, settings, options.ResultSetsTypeOrdered, resultOpts...)
 	if err != nil {
 		return nil, xerrors.WithStackTrace(err)
 	}
@@ -165,7 +165,7 @@ func (s *Session) Begin(
 }
 
 func (s *Session) execute(ctx context.Context,
-	q string, settings executeSettings, concurrentResultSets options.ConcurrentResultSetsType, opts ...resultOption,
+	q string, settings executeSettings, concurrentResultSets options.ResultSetsType, opts ...resultOption,
 ) (_ *streamResult, finalErr error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer func() {
@@ -203,7 +203,7 @@ func (s *Session) Exec(ctx context.Context, q string, opts ...options.Execute) (
 		onDone(finalErr)
 	}()
 
-	r, err := s.execute(ctx, q, settings, options.OrderedResultSets,
+	r, err := s.execute(ctx, q, settings, options.ResultSetsTypeOrdered,
 		withStreamResultTrace(s.trace),
 		withIssuesHandler(settings.IssuesOpts()),
 	)
@@ -239,7 +239,7 @@ func (s *Session) Query(ctx context.Context, q string, opts ...options.Execute) 
 		onDone(finalErr)
 	}()
 
-	r, err := s.execute(ctx, q, settings, options.OrderedResultSets,
+	r, err := s.execute(ctx, q, settings, options.ResultSetsTypeOrdered,
 		withStreamResultTrace(s.trace),
 		withIssuesHandler(settings.IssuesOpts()),
 	)
@@ -265,7 +265,7 @@ func (s *Session) QueryArrow(ctx context.Context, q string, opts ...options.Exec
 		}
 	}()
 
-	request, callOptions, err := executeQueryRequest(s.ID(), q, settings, options.OrderedResultSets)
+	request, callOptions, err := executeQueryRequest(s.ID(), q, settings, options.ResultSetsTypeOrdered)
 	if err != nil {
 		return nil, xerrors.WithStackTrace(err)
 	}

--- a/internal/query/session.go
+++ b/internal/query/session.go
@@ -47,7 +47,7 @@ func (s *Session) QueryResultSet(
 		onDone(finalErr)
 	}()
 
-	r, err := s.execute(ctx, q, settings,
+	r, err := s.execute(ctx, q, settings, false,
 		withStreamResultTrace(s.trace),
 		withIssuesHandler(settings.IssuesOpts()),
 	)
@@ -66,7 +66,7 @@ func (s *Session) QueryResultSet(
 func (s *Session) queryRow(
 	ctx context.Context, q string, settings executeSettings, resultOpts ...resultOption,
 ) (row query.Row, finalErr error) {
-	r, err := s.execute(ctx, q, settings, resultOpts...)
+	r, err := s.execute(ctx, q, settings, false, resultOpts...)
 	if err != nil {
 		return nil, xerrors.WithStackTrace(err)
 	}
@@ -165,7 +165,7 @@ func (s *Session) Begin(
 }
 
 func (s *Session) execute(
-	ctx context.Context, q string, settings executeSettings, opts ...resultOption,
+	ctx context.Context, q string, settings executeSettings, concurrentResultSets bool, opts ...resultOption,
 ) (_ *streamResult, finalErr error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer func() {
@@ -175,7 +175,7 @@ func (s *Session) execute(
 		}
 	}()
 
-	r, err := execute(ctx, s.ID(), s.client, q, settings, append(opts,
+	r, err := execute(ctx, s.ID(), s.client, q, settings, concurrentResultSets, append(opts,
 		withStreamResultCloseTimeout(s.streamResultCloseTimeout),
 		withStreamResultOnClose(cancel),
 	)...)
@@ -203,7 +203,7 @@ func (s *Session) Exec(ctx context.Context, q string, opts ...options.Execute) (
 		onDone(finalErr)
 	}()
 
-	r, err := s.execute(ctx, q, settings,
+	r, err := s.execute(ctx, q, settings, false,
 		withStreamResultTrace(s.trace),
 		withIssuesHandler(settings.IssuesOpts()),
 	)
@@ -239,7 +239,7 @@ func (s *Session) Query(ctx context.Context, q string, opts ...options.Execute) 
 		onDone(finalErr)
 	}()
 
-	r, err := s.execute(ctx, q, settings,
+	r, err := s.execute(ctx, q, settings, false,
 		withStreamResultTrace(s.trace),
 		withIssuesHandler(settings.IssuesOpts()),
 	)
@@ -265,7 +265,7 @@ func (s *Session) QueryArrow(ctx context.Context, q string, opts ...options.Exec
 		}
 	}()
 
-	request, callOptions, err := executeQueryRequest(s.ID(), q, settings)
+	request, callOptions, err := executeQueryRequest(s.ID(), q, settings, false)
 	if err != nil {
 		return nil, xerrors.WithStackTrace(err)
 	}

--- a/internal/query/session.go
+++ b/internal/query/session.go
@@ -47,7 +47,7 @@ func (s *Session) QueryResultSet(
 		onDone(finalErr)
 	}()
 
-	r, err := s.execute(ctx, q, settings, options.ORDERED_RESULT_SETS,
+	r, err := s.execute(ctx, q, settings, options.OrderedResultSets,
 		withStreamResultTrace(s.trace),
 		withIssuesHandler(settings.IssuesOpts()),
 	)
@@ -66,7 +66,7 @@ func (s *Session) QueryResultSet(
 func (s *Session) queryRow(
 	ctx context.Context, q string, settings executeSettings, resultOpts ...resultOption,
 ) (row query.Row, finalErr error) {
-	r, err := s.execute(ctx, q, settings, options.ORDERED_RESULT_SETS, resultOpts...)
+	r, err := s.execute(ctx, q, settings, options.OrderedResultSets, resultOpts...)
 	if err != nil {
 		return nil, xerrors.WithStackTrace(err)
 	}
@@ -165,7 +165,7 @@ func (s *Session) Begin(
 }
 
 func (s *Session) execute(ctx context.Context,
-	q string, settings executeSettings, concurrentResultSets options.ConcurrentResultSets, opts ...resultOption,
+	q string, settings executeSettings, concurrentResultSets options.ConcurrentResultSetsType, opts ...resultOption,
 ) (_ *streamResult, finalErr error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer func() {
@@ -203,7 +203,7 @@ func (s *Session) Exec(ctx context.Context, q string, opts ...options.Execute) (
 		onDone(finalErr)
 	}()
 
-	r, err := s.execute(ctx, q, settings, options.ORDERED_RESULT_SETS,
+	r, err := s.execute(ctx, q, settings, options.OrderedResultSets,
 		withStreamResultTrace(s.trace),
 		withIssuesHandler(settings.IssuesOpts()),
 	)
@@ -239,7 +239,7 @@ func (s *Session) Query(ctx context.Context, q string, opts ...options.Execute) 
 		onDone(finalErr)
 	}()
 
-	r, err := s.execute(ctx, q, settings, options.ORDERED_RESULT_SETS,
+	r, err := s.execute(ctx, q, settings, options.OrderedResultSets,
 		withStreamResultTrace(s.trace),
 		withIssuesHandler(settings.IssuesOpts()),
 	)
@@ -265,7 +265,7 @@ func (s *Session) QueryArrow(ctx context.Context, q string, opts ...options.Exec
 		}
 	}()
 
-	request, callOptions, err := executeQueryRequest(s.ID(), q, settings, options.ORDERED_RESULT_SETS)
+	request, callOptions, err := executeQueryRequest(s.ID(), q, settings, options.OrderedResultSets)
 	if err != nil {
 		return nil, xerrors.WithStackTrace(err)
 	}

--- a/internal/query/session.go
+++ b/internal/query/session.go
@@ -47,7 +47,7 @@ func (s *Session) QueryResultSet(
 		onDone(finalErr)
 	}()
 
-	r, err := s.execute(ctx, q, settings, false,
+	r, err := s.execute(ctx, q, settings, options.ORDERED_RESULT_SETS,
 		withStreamResultTrace(s.trace),
 		withIssuesHandler(settings.IssuesOpts()),
 	)
@@ -66,7 +66,7 @@ func (s *Session) QueryResultSet(
 func (s *Session) queryRow(
 	ctx context.Context, q string, settings executeSettings, resultOpts ...resultOption,
 ) (row query.Row, finalErr error) {
-	r, err := s.execute(ctx, q, settings, false, resultOpts...)
+	r, err := s.execute(ctx, q, settings, options.ORDERED_RESULT_SETS, resultOpts...)
 	if err != nil {
 		return nil, xerrors.WithStackTrace(err)
 	}
@@ -203,7 +203,7 @@ func (s *Session) Exec(ctx context.Context, q string, opts ...options.Execute) (
 		onDone(finalErr)
 	}()
 
-	r, err := s.execute(ctx, q, settings, false,
+	r, err := s.execute(ctx, q, settings, options.ORDERED_RESULT_SETS,
 		withStreamResultTrace(s.trace),
 		withIssuesHandler(settings.IssuesOpts()),
 	)
@@ -239,7 +239,7 @@ func (s *Session) Query(ctx context.Context, q string, opts ...options.Execute) 
 		onDone(finalErr)
 	}()
 
-	r, err := s.execute(ctx, q, settings, false,
+	r, err := s.execute(ctx, q, settings, options.ORDERED_RESULT_SETS,
 		withStreamResultTrace(s.trace),
 		withIssuesHandler(settings.IssuesOpts()),
 	)
@@ -265,7 +265,7 @@ func (s *Session) QueryArrow(ctx context.Context, q string, opts ...options.Exec
 		}
 	}()
 
-	request, callOptions, err := executeQueryRequest(s.ID(), q, settings, false)
+	request, callOptions, err := executeQueryRequest(s.ID(), q, settings, options.ORDERED_RESULT_SETS)
 	if err != nil {
 		return nil, xerrors.WithStackTrace(err)
 	}

--- a/internal/query/session.go
+++ b/internal/query/session.go
@@ -164,8 +164,8 @@ func (s *Session) Begin(
 	}, nil
 }
 
-func (s *Session) execute(
-	ctx context.Context, q string, settings executeSettings, concurrentResultSets bool, opts ...resultOption,
+func (s *Session) execute(ctx context.Context,
+	q string, settings executeSettings, concurrentResultSets options.ConcurrentResultSets, opts ...resultOption,
 ) (_ *streamResult, finalErr error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer func() {

--- a/internal/query/transaction.go
+++ b/internal/query/transaction.go
@@ -118,7 +118,7 @@ func (tx *Transaction) QueryResultSet(
 			}),
 		)
 	}
-	r, err := tx.s.execute(ctx, q, txSettings, resultOpts...)
+	r, err := tx.s.execute(ctx, q, txSettings, false, resultOpts...)
 	if err != nil {
 		return nil, xerrors.WithStackTrace(err)
 	}
@@ -168,7 +168,7 @@ func (tx *Transaction) QueryRow(
 			}),
 		)
 	}
-	r, err := tx.s.execute(ctx, q, txSettings, resultOpts...)
+	r, err := tx.s.execute(ctx, q, txSettings, false, resultOpts...)
 	if err != nil {
 		return nil, xerrors.WithStackTrace(err)
 	}
@@ -243,7 +243,7 @@ func (tx *Transaction) Exec(ctx context.Context, q string, opts ...options.Execu
 		)
 	}
 
-	r, err := tx.s.execute(ctx, q, txSettings, resultOpts...)
+	r, err := tx.s.execute(ctx, q, txSettings, false, resultOpts...)
 	if err != nil {
 		return xerrors.WithStackTrace(err)
 	}
@@ -335,7 +335,7 @@ func (tx *Transaction) Query(ctx context.Context, q string, opts ...options.Exec
 			}),
 		)
 	}
-	r, err := tx.s.execute(ctx, q, txSettings, resultOpts...)
+	r, err := tx.s.execute(ctx, q, txSettings, false, resultOpts...)
 	if err != nil {
 		return nil, xerrors.WithStackTrace(err)
 	}

--- a/internal/query/transaction.go
+++ b/internal/query/transaction.go
@@ -118,7 +118,7 @@ func (tx *Transaction) QueryResultSet(
 			}),
 		)
 	}
-	r, err := tx.s.execute(ctx, q, txSettings, false, resultOpts...)
+	r, err := tx.s.execute(ctx, q, txSettings, options.ORDERED_RESULT_SETS, resultOpts...)
 	if err != nil {
 		return nil, xerrors.WithStackTrace(err)
 	}
@@ -168,7 +168,7 @@ func (tx *Transaction) QueryRow(
 			}),
 		)
 	}
-	r, err := tx.s.execute(ctx, q, txSettings, false, resultOpts...)
+	r, err := tx.s.execute(ctx, q, txSettings, options.ORDERED_RESULT_SETS, resultOpts...)
 	if err != nil {
 		return nil, xerrors.WithStackTrace(err)
 	}
@@ -243,7 +243,7 @@ func (tx *Transaction) Exec(ctx context.Context, q string, opts ...options.Execu
 		)
 	}
 
-	r, err := tx.s.execute(ctx, q, txSettings, false, resultOpts...)
+	r, err := tx.s.execute(ctx, q, txSettings, options.ORDERED_RESULT_SETS, resultOpts...)
 	if err != nil {
 		return xerrors.WithStackTrace(err)
 	}
@@ -335,7 +335,7 @@ func (tx *Transaction) Query(ctx context.Context, q string, opts ...options.Exec
 			}),
 		)
 	}
-	r, err := tx.s.execute(ctx, q, txSettings, false, resultOpts...)
+	r, err := tx.s.execute(ctx, q, txSettings, options.ORDERED_RESULT_SETS, resultOpts...)
 	if err != nil {
 		return nil, xerrors.WithStackTrace(err)
 	}

--- a/internal/query/transaction.go
+++ b/internal/query/transaction.go
@@ -118,7 +118,7 @@ func (tx *Transaction) QueryResultSet(
 			}),
 		)
 	}
-	r, err := tx.s.execute(ctx, q, txSettings, options.ORDERED_RESULT_SETS, resultOpts...)
+	r, err := tx.s.execute(ctx, q, txSettings, options.OrderedResultSets, resultOpts...)
 	if err != nil {
 		return nil, xerrors.WithStackTrace(err)
 	}
@@ -168,7 +168,7 @@ func (tx *Transaction) QueryRow(
 			}),
 		)
 	}
-	r, err := tx.s.execute(ctx, q, txSettings, options.ORDERED_RESULT_SETS, resultOpts...)
+	r, err := tx.s.execute(ctx, q, txSettings, options.OrderedResultSets, resultOpts...)
 	if err != nil {
 		return nil, xerrors.WithStackTrace(err)
 	}
@@ -243,7 +243,7 @@ func (tx *Transaction) Exec(ctx context.Context, q string, opts ...options.Execu
 		)
 	}
 
-	r, err := tx.s.execute(ctx, q, txSettings, options.ORDERED_RESULT_SETS, resultOpts...)
+	r, err := tx.s.execute(ctx, q, txSettings, options.OrderedResultSets, resultOpts...)
 	if err != nil {
 		return xerrors.WithStackTrace(err)
 	}
@@ -335,7 +335,7 @@ func (tx *Transaction) Query(ctx context.Context, q string, opts ...options.Exec
 			}),
 		)
 	}
-	r, err := tx.s.execute(ctx, q, txSettings, options.ORDERED_RESULT_SETS, resultOpts...)
+	r, err := tx.s.execute(ctx, q, txSettings, options.OrderedResultSets, resultOpts...)
 	if err != nil {
 		return nil, xerrors.WithStackTrace(err)
 	}

--- a/internal/query/transaction.go
+++ b/internal/query/transaction.go
@@ -118,7 +118,7 @@ func (tx *Transaction) QueryResultSet(
 			}),
 		)
 	}
-	r, err := tx.s.execute(ctx, q, txSettings, options.OrderedResultSets, resultOpts...)
+	r, err := tx.s.execute(ctx, q, txSettings, options.ResultSetsTypeOrdered, resultOpts...)
 	if err != nil {
 		return nil, xerrors.WithStackTrace(err)
 	}
@@ -168,7 +168,7 @@ func (tx *Transaction) QueryRow(
 			}),
 		)
 	}
-	r, err := tx.s.execute(ctx, q, txSettings, options.OrderedResultSets, resultOpts...)
+	r, err := tx.s.execute(ctx, q, txSettings, options.ResultSetsTypeOrdered, resultOpts...)
 	if err != nil {
 		return nil, xerrors.WithStackTrace(err)
 	}
@@ -243,7 +243,7 @@ func (tx *Transaction) Exec(ctx context.Context, q string, opts ...options.Execu
 		)
 	}
 
-	r, err := tx.s.execute(ctx, q, txSettings, options.OrderedResultSets, resultOpts...)
+	r, err := tx.s.execute(ctx, q, txSettings, options.ResultSetsTypeOrdered, resultOpts...)
 	if err != nil {
 		return xerrors.WithStackTrace(err)
 	}
@@ -335,7 +335,7 @@ func (tx *Transaction) Query(ctx context.Context, q string, opts ...options.Exec
 			}),
 		)
 	}
-	r, err := tx.s.execute(ctx, q, txSettings, options.OrderedResultSets, resultOpts...)
+	r, err := tx.s.execute(ctx, q, txSettings, options.ResultSetsTypeOrdered, resultOpts...)
 	if err != nil {
 		return nil, xerrors.WithStackTrace(err)
 	}

--- a/query/execute_options.go
+++ b/query/execute_options.go
@@ -86,6 +86,8 @@ func WithResponsePartPrefetch(parts int) ExecuteOption {
 // WithConcurrentResultSets is deprecated and has no effect.
 //
 // Client.Query always enables concurrent result sets internally because it materializes the full response.
+// Session, transaction, and other streaming query paths always use sequential result set delivery
+// (`concurrent_result_sets=false` on the wire); the deprecated option no longer changes that behavior.
 //
 // Deprecated: WithConcurrentResultSets is deprecated and has no effect.
 func WithConcurrentResultSets(bool) ExecuteOption {

--- a/query/execute_options.go
+++ b/query/execute_options.go
@@ -89,7 +89,7 @@ func WithResponsePartPrefetch(parts int) ExecuteOption {
 //
 // Deprecated: WithConcurrentResultSets is deprecated and has no effect.
 func WithConcurrentResultSets(isEnabled bool) ExecuteOption {
-	return nil
+	return options.WithConcurrentResultSets(isEnabled)
 }
 
 func WithCallOptions(opts ...grpc.CallOption) ExecuteOption {

--- a/query/execute_options.go
+++ b/query/execute_options.go
@@ -89,7 +89,7 @@ func WithResponsePartPrefetch(parts int) ExecuteOption {
 //
 // Deprecated: WithConcurrentResultSets is deprecated and has no effect.
 func WithConcurrentResultSets(bool) ExecuteOption {
-	return options.NOP()
+	return options.Nop()
 }
 
 func WithCallOptions(opts ...grpc.CallOption) ExecuteOption {

--- a/query/execute_options.go
+++ b/query/execute_options.go
@@ -84,11 +84,12 @@ func WithResponsePartPrefetch(parts int) ExecuteOption {
 }
 
 // WithConcurrentResultSets is deprecated and has no effect.
+//
 // Client.Query always enables concurrent result sets internally because it materializes the full response.
 //
 // Deprecated: WithConcurrentResultSets is deprecated and has no effect.
 func WithConcurrentResultSets(isEnabled bool) ExecuteOption {
-	return options.WithConcurrentResultSets(isEnabled)
+	return nil
 }
 
 func WithCallOptions(opts ...grpc.CallOption) ExecuteOption {

--- a/query/execute_options.go
+++ b/query/execute_options.go
@@ -83,11 +83,10 @@ func WithResponsePartPrefetch(parts int) ExecuteOption {
 	return options.WithResponsePartPrefetch(parts)
 }
 
-// WithConcurrentResultSets enables concurrent computation of result sets. It is useful when a single query executes
-// multiple independent SELECT statements.
+// WithConcurrentResultSets is deprecated and has no effect.
+// Client.Query always enables concurrent result sets internally because it materializes the full response.
 //
-// WARNING: This option must be used only in Query() method. Using it with other methods results in undefined behavior
-// or an error.
+// Deprecated: WithConcurrentResultSets is deprecated and has no effect.
 func WithConcurrentResultSets(isEnabled bool) ExecuteOption {
 	return options.WithConcurrentResultSets(isEnabled)
 }

--- a/query/execute_options.go
+++ b/query/execute_options.go
@@ -88,8 +88,8 @@ func WithResponsePartPrefetch(parts int) ExecuteOption {
 // Client.Query always enables concurrent result sets internally because it materializes the full response.
 //
 // Deprecated: WithConcurrentResultSets is deprecated and has no effect.
-func WithConcurrentResultSets(isEnabled bool) ExecuteOption {
-	return options.WithConcurrentResultSets(isEnabled)
+func WithConcurrentResultSets(bool) ExecuteOption {
+	return options.NOP()
 }
 
 func WithCallOptions(opts ...grpc.CallOption) ExecuteOption {

--- a/tests/integration/query_execute_test.go
+++ b/tests/integration/query_execute_test.go
@@ -807,8 +807,7 @@ func TestIssue1872QueryWarning(t *testing.T) {
 	require.NoError(t, err)
 	t.Run("Query with declare", func(t *testing.T) {
 		collector := make([]*Ydb_Issue.IssueMessage, 0)
-		q := db.Query()
-		_, err := q.Query(ctx, `
+		_, err := db.Query().Query(ctx, `
 				DECLARE $x as String;
 				SELECT 42;
 				SELECT 43;
@@ -825,8 +824,7 @@ func TestIssue1872QueryWarning(t *testing.T) {
 	})
 	t.Run("Exec with declare", func(t *testing.T) {
 		collector := make([]*Ydb_Issue.IssueMessage, 0)
-		q := db.Query()
-		_, err := q.Query(ctx, `
+		_, err := db.Query().Query(ctx, `
 					DECLARE $x as String;
 					SELECT 42;
 					SELECT 43;
@@ -843,8 +841,7 @@ func TestIssue1872QueryWarning(t *testing.T) {
 	})
 	issueCount := -1
 	t.Run("Query no issues", func(t *testing.T) {
-		q := db.Query()
-		_, err := q.Query(ctx, `
+		_, err := db.Query().Query(ctx, `
 				SELECT 42;
 				SELECT 43;
 	        `,
@@ -859,8 +856,7 @@ func TestIssue1872QueryWarning(t *testing.T) {
 	require.Equal(t, -1, issueCount)
 	issueCount = -1
 	t.Run("Exec no issues", func(t *testing.T) {
-		q := db.Query()
-		_, err := q.Query(ctx, `
+		_, err := db.Query().Query(ctx, `
 				SELECT 42;
 				SELECT 43;
 	        `,
@@ -875,8 +871,7 @@ func TestIssue1872QueryWarning(t *testing.T) {
 	require.Equal(t, -1, issueCount)
 	t.Run("Exec insert", func(t *testing.T) {
 		var issueList []*Ydb_Issue.IssueMessage
-		q := db.Query()
-		err := q.Exec(ctx, `
+		err := db.Query().Exec(ctx, `
 			insert into TestIssue1872QueryWarning (Id, Amount)
 			values (-7, Decimal("37.01",22,9));
 			`,
@@ -972,8 +967,7 @@ func TestIssue1872QueryWarning(t *testing.T) {
 	})
 	t.Run("Exec 2 inserts", func(t *testing.T) {
 		var issueList []*Ydb_Issue.IssueMessage
-		q := db.Query()
-		_, err := q.Query(ctx, `
+		_, err := db.Query().Query(ctx, `
 		        insert into TestIssue1872QueryWarning (Id, Amount) values (-19, Decimal("3.01",22,9));
 				insert into TestIssue1872QueryWarning (Id, Amount) values (-15, Decimal("5.01",22,9));
 		        `,
@@ -1019,8 +1013,7 @@ func TestIssue1878ConcurrentResultSet(t *testing.T) {
 	)
 	require.NoError(t, err)
 	t.Run("Select with enabled option", func(t *testing.T) {
-		q := db.Query()
-		res, err := q.Query(ctx, `
+		res, err := db.Query().Query(ctx, `
 				SELECT 1;
 				SELECT 2;
 				SELECT 3;

--- a/tests/integration/query_execute_test.go
+++ b/tests/integration/query_execute_test.go
@@ -1030,7 +1030,6 @@ func TestIssue1878ConcurrentResultSet(t *testing.T) {
 	        `,
 			query.WithSyntax(query.SyntaxYQL),
 			query.WithIdempotent(),
-			query.WithConcurrentResultSets(true),
 		)
 		require.NoError(t, err)
 		rsCount := 0

--- a/tests/integration/query_execute_test.go
+++ b/tests/integration/query_execute_test.go
@@ -946,8 +946,7 @@ func TestIssue1872QueryWarning(t *testing.T) {
 	})
 	t.Run("Query 2 inserts", func(t *testing.T) {
 		var issueList []*Ydb_Issue.IssueMessage
-		q := db.Query()
-		_, err := q.Query(ctx, `
+		_, err := db.Query().Query(ctx, `
 		        insert into TestIssue1872QueryWarning (Id, Amount) values (-9, Decimal("3.01",22,9));
 				insert into TestIssue1872QueryWarning (Id, Amount) values (-5, Decimal("5.01",22,9));
 		        `,


### PR DESCRIPTION
## Summary
- Deprecate `query.WithConcurrentResultSets`: the option is now a no-op for backward compatibility.
- Always set `ConcurrentResultSets=true` in `Client.Query`, which materializes the full response and can safely consume interleaved result set parts.
- Remove the now-redundant option from integration tests.

## Test plan
- [x] `go test ./internal/query/...`
- [x] Integration test `TestQueryConcurrentResultSets` (requires YDB)


Made with [Cursor](https://cursor.com)