### PR TITLE
Add native-sdk Codecov component

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -10,3 +10,14 @@ ignore:
   - examples
   - internal/mock
   - pkg/xtest
+
+# Cross-repo uniform metric: every YDB SDK repo defines this same component_id,
+# so native-SDK coverage is queryable identically via the Codecov API
+# (?component_id=native-sdk). This repo is a single-module SDK, so the component
+# spans the whole module; the ignore list above already scopes out non-SDK code.
+component_management:
+  individual_components:
+    - component_id: native-sdk
+      name: Native SDK
+      paths:
+        - "**"


### PR DESCRIPTION
Adds a path-based `native-sdk` component to the existing `codecov.yml`. This repo is a single-module SDK, so the component spans the whole module (`**`); the existing `ignore` list already scopes out non-SDK code, so the component number equals the current repo-level coverage.

The `native-sdk` `component_id` is shared across all YDB SDK repos so native-SDK coverage is queryable uniformly via the Codecov API (`?component_id=native-sdk`). Purely additive — existing ignore, gates, and comment behavior are untouched.