### PR TITLE
fix(query): propagate call-level trace in Do and DoTx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-* Propagated call-level `trace.Query` in `db.Query().{Do,DoTx}(..., query.WithTrace(&tracer))`
+* Propagated the call-level `trace.Query` in `db.Query().{Do,DoTx}(..., query.WithTrace(&tracer))`
 
 ## v3.141.3
 * Deprecated `query.WithConcurrentResultSets`: the option is now a no-op; `Client.Query` always enables concurrent result sets internally because it materializes the full response. Session, transaction, and other streaming paths always send `concurrent_result_sets=false`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Propagated call-level `trace.Query` in `db.Query().{Do,DoTx}(..., query.WithTrace(&tracer))`
+
 ## v3.141.3
 * Deprecated `query.WithConcurrentResultSets`: the option is now a no-op; `Client.Query` always enables concurrent result sets internally because it materializes the full response. Session, transaction, and other streaming paths always send `concurrent_result_sets=false`
 

--- a/internal/query/client.go
+++ b/internal/query/client.go
@@ -369,7 +369,7 @@ func (c *Client) Do(ctx context.Context, op query.Operation, opts ...options.DoO
 
 	err = do(ctx, c.explicitSessionPool,
 		func(ctx context.Context, s *Session) error {
-			return withSessionTrace(s, settings.Trace(), func() error {
+			return withSessionTrace(s, settings.CallTrace(), func() error {
 				return op(ctx, s)
 			})
 		},
@@ -390,13 +390,13 @@ func (c *Client) Do(ctx context.Context, op query.Operation, opts ...options.DoO
 	return err
 }
 
-func withSessionTrace(s *Session, t *trace.Query, op func() error) error {
-	if t == nil {
+func withSessionTrace(s *Session, callTrace *trace.Query, op func() error) error {
+	if callTrace == nil {
 		return op()
 	}
 
 	prev := s.trace
-	s.trace = t
+	s.trace = gtrace.Compose(s.trace, callTrace)
 	defer func() {
 		s.trace = prev
 	}()
@@ -719,7 +719,7 @@ func (c *Client) DoTx(ctx context.Context, op query.TxOperation, opts ...options
 
 	err = doTx(ctx, c.explicitSessionPool, op,
 		settings.TxSettings(),
-		settings.Trace(),
+		settings.CallTrace(),
 		append(
 			[]retry.Option{
 				// Driver-level trace.Retry (e.g. spans.WithTraces) so retry

--- a/internal/query/client.go
+++ b/internal/query/client.go
@@ -369,7 +369,9 @@ func (c *Client) Do(ctx context.Context, op query.Operation, opts ...options.DoO
 
 	err = do(ctx, c.explicitSessionPool,
 		func(ctx context.Context, s *Session) error {
-			return op(ctx, s)
+			return withSessionTrace(s, settings.Trace(), func() error {
+				return op(ctx, s)
+			})
 		},
 		append([]retry.Option{
 			// Driver-level trace.Retry (e.g. spans.WithTraces) so retry
@@ -388,34 +390,51 @@ func (c *Client) Do(ctx context.Context, op query.Operation, opts ...options.DoO
 	return err
 }
 
+func withSessionTrace(s *Session, t *trace.Query, op func() error) error {
+	if t == nil {
+		return op()
+	}
+
+	prev := s.trace
+	s.trace = t
+	defer func() {
+		s.trace = prev
+	}()
+
+	return op()
+}
+
 func doTx(
 	ctx context.Context,
 	pool sessionPool,
 	op query.TxOperation,
 	txSettings tx.Settings,
+	callTrace *trace.Query,
 	opts ...retry.Option,
 ) (finalErr error) {
 	err := do(ctx, pool, func(ctx context.Context, s *Session) (opErr error) {
-		tx, err := s.Begin(ctx, txSettings)
-		if err != nil {
-			return xerrors.WithStackTrace(err)
-		}
+		return withSessionTrace(s, callTrace, func() error {
+			tx, err := s.Begin(ctx, txSettings)
+			if err != nil {
+				return xerrors.WithStackTrace(err)
+			}
 
-		defer func() {
-			_ = tx.Rollback(ctx)
-		}()
+			defer func() {
+				_ = tx.Rollback(ctx)
+			}()
 
-		err = op(ctx, tx)
-		if err != nil {
-			return xerrors.WithStackTrace(err)
-		}
+			err = op(ctx, tx)
+			if err != nil {
+				return xerrors.WithStackTrace(err)
+			}
 
-		err = tx.CommitTx(ctx)
-		if err != nil {
-			return xerrors.WithStackTrace(err)
-		}
+			err = tx.CommitTx(ctx)
+			if err != nil {
+				return xerrors.WithStackTrace(err)
+			}
 
-		return nil
+			return nil
+		})
 	}, opts...)
 	if err != nil {
 		return xerrors.WithStackTrace(err)
@@ -700,6 +719,7 @@ func (c *Client) DoTx(ctx context.Context, op query.TxOperation, opts ...options
 
 	err = doTx(ctx, c.explicitSessionPool, op,
 		settings.TxSettings(),
+		settings.Trace(),
 		append(
 			[]retry.Option{
 				// Driver-level trace.Retry (e.g. spans.WithTraces) so retry

--- a/internal/query/client_dotx_trace_test.go
+++ b/internal/query/client_dotx_trace_test.go
@@ -10,16 +10,16 @@ import (
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Query"
 	"go.uber.org/mock/gomock"
 
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/query/config"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/query/options"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xsync"
 	"github.com/ydb-platform/ydb-go-sdk/v3/query"
 	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
 )
 
-func TestClient_DoTx_CallLevelTrace(t *testing.T) {
-	ctx := t.Context()
-	ctrl := gomock.NewController(t)
+func stubDoTxExecuteQuery(t *testing.T, ctrl *gomock.Controller, client *MockQueryServiceClient) {
+	t.Helper()
 
-	client := NewMockQueryServiceClient(ctrl)
 	stream := newExecuteQueryStreamMock(ctrl)
 	stream.EXPECT().Recv().DoAndReturn(func() (*Ydb_Query.ExecuteQueryResponsePart, error) {
 		client.EXPECT().CommitTransaction(gomock.Any(), gomock.Any()).Return(&Ydb_Query.CommitTransactionResponse{
@@ -35,6 +35,46 @@ func TestClient_DoTx_CallLevelTrace(t *testing.T) {
 	})
 	stream.EXPECT().Recv().Return(nil, io.EOF)
 	client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
+}
+
+func stubDoExecuteQuery(t *testing.T, ctrl *gomock.Controller, client *MockQueryServiceClient) {
+	t.Helper()
+
+	stream := newExecuteQueryStreamMock(ctrl)
+	stream.EXPECT().Recv().Return(&Ydb_Query.ExecuteQueryResponsePart{
+		Status: Ydb.StatusIds_SUCCESS,
+	}, nil)
+	stream.EXPECT().Recv().Return(nil, io.EOF)
+	client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
+}
+
+func testClientWithDriverTrace(t *testing.T, client *MockQueryServiceClient, driverTrace *trace.Query) *Client {
+	t.Helper()
+
+	return &Client{
+		config: config.New(config.WithTrace(driverTrace)),
+		client: client,
+		explicitSessionPool: &mockSessionPool{
+			withFunc: func(ctx context.Context, f func(ctx context.Context, s *Session) error) error {
+				s := newTestSessionWithClient("s-1", client, true)
+				s.trace = driverTrace
+
+				return f(ctx, s)
+			},
+		},
+		implicitSessionPool: &mockSessionPool{},
+		closed: xsync.NewValue(&closeState{
+			cancels: make(map[uint64]context.CancelFunc),
+		}),
+	}
+}
+
+func TestClient_DoTx_CallLevelTrace(t *testing.T) {
+	ctx := t.Context()
+	ctrl := gomock.NewController(t)
+
+	client := NewMockQueryServiceClient(ctrl)
+	stubDoTxExecuteQuery(t, ctrl, client)
 
 	var onDoTxCalled, onTxExecCalled int
 	callTrace := &trace.Query{
@@ -65,17 +105,45 @@ func TestClient_DoTx_CallLevelTrace(t *testing.T) {
 	require.Equal(t, 1, onTxExecCalled, "call-level OnTxExec must be invoked inside DoTx")
 }
 
+func TestClient_DoTx_ComposedTrace(t *testing.T) {
+	ctx := t.Context()
+	ctrl := gomock.NewController(t)
+
+	client := NewMockQueryServiceClient(ctrl)
+	stubDoTxExecuteQuery(t, ctrl, client)
+
+	var driverOnTxExecCalled, callOnTxExecCalled int
+	driverTrace := &trace.Query{
+		OnTxExec: func(info trace.QueryTxExecStartInfo) func(trace.QueryTxExecDoneInfo) {
+			driverOnTxExecCalled++
+
+			return func(trace.QueryTxExecDoneInfo) {}
+		},
+	}
+	callTrace := &trace.Query{
+		OnTxExec: func(info trace.QueryTxExecStartInfo) func(trace.QueryTxExecDoneInfo) {
+			callOnTxExecCalled++
+
+			return func(trace.QueryTxExecDoneInfo) {}
+		},
+	}
+
+	c := testClientWithDriverTrace(t, client, driverTrace)
+
+	err := c.DoTx(ctx, func(ctx context.Context, tx query.TxActor) error {
+		return tx.Exec(ctx, "SELECT 1")
+	}, options.WithTrace(callTrace))
+	require.NoError(t, err)
+	require.Equal(t, 1, driverOnTxExecCalled, "driver-level OnTxExec must not be dropped")
+	require.Equal(t, 1, callOnTxExecCalled, "call-level OnTxExec must be invoked inside DoTx")
+}
+
 func TestClient_Do_CallLevelTrace(t *testing.T) {
 	ctx := t.Context()
 	ctrl := gomock.NewController(t)
 
 	client := NewMockQueryServiceClient(ctrl)
-	stream := newExecuteQueryStreamMock(ctrl)
-	stream.EXPECT().Recv().Return(&Ydb_Query.ExecuteQueryResponsePart{
-		Status: Ydb.StatusIds_SUCCESS,
-	}, nil)
-	stream.EXPECT().Recv().Return(nil, io.EOF)
-	client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
+	stubDoExecuteQuery(t, ctrl, client)
 
 	var onDoCalled, onSessionExecCalled int
 	callTrace := &trace.Query{
@@ -104,4 +172,37 @@ func TestClient_Do_CallLevelTrace(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, onDoCalled, "call-level OnDo must be invoked")
 	require.Equal(t, 1, onSessionExecCalled, "call-level OnSessionExec must be invoked inside Do")
+}
+
+func TestClient_Do_ComposedTrace(t *testing.T) {
+	ctx := t.Context()
+	ctrl := gomock.NewController(t)
+
+	client := NewMockQueryServiceClient(ctrl)
+	stubDoExecuteQuery(t, ctrl, client)
+
+	var driverOnSessionExecCalled, callOnSessionExecCalled int
+	driverTrace := &trace.Query{
+		OnSessionExec: func(info trace.QuerySessionExecStartInfo) func(trace.QuerySessionExecDoneInfo) {
+			driverOnSessionExecCalled++
+
+			return func(trace.QuerySessionExecDoneInfo) {}
+		},
+	}
+	callTrace := &trace.Query{
+		OnSessionExec: func(info trace.QuerySessionExecStartInfo) func(trace.QuerySessionExecDoneInfo) {
+			callOnSessionExecCalled++
+
+			return func(trace.QuerySessionExecDoneInfo) {}
+		},
+	}
+
+	c := testClientWithDriverTrace(t, client, driverTrace)
+
+	err := c.Do(ctx, func(ctx context.Context, s query.Session) error {
+		return s.Exec(ctx, "SELECT 1")
+	}, options.WithTrace(callTrace))
+	require.NoError(t, err)
+	require.Equal(t, 1, driverOnSessionExecCalled, "driver-level OnSessionExec must not be dropped")
+	require.Equal(t, 1, callOnSessionExecCalled, "call-level OnSessionExec must be invoked inside Do")
 }

--- a/internal/query/client_dotx_trace_test.go
+++ b/internal/query/client_dotx_trace_test.go
@@ -1,0 +1,107 @@
+package query
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb"
+	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Query"
+	"go.uber.org/mock/gomock"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/query/options"
+	"github.com/ydb-platform/ydb-go-sdk/v3/query"
+	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
+)
+
+func TestClient_DoTx_CallLevelTrace(t *testing.T) {
+	ctx := t.Context()
+	ctrl := gomock.NewController(t)
+
+	client := NewMockQueryServiceClient(ctrl)
+	stream := newExecuteQueryStreamMock(ctrl)
+	stream.EXPECT().Recv().DoAndReturn(func() (*Ydb_Query.ExecuteQueryResponsePart, error) {
+		client.EXPECT().CommitTransaction(gomock.Any(), gomock.Any()).Return(&Ydb_Query.CommitTransactionResponse{
+			Status: Ydb.StatusIds_SUCCESS,
+		}, nil)
+
+		return &Ydb_Query.ExecuteQueryResponsePart{
+			Status: Ydb.StatusIds_SUCCESS,
+			TxMeta: &Ydb_Query.TransactionMeta{
+				Id: "tx-1",
+			},
+		}, nil
+	})
+	stream.EXPECT().Recv().Return(nil, io.EOF)
+	client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
+
+	var onDoTxCalled, onTxExecCalled int
+	callTrace := &trace.Query{
+		OnDoTx: func(info trace.QueryDoTxStartInfo) func(trace.QueryDoTxDoneInfo) {
+			onDoTxCalled++
+
+			return func(trace.QueryDoTxDoneInfo) {}
+		},
+		OnTxExec: func(info trace.QueryTxExecStartInfo) func(trace.QueryTxExecDoneInfo) {
+			onTxExecCalled++
+
+			return func(trace.QueryTxExecDoneInfo) {}
+		},
+	}
+
+	c := testClient(t, client)
+	c.explicitSessionPool = &mockSessionPool{
+		withFunc: func(ctx context.Context, f func(ctx context.Context, s *Session) error) error {
+			return f(ctx, newTestSessionWithClient("s-1", client, true))
+		},
+	}
+
+	err := c.DoTx(ctx, func(ctx context.Context, tx query.TxActor) error {
+		return tx.Exec(ctx, "SELECT 1")
+	}, options.WithTrace(callTrace))
+	require.NoError(t, err)
+	require.Equal(t, 1, onDoTxCalled, "call-level OnDoTx must be invoked")
+	require.Equal(t, 1, onTxExecCalled, "call-level OnTxExec must be invoked inside DoTx")
+}
+
+func TestClient_Do_CallLevelTrace(t *testing.T) {
+	ctx := t.Context()
+	ctrl := gomock.NewController(t)
+
+	client := NewMockQueryServiceClient(ctrl)
+	stream := newExecuteQueryStreamMock(ctrl)
+	stream.EXPECT().Recv().Return(&Ydb_Query.ExecuteQueryResponsePart{
+		Status: Ydb.StatusIds_SUCCESS,
+	}, nil)
+	stream.EXPECT().Recv().Return(nil, io.EOF)
+	client.EXPECT().ExecuteQuery(gomock.Any(), gomock.Any()).Return(stream, nil)
+
+	var onDoCalled, onSessionExecCalled int
+	callTrace := &trace.Query{
+		OnDo: func(info trace.QueryDoStartInfo) func(trace.QueryDoDoneInfo) {
+			onDoCalled++
+
+			return func(trace.QueryDoDoneInfo) {}
+		},
+		OnSessionExec: func(info trace.QuerySessionExecStartInfo) func(trace.QuerySessionExecDoneInfo) {
+			onSessionExecCalled++
+
+			return func(trace.QuerySessionExecDoneInfo) {}
+		},
+	}
+
+	c := testClient(t, client)
+	c.explicitSessionPool = &mockSessionPool{
+		withFunc: func(ctx context.Context, f func(ctx context.Context, s *Session) error) error {
+			return f(ctx, newTestSessionWithClient("s-1", client, true))
+		},
+	}
+
+	err := c.Do(ctx, func(ctx context.Context, s query.Session) error {
+		return s.Exec(ctx, "SELECT 1")
+	}, options.WithTrace(callTrace))
+	require.NoError(t, err)
+	require.Equal(t, 1, onDoCalled, "call-level OnDo must be invoked")
+	require.Equal(t, 1, onSessionExecCalled, "call-level OnSessionExec must be invoked inside Do")
+}

--- a/internal/query/client_test.go
+++ b/internal/query/client_test.go
@@ -260,7 +260,7 @@ func TestClient(t *testing.T) {
 					}()
 
 					return tx.Exec(ctx, "")
-				}, tx.NewSettings(tx.WithDefaultTxMode()))
+				}, tx.NewSettings(tx.WithDefaultTxMode()), nil)
 				require.NoError(t, err)
 			})
 			t.Run("NoLazyTx", func(t *testing.T) {
@@ -364,7 +364,7 @@ func TestClient(t *testing.T) {
 					}()
 
 					return tx.Exec(ctx, "")
-				}, tx.NewSettings(tx.WithDefaultTxMode()))
+				}, tx.NewSettings(tx.WithDefaultTxMode()), nil)
 				require.NoError(t, err)
 			})
 		})
@@ -390,7 +390,7 @@ func TestClient(t *testing.T) {
 				}
 
 				return nil
-			}, tx.NewSettings(tx.WithDefaultTxMode()))
+			}, tx.NewSettings(tx.WithDefaultTxMode()), nil)
 			require.NoError(t, err)
 			require.Equal(t, 10, counter)
 		})
@@ -444,7 +444,7 @@ func TestClient(t *testing.T) {
 							return newTestSessionWithClient("123", client, true), nil
 						}), func(ctx context.Context, tx query.TxActor) error {
 							return tx.Exec(ctx, "")
-						}, tx.NewSettings(tx.WithSerializableReadWrite()))
+						}, tx.NewSettings(tx.WithSerializableReadWrite()), nil)
 						require.NoError(t, err)
 						require.Zero(t, txInFlight)
 					})
@@ -496,7 +496,7 @@ func TestClient(t *testing.T) {
 							return newTestSessionWithClient("123", client, true), nil
 						}), func(ctx context.Context, tx query.TxActor) error {
 							return tx.Exec(ctx, "", options.WithCommit())
-						}, tx.NewSettings(tx.WithSerializableReadWrite()))
+						}, tx.NewSettings(tx.WithSerializableReadWrite()), nil)
 						require.NoError(t, err)
 						require.Zero(t, txInFlight)
 					})
@@ -589,7 +589,7 @@ func TestClient(t *testing.T) {
 							}
 
 							return tx.Exec(ctx, "")
-						}, tx.NewSettings(tx.WithSerializableReadWrite()))
+						}, tx.NewSettings(tx.WithSerializableReadWrite()), nil)
 						require.NoError(t, err)
 					})
 				})
@@ -670,7 +670,7 @@ func TestClient(t *testing.T) {
 							}
 
 							return tx.Exec(ctx, "", options.WithCommit())
-						}, tx.NewSettings(tx.WithSerializableReadWrite()))
+						}, tx.NewSettings(tx.WithSerializableReadWrite()), nil)
 						require.NoError(t, err)
 					})
 				})

--- a/internal/query/options/retry.go
+++ b/internal/query/options/retry.go
@@ -26,6 +26,7 @@ type (
 	doSettings struct {
 		retryOpts []retry.Option
 		trace     *trace.Query
+		callTrace *trace.Query
 		label     string
 	}
 
@@ -76,6 +77,10 @@ func (s *doSettings) Trace() *trace.Query {
 	return s.trace
 }
 
+func (s *doSettings) CallTrace() *trace.Query {
+	return s.callTrace
+}
+
 func (s *doSettings) RetryOpts() []retry.Option {
 	return s.retryOpts
 }
@@ -94,6 +99,7 @@ func (s *doTxSettings) LazyTx() *bool {
 
 func (opt TraceOption) applyDoOption(s *doSettings) {
 	s.trace = gtrace.Compose(s.trace, opt.t)
+	s.callTrace = gtrace.Compose(s.callTrace, opt.t)
 }
 
 func (opt TraceOption) applyDoTxOption(s *doTxSettings) {


### PR DESCRIPTION
## Summary
- Fixes [#2218](https://github.com/ydb-platform/ydb-go-sdk/issues/2218): `query.WithTrace` passed to `DoTx` (and `Do`) was parsed into settings but not applied to session/transaction operations.
- `Client.DoTx` now passes the composed call-level trace into `doTx`, which temporarily sets it on the session for begin/exec/commit/rollback callbacks.
- `Client.Do` applies the same pattern for consistency (`OnSessionExec`, etc.).
- Added unit tests verifying `OnDoTx`/`OnTxExec` and `OnDo`/`OnSessionExec` fire for call-level tracers without driver-level trace.

## Test plan
- [x] `go test ./internal/query/ -run TestClient_DoTx_CallLevelTrace`
- [x] `go test ./internal/query/ -run TestClient_Do_CallLevelTrace`
- [x] `go test ./internal/query/`