### PR TITLE
feat: shared driver session pool for table and query clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v3.144.0
+* **Breaking change:** driver session pool is shared between `table.Client` and `query.Client`. `WithSessionPoolSizeLimit(N)` and related `WithSessionPool*` options now configure a single pool on the driver (at most **N** concurrent sessions total, not N per client). Table pooled operations use Query `CreateSession` + `AttachSession` (aligned with ydb-rs-sdk). Use `Driver.SessionPoolStats()` for pool counters. Query implicit session pool is unchanged.
+
 ## v3.143.0
 * Added experimental helper `sugar.NewKVClientBuilder(ctx, db)` to use `YDB` with Redis-like commands: `Get`, `Set`, `Del` and `Keys`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-## v3.144.0
 * **Breaking change:** driver session pool is shared between `table.Client` and `query.Client`. `WithSessionPoolSizeLimit(N)` and related `WithSessionPool*` options now configure a single pool on the driver (at most **N** concurrent sessions total, not N per client). Table pooled operations use Query `CreateSession` + `AttachSession` (aligned with ydb-rs-sdk). Use `Driver.SessionPoolStats()` for pool counters. Query implicit session pool is unchanged.
 
 ## v3.143.0

--- a/driver.go
+++ b/driver.go
@@ -102,6 +102,9 @@ type (
 
 		pool *conn.Pool
 
+		sessionPoolConfig driverSessionPoolConfig
+		sharedSessionPool *xsync.Once[*internalQuery.SharedSessionPool]
+
 		mtx          sync.Mutex
 		metaBalancer *balancerWithMeta
 
@@ -190,6 +193,7 @@ func (d *Driver) Close(ctx context.Context) (finalErr error) {
 		d.table.Close,
 		d.operation.Close,
 		d.query.Close,
+		d.sharedSessionPool.Close,
 		d.topic.Close,
 		d.discovery.Close,
 		d.metaBalancer.Close,
@@ -371,9 +375,10 @@ func driverFromOptions(ctx context.Context, opts ...Option) (_ *Driver, err erro
 	}()
 
 	d := &Driver{
-		children:     make(map[uint64]*Driver),
-		ctxCancel:    driverCtxCancel,
-		metaBalancer: &balancerWithMeta{},
+		children:            make(map[uint64]*Driver),
+		ctxCancel:           driverCtxCancel,
+		metaBalancer:        &balancerWithMeta{},
+		sessionPoolConfig:   defaultDriverSessionPoolConfig(),
 	}
 
 	if caFile, has := os.LookupEnv("YDB_SSL_ROOT_CERTIFICATES_FILE"); has {
@@ -472,7 +477,29 @@ func (d *Driver) connect(ctx context.Context) error {
 	}
 	d.metaBalancer.meta = d.config.Meta()
 
+	d.sharedSessionPool = xsync.OnceValue(func() (*internalQuery.SharedSessionPool, error) {
+		queryCfg := queryConfig.New(
+			append(
+				[]queryConfig.Option{
+					queryConfig.With(d.config.Common),
+				},
+				d.queryOptions...,
+			)...,
+		)
+
+		return internalQuery.NewSharedSessionPool(
+			xcontext.ValueOnly(ctx),
+			d.metaBalancer,
+			d.sharedSessionPoolSettings(queryCfg.Trace()),
+		)
+	})
+
 	d.table = xsync.OnceValue(func() (*internalTable.Client, error) {
+		shared, err := d.sharedSessionPool.Get()
+		if err != nil {
+			return nil, xerrors.WithStackTrace(err)
+		}
+
 		return internalTable.New(xcontext.ValueOnly(ctx),
 			d.metaBalancer,
 			tableConfig.New(
@@ -482,14 +509,21 @@ func (d *Driver) connect(ctx context.Context) error {
 						tableConfig.With(d.config.Common),
 
 						tableConfig.WithMaxRequestMessageSize(d.config.GrpcMaxMessageSize()),
+						tableConfig.UseQuerySession(true),
 					},
 					d.tableOptions...,
 				)...,
 			),
+			internalTable.WithSharedSessionPool(shared),
 		)
 	})
 
 	d.query = xsync.OnceValue(func() (*internalQuery.Client, error) {
+		shared, err := d.sharedSessionPool.Get()
+		if err != nil {
+			return nil, xerrors.WithStackTrace(err)
+		}
+
 		return internalQuery.New(xcontext.ValueOnly(ctx),
 			d.metaBalancer,
 			queryConfig.New(
@@ -501,6 +535,7 @@ func (d *Driver) connect(ctx context.Context) error {
 					d.queryOptions...,
 				)...,
 			),
+			internalQuery.WithSharedSessionPool(shared),
 		)
 	})
 

--- a/driver.go
+++ b/driver.go
@@ -103,7 +103,7 @@ type (
 		pool *conn.Pool
 
 		sessionPoolConfig driverSessionPoolConfig
-		sharedSessionPool *xsync.Once[*internalQuery.SharedSessionPool]
+		sessionPool       *xsync.Once[*internalQuery.SessionPool]
 
 		mtx          sync.Mutex
 		metaBalancer *balancerWithMeta
@@ -193,7 +193,7 @@ func (d *Driver) Close(ctx context.Context) (finalErr error) {
 		d.table.Close,
 		d.operation.Close,
 		d.query.Close,
-		d.sharedSessionPool.Close,
+		d.sessionPool.Close,
 		d.topic.Close,
 		d.discovery.Close,
 		d.metaBalancer.Close,
@@ -375,10 +375,10 @@ func driverFromOptions(ctx context.Context, opts ...Option) (_ *Driver, err erro
 	}()
 
 	d := &Driver{
-		children:            make(map[uint64]*Driver),
-		ctxCancel:           driverCtxCancel,
-		metaBalancer:        &balancerWithMeta{},
-		sessionPoolConfig:   defaultDriverSessionPoolConfig(),
+		children:          make(map[uint64]*Driver),
+		ctxCancel:         driverCtxCancel,
+		metaBalancer:      &balancerWithMeta{},
+		sessionPoolConfig: defaultDriverSessionPoolConfig(),
 	}
 
 	if caFile, has := os.LookupEnv("YDB_SSL_ROOT_CERTIFICATES_FILE"); has {
@@ -477,7 +477,7 @@ func (d *Driver) connect(ctx context.Context) error {
 	}
 	d.metaBalancer.meta = d.config.Meta()
 
-	d.sharedSessionPool = xsync.OnceValue(func() (*internalQuery.SharedSessionPool, error) {
+	d.sessionPool = xsync.OnceValue(func() (*internalQuery.SessionPool, error) {
 		queryCfg := queryConfig.New(
 			append(
 				[]queryConfig.Option{
@@ -495,7 +495,7 @@ func (d *Driver) connect(ctx context.Context) error {
 	})
 
 	d.table = xsync.OnceValue(func() (*internalTable.Client, error) {
-		shared, err := d.sharedSessionPool.Get()
+		pool, err := d.sessionPool.Get()
 		if err != nil {
 			return nil, xerrors.WithStackTrace(err)
 		}
@@ -514,12 +514,12 @@ func (d *Driver) connect(ctx context.Context) error {
 					d.tableOptions...,
 				)...,
 			),
-			internalTable.WithSharedSessionPool(shared),
+			internalTable.WithSessionPool(pool),
 		)
 	})
 
 	d.query = xsync.OnceValue(func() (*internalQuery.Client, error) {
-		shared, err := d.sharedSessionPool.Get()
+		pool, err := d.sessionPool.Get()
 		if err != nil {
 			return nil, xerrors.WithStackTrace(err)
 		}
@@ -535,7 +535,7 @@ func (d *Driver) connect(ctx context.Context) error {
 					d.queryOptions...,
 				)...,
 			),
-			internalQuery.WithSharedSessionPool(shared),
+			internalQuery.WithSessionPool(pool),
 		)
 	})
 

--- a/driver_session_pool_config.go
+++ b/driver_session_pool_config.go
@@ -11,14 +11,14 @@ import (
 )
 
 type driverSessionPoolConfig struct {
-	limit            int
-	warmUp           int
-	itemUsageLimit   uint64
-	itemUsageTTL     time.Duration
-	idleTTL          time.Duration
-	createTimeout    time.Duration
-	deleteTimeout    time.Duration
-	disableBalancer  bool
+	limit           int
+	warmUp          int
+	itemUsageLimit  uint64
+	itemUsageTTL    time.Duration
+	idleTTL         time.Duration
+	createTimeout   time.Duration
+	deleteTimeout   time.Duration
+	disableBalancer bool
 }
 
 func defaultDriverSessionPoolConfig() driverSessionPoolConfig {

--- a/driver_session_pool_config.go
+++ b/driver_session_pool_config.go
@@ -1,0 +1,64 @@
+package ydb
+
+import (
+	"time"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/pool"
+	internalQuery "github.com/ydb-platform/ydb-go-sdk/v3/internal/query"
+	queryConfig "github.com/ydb-platform/ydb-go-sdk/v3/internal/query/config"
+	tableConfig "github.com/ydb-platform/ydb-go-sdk/v3/internal/table/config"
+	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
+)
+
+type driverSessionPoolConfig struct {
+	limit            int
+	warmUp           int
+	itemUsageLimit   uint64
+	itemUsageTTL     time.Duration
+	idleTTL          time.Duration
+	createTimeout    time.Duration
+	deleteTimeout    time.Duration
+	disableBalancer  bool
+}
+
+func defaultDriverSessionPoolConfig() driverSessionPoolConfig {
+	return driverSessionPoolConfig{
+		limit: pool.DefaultLimit,
+	}
+}
+
+func (d *Driver) sharedSessionPoolSettings(queryTrace *trace.Query) internalQuery.SharedSessionPoolConfig {
+	cfg := d.sessionPoolConfig
+
+	limit := cfg.limit
+	if limit <= 0 {
+		limit = pool.DefaultLimit
+	}
+
+	createTimeout := cfg.createTimeout
+	if createTimeout <= 0 {
+		createTimeout = queryConfig.DefaultSessionCreateTimeout
+	}
+
+	deleteTimeout := cfg.deleteTimeout
+	if deleteTimeout <= 0 {
+		deleteTimeout = queryConfig.DefaultSessionDeleteTimeout
+	}
+
+	idleTTL := cfg.idleTTL
+	if idleTTL <= 0 {
+		idleTTL = tableConfig.DefaultSessionPoolIdleThreshold
+	}
+
+	return internalQuery.SharedSessionPoolConfig{
+		Limit:                  limit,
+		WarmUp:                 cfg.warmUp,
+		ItemUsageLimit:         cfg.itemUsageLimit,
+		ItemUsageTTL:           cfg.itemUsageTTL,
+		IdleTTL:                idleTTL,
+		SessionCreateTimeout:   createTimeout,
+		SessionDeleteTimeout:   deleteTimeout,
+		DisableSessionBalancer: cfg.disableBalancer,
+		Trace:                  queryTrace,
+	}
+}

--- a/internal/query/client.go
+++ b/internal/query/client.go
@@ -10,7 +10,6 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/closer"
-	"github.com/ydb-platform/ydb-go-sdk/v3/internal/meta"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/operation"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/pool"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/query/config"
@@ -775,7 +774,9 @@ func CreateSession(ctx context.Context, client Ydb_Query_V1.QueryServiceClient, 
 	return s, nil
 }
 
-func New(ctx context.Context, cc grpc.ClientConnInterface, cfg *config.Config, opts ...NewClientOption) (*Client, error) {
+func New(ctx context.Context, cc grpc.ClientConnInterface, cfg *config.Config, opts ...NewClientOption) (
+	_ *Client, finalErr error,
+) {
 	var clientOpts newClientOptions
 	for _, opt := range opts {
 		if opt != nil {
@@ -786,20 +787,21 @@ func New(ctx context.Context, cc grpc.ClientConnInterface, cfg *config.Config, o
 	onDone := gtrace.QueryOnNew(cfg.Trace(), &ctx,
 		stack.FunctionID("github.com/ydb-platform/ydb-go-sdk/v3/internal/query.New"),
 	)
-	defer onDone()
+	defer func() {
+		onDone(cfg.PoolLimit(), finalErr)
+	}()
 
 	client := Ydb_Query_V1.NewQueryServiceClient(cc)
 
 	return newWithQueryServiceClient(ctx, client, cc, cfg, clientOpts)
 }
 
-//nolint:funlen
 func newWithQueryServiceClient(ctx context.Context,
 	client Ydb_Query_V1.QueryServiceClient,
 	cc grpc.ClientConnInterface,
 	cfg *config.Config,
 	clientOpts newClientOptions,
-) (*Client, error) {
+) (_ *Client, err error) {
 	c := &Client{
 		config: cfg,
 		client: client,
@@ -808,53 +810,14 @@ func newWithQueryServiceClient(ctx context.Context,
 		}),
 	}
 
-	var explicitSessionPool sessionPool
-	if clientOpts.sharedSessionPool != nil {
-		explicitSessionPool = newSharedExplicitPoolAdapter(clientOpts.sharedSessionPool, cfg)
-	} else {
-		var err error
-		explicitSessionPool, err = pool.New(ctx,
-		pool.WithLimit[*Session](cfg.PoolLimit()),
-		pool.WithWarmUpItems[*Session](cfg.PoolWarmUpSize()),
-		pool.WithItemUsageLimit[*Session](cfg.PoolSessionUsageLimit()),
-		pool.WithItemUsageTTL[*Session](cfg.PoolSessionUsageTTL()),
-		pool.WithTrace[*Session](poolTrace(cfg.Trace())),
-		pool.WithCreateItemTimeout[*Session](cfg.SessionCreateTimeout()),
-		pool.WithCloseItemTimeout[*Session](cfg.SessionDeleteTimeout()),
-		pool.WithMustDeleteItemFunc(func(s *Session, err error) bool {
-			if !s.IsAlive() {
-				return true
-			}
-
-			return err != nil && xerrors.MustDeleteTableOrQuerySession(err)
-		}),
-		pool.WithIdleTimeToLive[*Session](cfg.SessionIdleTimeToLive()),
-		pool.WithCreateItemFunc(func(ctx context.Context) (_ *Session, err error) {
-			if !cfg.DisableSessionBalancer() {
-				ctx = meta.WithAllowFeatures(ctx, meta.HintSessionBalancer)
-			}
-
-			s, err := createSession(ctx, client,
-				WithConn(cc),
-				WithDeleteTimeout(cfg.SessionDeleteTimeout()),
-				WithRegisterCloseCancel(c.registerCloseCancel),
-				WithTrace(cfg.Trace()),
-			)
-			if err != nil {
-				return nil, xerrors.WithStackTrace(err)
-			}
-
-			s.lazyTx = cfg.LazyTx()
-
-			return s, nil
-		}),
-		)
-		if err != nil {
-			return nil, xerrors.WithStackTrace(err)
-		}
+	if clientOpts.sessionPool == nil {
+		return nil, xerrors.WithStackTrace(errNilPool)
 	}
 
-	c.explicitSessionPool = explicitSessionPool
+	c.explicitSessionPool = &sessionPoolAdapter{
+		shared: clientOpts.sessionPool,
+		cfg:    cfg,
+	}
 
 	implicitSessionPool, err := createImplicitSessionPool(ctx, cfg, client, cc)
 	if err != nil {

--- a/internal/query/client.go
+++ b/internal/query/client.go
@@ -775,7 +775,14 @@ func CreateSession(ctx context.Context, client Ydb_Query_V1.QueryServiceClient, 
 	return s, nil
 }
 
-func New(ctx context.Context, cc grpc.ClientConnInterface, cfg *config.Config) (*Client, error) {
+func New(ctx context.Context, cc grpc.ClientConnInterface, cfg *config.Config, opts ...NewClientOption) (*Client, error) {
+	var clientOpts newClientOptions
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&clientOpts)
+		}
+	}
+
 	onDone := gtrace.QueryOnNew(cfg.Trace(), &ctx,
 		stack.FunctionID("github.com/ydb-platform/ydb-go-sdk/v3/internal/query.New"),
 	)
@@ -783,7 +790,7 @@ func New(ctx context.Context, cc grpc.ClientConnInterface, cfg *config.Config) (
 
 	client := Ydb_Query_V1.NewQueryServiceClient(cc)
 
-	return newWithQueryServiceClient(ctx, client, cc, cfg)
+	return newWithQueryServiceClient(ctx, client, cc, cfg, clientOpts)
 }
 
 //nolint:funlen
@@ -791,6 +798,7 @@ func newWithQueryServiceClient(ctx context.Context,
 	client Ydb_Query_V1.QueryServiceClient,
 	cc grpc.ClientConnInterface,
 	cfg *config.Config,
+	clientOpts newClientOptions,
 ) (*Client, error) {
 	c := &Client{
 		config: cfg,
@@ -799,7 +807,13 @@ func newWithQueryServiceClient(ctx context.Context,
 			cancels: make(map[uint64]context.CancelFunc),
 		}),
 	}
-	explicitSessionPool, err := pool.New(ctx,
+
+	var explicitSessionPool sessionPool
+	if clientOpts.sharedSessionPool != nil {
+		explicitSessionPool = newSharedExplicitPoolAdapter(clientOpts.sharedSessionPool, cfg)
+	} else {
+		var err error
+		explicitSessionPool, err = pool.New(ctx,
 		pool.WithLimit[*Session](cfg.PoolLimit()),
 		pool.WithWarmUpItems[*Session](cfg.PoolWarmUpSize()),
 		pool.WithItemUsageLimit[*Session](cfg.PoolSessionUsageLimit()),
@@ -834,9 +848,10 @@ func newWithQueryServiceClient(ctx context.Context,
 
 			return s, nil
 		}),
-	)
-	if err != nil {
-		return nil, xerrors.WithStackTrace(err)
+		)
+		if err != nil {
+			return nil, xerrors.WithStackTrace(err)
+		}
 	}
 
 	c.explicitSessionPool = explicitSessionPool

--- a/internal/query/client_options.go
+++ b/internal/query/client_options.go
@@ -1,0 +1,15 @@
+package query
+
+// NewClientOption configures query client construction.
+type NewClientOption func(*newClientOptions)
+
+type newClientOptions struct {
+	sharedSessionPool *SharedSessionPool
+}
+
+// WithSharedSessionPool leases explicit sessions from the driver-level pool.
+func WithSharedSessionPool(pool *SharedSessionPool) NewClientOption {
+	return func(o *newClientOptions) {
+		o.sharedSessionPool = pool
+	}
+}

--- a/internal/query/client_options.go
+++ b/internal/query/client_options.go
@@ -4,12 +4,12 @@ package query
 type NewClientOption func(*newClientOptions)
 
 type newClientOptions struct {
-	sharedSessionPool *SharedSessionPool
+	sessionPool *SessionPool
 }
 
-// WithSharedSessionPool leases explicit sessions from the driver-level pool.
-func WithSharedSessionPool(pool *SharedSessionPool) NewClientOption {
+// WithSessionPool leases explicit sessions from the driver-level pool.
+func WithSessionPool(pool *SessionPool) NewClientOption {
 	return func(o *newClientOptions) {
-		o.sharedSessionPool = pool
+		o.sessionPool = pool
 	}
 }

--- a/internal/query/client_test.go
+++ b/internal/query/client_test.go
@@ -1819,7 +1819,7 @@ func mockClientForImplicitSessionTest(ctx context.Context, t *testing.T) *Client
 
 	cfg := config.New(config.AllowImplicitSessions())
 
-	c, err := newWithQueryServiceClient(ctx, queryService, nil, cfg)
+	c, err := newWithQueryServiceClient(ctx, queryService, nil, cfg, newClientOptions{})
 	require.NoError(t, err)
 
 	return c

--- a/internal/query/concurrent_result_sets_test.go
+++ b/internal/query/concurrent_result_sets_test.go
@@ -77,7 +77,7 @@ func TestClientConcurrentResultSets(t *testing.T) {
 			Status: Ydb.StatusIds_SUCCESS,
 		}, nil).AnyTimes()
 
-		client, err := newWithQueryServiceClient(ctx, queryService, nil, explicitSessionConfig())
+		client, err := newWithQueryServiceClient(ctx, queryService, nil, explicitSessionConfig(), newClientOptions{})
 		require.NoError(t, err)
 
 		err = client.DoTx(ctx, func(ctx context.Context, tx query.TxActor) error {
@@ -113,7 +113,7 @@ func TestClientConcurrentResultSets(t *testing.T) {
 				return interleavedMultiResultSetStream(ctrl), nil
 			})
 
-		client, err := newWithQueryServiceClient(ctx, queryService, nil, implicitSessionConfig())
+		client, err := newWithQueryServiceClient(ctx, queryService, nil, implicitSessionConfig(), newClientOptions{})
 		require.NoError(t, err)
 
 		r, err := client.Query(ctx, "SELECT 1; SELECT 2")
@@ -186,7 +186,7 @@ func newMockClientCheckingConcurrentResultSets(
 			Times(1)
 	}
 
-	client, err := newWithQueryServiceClient(t.Context(), queryService, nil, cfg)
+	client, err := newWithQueryServiceClient(t.Context(), queryService, nil, cfg, newClientOptions{})
 	require.NoError(t, err)
 
 	return client

--- a/internal/query/errors.go
+++ b/internal/query/errors.go
@@ -15,6 +15,7 @@ var (
 	ErrOptionNotForTxExecute  = query.ErrOptionNotForTxExecute
 	ErrTransactionRollingBack = xerrors.Wrap(errors.New("the transaction is rolling back"))
 
+	errNilPool                 = xerrors.Wrap(errors.New("query client required external session pool"))
 	errNilClient               = xerrors.Wrap(errors.New("table client is not initialized"))
 	errClosedClient            = xerrors.Wrap(errors.New("query client closed early"))
 	errWrongNextResultSetIndex = errors.New("wrong result set index")

--- a/internal/query/gtrace/query_gtrace.go
+++ b/internal/query/gtrace/query_gtrace.go
@@ -1718,13 +1718,15 @@ func onResultClose(t *trace.Query, q trace.QueryResultCloseStartInfo) func(info 
 	return res
 }
 // Internals: https://github.com/ydb-platform/ydb-go-sdk/blob/master/VERSIONING.md#internals
-func QueryOnNew(t *trace.Query, c *context.Context, c1 trace.Call) func() {
+func QueryOnNew(t *trace.Query, c *context.Context, c1 trace.Call) func(limit int, _ error) {
 	var p trace.QueryNewStartInfo
 	p.Context = c
 	p.Call = c1
 	res := onNew(t, p)
-	return func() {
+	return func(limit int, e error) {
 		var p trace.QueryNewDoneInfo
+		p.Limit = limit
+		p.Error = e
 		res(p)
 	}
 }

--- a/internal/query/pool_warm_up_test.go
+++ b/internal/query/pool_warm_up_test.go
@@ -23,7 +23,7 @@ func TestSessionPoolWarmUp(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		client := newMockQueryServiceForWarmUp(ctrl, 0)
 
-		c, err := newWithQueryServiceClient(ctx, client, nil, config.New(config.WithPoolLimit(10)))
+		c, err := newWithQueryServiceClient(ctx, client, nil, config.New(config.WithPoolLimit(10)), newClientOptions{})
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = c.Close(ctx) })
 
@@ -40,7 +40,7 @@ func TestSessionPoolWarmUp(t *testing.T) {
 		c, err := newWithQueryServiceClient(ctx, client, nil, config.New(
 			config.WithPoolLimit(10),
 			config.WithSessionPoolWarmUpSessions(warmUpSize),
-		))
+		), newClientOptions{})
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = c.Close(ctx) })
 
@@ -58,7 +58,7 @@ func TestSessionPoolWarmUp(t *testing.T) {
 			config.AllowImplicitSessions(),
 			config.WithPoolLimit(10),
 			config.WithSessionPoolWarmUpSessions(warmUpSize),
-		))
+		), newClientOptions{})
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = c.Close(ctx) })
 
@@ -78,7 +78,7 @@ func TestSessionPoolWarmUp(t *testing.T) {
 		c, err := newWithQueryServiceClient(ctx, client, nil, config.New(
 			config.WithPoolLimit(limit),
 			config.WithSessionPoolWarmUpSessions(warmUpSize),
-		))
+		), newClientOptions{})
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = c.Close(ctx) })
 
@@ -92,7 +92,7 @@ func TestSessionPoolWarmUp(t *testing.T) {
 
 		_, err := newWithQueryServiceClient(ctx, client, nil, config.New(
 			config.WithSessionPoolWarmUpSessions(1),
-		))
+		), newClientOptions{})
 		require.Error(t, err)
 	})
 }

--- a/internal/query/shared_session_pool.go
+++ b/internal/query/shared_session_pool.go
@@ -31,21 +31,21 @@ type SharedSessionPoolConfig struct {
 	Trace                  *trace.Query
 }
 
-// SharedSessionPool is a driver-level pool of query session cores (CreateSession + AttachSession).
+// SessionPool is a driver-level pool of query session cores (CreateSession + AttachSession).
 // Table and query clients lease sessions from the same pool instance.
-type SharedSessionPool struct {
+type SessionPool struct {
 	corePool *pool.Pool[*sessionCore, sessionCore]
 
 	closed *xsync.Value[*closeState]
 }
 
 // NewSharedSessionPool creates and optionally warms up the driver session pool.
-func NewSharedSessionPool(
+func NewSharedSessionPool( //nolint:funlen
 	ctx context.Context,
 	cc grpc.ClientConnInterface,
 	cfg SharedSessionPoolConfig,
-) (*SharedSessionPool, error) {
-	p := &SharedSessionPool{
+) (*SessionPool, error) {
+	p := &SessionPool{
 		closed: xsync.NewValue(&closeState{
 			cancels: make(map[uint64]context.CancelFunc),
 		}),
@@ -121,7 +121,7 @@ func NewSharedSessionPool(
 	return p, nil
 }
 
-func (p *SharedSessionPool) registerCloseCancel(cancel context.CancelFunc) func() {
+func (p *SessionPool) registerCloseCancel(cancel context.CancelFunc) func() {
 	var id uint64
 	p.closed.Change(func(old *closeState) *closeState {
 		if old.closed {
@@ -147,7 +147,7 @@ func (p *SharedSessionPool) registerCloseCancel(cancel context.CancelFunc) func(
 	}
 }
 
-func (p *SharedSessionPool) unregisterCloseCancel(id uint64) {
+func (p *SessionPool) unregisterCloseCancel(id uint64) {
 	p.closed.Change(func(old *closeState) *closeState {
 		delete(old.cancels, id)
 
@@ -156,12 +156,12 @@ func (p *SharedSessionPool) unregisterCloseCancel(id uint64) {
 }
 
 // Stats returns pool counters (shared by table and query clients).
-func (p *SharedSessionPool) Stats() pool.Stats {
+func (p *SessionPool) Stats() pool.Stats {
 	return p.corePool.Stats()
 }
 
 // Close closes all pooled sessions.
-func (p *SharedSessionPool) Close(ctx context.Context) error {
+func (p *SessionPool) Close(ctx context.Context) error {
 	var cancels []context.CancelFunc
 	p.closed.Change(func(old *closeState) *closeState {
 		if old.closed {
@@ -177,10 +177,8 @@ func (p *SharedSessionPool) Close(ctx context.Context) error {
 
 		return old
 	})
-	if cancels != nil {
-		for _, cancel := range cancels {
-			cancel()
-		}
+	for _, cancel := range cancels {
+		cancel()
 	}
 
 	if err := p.corePool.Close(ctx); err != nil {
@@ -191,7 +189,7 @@ func (p *SharedSessionPool) Close(ctx context.Context) error {
 }
 
 // WithCore leases a session core from the pool.
-func (p *SharedSessionPool) WithCore(
+func (p *SessionPool) WithCore(
 	ctx context.Context,
 	op func(ctx context.Context, core Core) error,
 	opts ...retry.Option,
@@ -205,8 +203,8 @@ func (p *SharedSessionPool) WithCore(
 	}, opts...)
 }
 
-// QueryServiceClientFromCore returns the query gRPC client bound to a pooled session core.
-func QueryServiceClientFromCore(core Core) Ydb_Query_V1.QueryServiceClient {
+// ClientFromCore returns the query gRPC client bound to a pooled session core.
+func ClientFromCore(core Core) Ydb_Query_V1.QueryServiceClient {
 	sc, ok := core.(*sessionCore)
 	if !ok || sc == nil {
 		return nil

--- a/internal/query/shared_session_pool.go
+++ b/internal/query/shared_session_pool.go
@@ -1,0 +1,266 @@
+package query
+
+import (
+	"context"
+	"time"
+
+	"github.com/ydb-platform/ydb-go-genproto/Ydb_Query_V1"
+	"google.golang.org/grpc"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/meta"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/pool"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/query/config"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/query/gtrace"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/stack"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xsync"
+	"github.com/ydb-platform/ydb-go-sdk/v3/retry"
+	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
+)
+
+// SharedSessionPoolConfig configures the driver-level session pool shared by table and query clients.
+type SharedSessionPoolConfig struct {
+	Limit                  int
+	WarmUp                 int
+	ItemUsageLimit         uint64
+	ItemUsageTTL           time.Duration
+	IdleTTL                time.Duration
+	SessionCreateTimeout   time.Duration
+	SessionDeleteTimeout   time.Duration
+	DisableSessionBalancer bool
+	Trace                  *trace.Query
+}
+
+// SharedSessionPool is a driver-level pool of query session cores (CreateSession + AttachSession).
+// Table and query clients lease sessions from the same pool instance.
+type SharedSessionPool struct {
+	corePool *pool.Pool[*sessionCore, sessionCore]
+
+	closed *xsync.Value[*closeState]
+}
+
+// NewSharedSessionPool creates and optionally warms up the driver session pool.
+func NewSharedSessionPool(
+	ctx context.Context,
+	cc grpc.ClientConnInterface,
+	cfg SharedSessionPoolConfig,
+) (*SharedSessionPool, error) {
+	p := &SharedSessionPool{
+		closed: xsync.NewValue(&closeState{
+			cancels: make(map[uint64]context.CancelFunc),
+		}),
+	}
+
+	client := Ydb_Query_V1.NewQueryServiceClient(cc)
+	traceQuery := cfg.Trace
+	if traceQuery == nil {
+		traceQuery = &trace.Query{}
+	}
+
+	deleteTimeout := cfg.SessionDeleteTimeout
+	if deleteTimeout <= 0 {
+		deleteTimeout = config.DefaultSessionDeleteTimeout
+	}
+
+	createTimeout := cfg.SessionCreateTimeout
+	if createTimeout <= 0 {
+		createTimeout = config.DefaultSessionCreateTimeout
+	}
+
+	limit := cfg.Limit
+	if limit <= 0 {
+		limit = config.DefaultPoolMaxSize
+	}
+
+	poolOpts := []pool.Option[*sessionCore, sessionCore]{
+		pool.WithLimit[*sessionCore, sessionCore](limit),
+		pool.WithWarmUpItems[*sessionCore, sessionCore](cfg.WarmUp),
+		pool.WithItemUsageLimit[*sessionCore, sessionCore](cfg.ItemUsageLimit),
+		pool.WithTrace[*sessionCore, sessionCore](sharedPoolTrace(traceQuery)),
+		pool.WithCreateItemTimeout[*sessionCore, sessionCore](createTimeout),
+		pool.WithCloseItemTimeout[*sessionCore, sessionCore](deleteTimeout),
+		pool.WithMustDeleteItemFunc(func(s *sessionCore, err error) bool {
+			if !s.IsAlive() {
+				return true
+			}
+
+			return err != nil && xerrors.MustDeleteTableOrQuerySession(err)
+		}),
+		pool.WithCreateItemFunc(func(ctx context.Context) (*sessionCore, error) {
+			if !cfg.DisableSessionBalancer {
+				ctx = meta.WithAllowFeatures(ctx, meta.HintSessionBalancer)
+			}
+
+			return Open(ctx, client,
+				WithConn(cc),
+				WithDeleteTimeout(deleteTimeout),
+				WithRegisterCloseCancel(p.registerCloseCancel),
+				WithTrace(traceQuery),
+			)
+		}),
+	}
+
+	if cfg.ItemUsageTTL > 0 {
+		poolOpts = append(poolOpts,
+			pool.WithItemUsageTTL[*sessionCore, sessionCore](cfg.ItemUsageTTL),
+		)
+	}
+	if cfg.IdleTTL > 0 {
+		poolOpts = append(poolOpts,
+			pool.WithIdleTimeToLive[*sessionCore, sessionCore](cfg.IdleTTL),
+		)
+	}
+
+	corePool, err := pool.New(ctx, poolOpts...)
+	if err != nil {
+		return nil, xerrors.WithStackTrace(err)
+	}
+
+	p.corePool = corePool
+
+	return p, nil
+}
+
+func (p *SharedSessionPool) registerCloseCancel(cancel context.CancelFunc) func() {
+	var id uint64
+	p.closed.Change(func(old *closeState) *closeState {
+		if old.closed {
+			return old
+		}
+
+		new := *old
+
+		new.nextCancelID++
+		id = new.nextCancelID
+		new.cancels[id] = cancel
+
+		return &new
+	})
+	if id == 0 {
+		cancel()
+
+		return func() {}
+	}
+
+	return func() {
+		p.unregisterCloseCancel(id)
+	}
+}
+
+func (p *SharedSessionPool) unregisterCloseCancel(id uint64) {
+	p.closed.Change(func(old *closeState) *closeState {
+		delete(old.cancels, id)
+
+		return old
+	})
+}
+
+// Stats returns pool counters (shared by table and query clients).
+func (p *SharedSessionPool) Stats() pool.Stats {
+	return p.corePool.Stats()
+}
+
+// Close closes all pooled sessions.
+func (p *SharedSessionPool) Close(ctx context.Context) error {
+	var cancels []context.CancelFunc
+	p.closed.Change(func(old *closeState) *closeState {
+		if old.closed {
+			return old
+		}
+
+		old.closed = true
+		cancels = make([]context.CancelFunc, 0, len(old.cancels))
+		for _, cancel := range old.cancels {
+			cancels = append(cancels, cancel)
+		}
+		old.cancels = nil
+
+		return old
+	})
+	if cancels != nil {
+		for _, cancel := range cancels {
+			cancel()
+		}
+	}
+
+	if err := p.corePool.Close(ctx); err != nil {
+		return xerrors.WithStackTrace(err)
+	}
+
+	return nil
+}
+
+// WithCore leases a session core from the pool.
+func (p *SharedSessionPool) WithCore(
+	ctx context.Context,
+	op func(ctx context.Context, core Core) error,
+	opts ...retry.Option,
+) error {
+	return p.corePool.With(ctx, func(ctx context.Context, core *sessionCore) error {
+		if err := op(ctx, core); err != nil {
+			return xerrors.WithStackTrace(err)
+		}
+
+		return nil
+	}, opts...)
+}
+
+// QueryServiceClientFromCore returns the query gRPC client bound to a pooled session core.
+func QueryServiceClientFromCore(core Core) Ydb_Query_V1.QueryServiceClient {
+	sc, ok := core.(*sessionCore)
+	if !ok || sc == nil {
+		return nil
+	}
+
+	return sc.Client
+}
+
+func sharedPoolTrace(t *trace.Query) *pool.Trace[*sessionCore, sessionCore] {
+	return &pool.Trace[*sessionCore, sessionCore]{
+		OnNew: func(ctx *context.Context, call stack.Caller) func(limit int) {
+			onDone := gtrace.QueryOnPoolNew(t, ctx, call)
+
+			return func(limit int) {
+				onDone(limit)
+			}
+		},
+		OnClose: func(ctx *context.Context, call stack.Caller) func(err error) {
+			onDone := gtrace.QueryOnClose(t, ctx, call)
+
+			return func(err error) {
+				onDone(err)
+			}
+		},
+		OnPut: func(ctx *context.Context, call stack.Caller, item *sessionCore) func(err error) {
+			onDone := gtrace.QueryOnPoolPut(t, ctx, call, item)
+
+			return func(err error) {
+				onDone(err)
+			}
+		},
+		OnGet: func(ctx *context.Context, call stack.Caller) func(
+			session *sessionCore,
+			hintInfo *trace.NodeHintInfo,
+			attempts int,
+			err error,
+		) {
+			onDone := gtrace.QueryOnPoolGet(t, ctx, call)
+
+			return func(session *sessionCore, hintInfo *trace.NodeHintInfo, attempts int, err error) {
+				onDone(session, attempts, hintInfo, err)
+			}
+		},
+		OnWith: func(ctx *context.Context, call stack.Caller) func(attempts int, err error) {
+			onDone := gtrace.QueryOnPoolWith(t, ctx, call)
+
+			return func(attempts int, err error) {
+				onDone(attempts, err)
+			}
+		},
+		OnChange: func(stats pool.Stats) {
+			gtrace.QueryOnPoolChange(t,
+				stats.Limit, stats.Idle, stats.CreateInProgress, stats.Concurrency, stats.Size,
+			)
+		},
+	}
+}

--- a/internal/query/shared_session_pool_adapter.go
+++ b/internal/query/shared_session_pool_adapter.go
@@ -9,28 +9,21 @@ import (
 	"github.com/ydb-platform/ydb-go-sdk/v3/retry"
 )
 
-type sharedExplicitPoolAdapter struct {
-	shared *SharedSessionPool
+type sessionPoolAdapter struct {
+	shared *SessionPool
 	cfg    *config.Config
 }
 
-func newSharedExplicitPoolAdapter(shared *SharedSessionPool, cfg *config.Config) sessionPool {
-	return &sharedExplicitPoolAdapter{
-		shared: shared,
-		cfg:    cfg,
-	}
-}
-
-func (a *sharedExplicitPoolAdapter) Stats() pool.Stats {
+func (a *sessionPoolAdapter) Stats() pool.Stats {
 	return a.shared.Stats()
 }
 
-func (a *sharedExplicitPoolAdapter) Close(ctx context.Context) error {
+func (a *sessionPoolAdapter) Close(ctx context.Context) error {
 	// The driver owns the shared pool lifecycle.
 	return nil
 }
 
-func (a *sharedExplicitPoolAdapter) With(
+func (a *sessionPoolAdapter) With(
 	ctx context.Context,
 	f func(ctx context.Context, s *Session) error,
 	opts ...retry.Option,

--- a/internal/query/shared_session_pool_adapter.go
+++ b/internal/query/shared_session_pool_adapter.go
@@ -1,0 +1,59 @@
+package query
+
+import (
+	"context"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/pool"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/query/config"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
+	"github.com/ydb-platform/ydb-go-sdk/v3/retry"
+)
+
+type sharedExplicitPoolAdapter struct {
+	shared *SharedSessionPool
+	cfg    *config.Config
+}
+
+func newSharedExplicitPoolAdapter(shared *SharedSessionPool, cfg *config.Config) sessionPool {
+	return &sharedExplicitPoolAdapter{
+		shared: shared,
+		cfg:    cfg,
+	}
+}
+
+func (a *sharedExplicitPoolAdapter) Stats() pool.Stats {
+	return a.shared.Stats()
+}
+
+func (a *sharedExplicitPoolAdapter) Close(ctx context.Context) error {
+	// The driver owns the shared pool lifecycle.
+	return nil
+}
+
+func (a *sharedExplicitPoolAdapter) With(
+	ctx context.Context,
+	f func(ctx context.Context, s *Session) error,
+	opts ...retry.Option,
+) error {
+	return a.shared.WithCore(ctx, func(ctx context.Context, core Core) error {
+		s := sessionFromCore(core, a.cfg)
+
+		if err := f(ctx, s); err != nil {
+			return xerrors.WithStackTrace(err)
+		}
+
+		return nil
+	}, opts...)
+}
+
+func sessionFromCore(core Core, cfg *config.Config) *Session {
+	sc, _ := core.(*sessionCore)
+
+	return &Session{
+		Core:                     core,
+		client:                   sc.Client,
+		trace:                    sc.Trace,
+		lazyTx:                   cfg.LazyTx(),
+		streamResultCloseTimeout: sc.deleteTimeout,
+	}
+}

--- a/internal/table/client.go
+++ b/internal/table/client.go
@@ -32,12 +32,25 @@ import (
 // sessionBuilder is the interface that holds logic of creating sessions.
 type sessionBuilder func(ctx context.Context) (*Session, error)
 
-func New(ctx context.Context, cc grpc.ClientConnInterface, config *config.Config) (*Client, error) { //nolint:funlen
+func New(ctx context.Context, cc grpc.ClientConnInterface, config *config.Config, opts ...NewClientOption) (*Client, error) { //nolint:funlen
+	var clientOpts newClientOptions
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&clientOpts)
+		}
+	}
+
 	onDone := gtrace.TableOnInit(config.Trace(), &ctx,
 		stack.FunctionID("github.com/ydb-platform/ydb-go-sdk/v3/internal/table.New"),
 	)
 
-	sessionPool, err := pool.New[*Session, Session](ctx,
+	var sessionPool sessionPool
+	if clientOpts.sharedSessionPool != nil {
+		sessionPool = newSharedSessionPoolAdapter(clientOpts.sharedSessionPool, cc, config)
+		onDone(config.SizeLimit())
+	} else {
+		var err error
+		sessionPool, err = pool.New[*Session, Session](ctx,
 		pool.WithLimit[*Session, Session](config.SizeLimit()),
 		pool.WithWarmUpItems[*Session, Session](config.PoolWarmUpSize()),
 		pool.WithItemUsageLimit[*Session, Session](config.SessionUsageLimit()),
@@ -98,9 +111,10 @@ func New(ctx context.Context, cc grpc.ClientConnInterface, config *config.Config
 				)
 			},
 		}),
-	)
-	if err != nil {
-		return nil, xerrors.WithStackTrace(err)
+		)
+		if err != nil {
+			return nil, xerrors.WithStackTrace(err)
+		}
 	}
 
 	return &Client{

--- a/internal/table/client.go
+++ b/internal/table/client.go
@@ -11,9 +11,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/ydb-platform/ydb-go-sdk/v3/internal/meta"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/operation"
-	"github.com/ydb-platform/ydb-go-sdk/v3/internal/pool"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/safe"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/stack"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/table/config"
@@ -32,7 +30,9 @@ import (
 // sessionBuilder is the interface that holds logic of creating sessions.
 type sessionBuilder func(ctx context.Context) (*Session, error)
 
-func New(ctx context.Context, cc grpc.ClientConnInterface, config *config.Config, opts ...NewClientOption) (*Client, error) { //nolint:funlen
+func New(ctx context.Context, cc grpc.ClientConnInterface, config *config.Config, opts ...NewClientOption) (
+	_ *Client, finalErr error,
+) {
 	var clientOpts newClientOptions
 	for _, opt := range opts {
 		if opt != nil {
@@ -43,78 +43,12 @@ func New(ctx context.Context, cc grpc.ClientConnInterface, config *config.Config
 	onDone := gtrace.TableOnInit(config.Trace(), &ctx,
 		stack.FunctionID("github.com/ydb-platform/ydb-go-sdk/v3/internal/table.New"),
 	)
+	defer func() {
+		onDone(config.SizeLimit(), finalErr)
+	}()
 
-	var sessionPool sessionPool
-	if clientOpts.sharedSessionPool != nil {
-		sessionPool = newSharedSessionPoolAdapter(clientOpts.sharedSessionPool, cc, config)
-		onDone(config.SizeLimit())
-	} else {
-		var err error
-		sessionPool, err = pool.New[*Session, Session](ctx,
-		pool.WithLimit[*Session, Session](config.SizeLimit()),
-		pool.WithWarmUpItems[*Session, Session](config.PoolWarmUpSize()),
-		pool.WithItemUsageLimit[*Session, Session](config.SessionUsageLimit()),
-		pool.WithItemUsageTTL[*Session, Session](config.SessionUsageTTL()),
-		pool.WithIdleTimeToLive[*Session, Session](config.IdleThreshold()),
-		pool.WithCreateItemTimeout[*Session, Session](config.CreateSessionTimeout()),
-		pool.WithCloseItemTimeout[*Session, Session](config.DeleteTimeout()),
-		pool.WithMustDeleteItemFunc[*Session, Session](func(s *Session, err error) bool {
-			if !s.IsAlive() {
-				return true
-			}
-
-			return err != nil && xerrors.MustDeleteTableOrQuerySession(err)
-		}),
-		pool.WithClock[*Session, Session](config.Clock()),
-		pool.WithCreateItemFunc[*Session, Session](func(ctx context.Context) (*Session, error) {
-			if !config.DisableSessionBalancer() {
-				ctx = meta.WithAllowFeatures(ctx, meta.HintSessionBalancer)
-			}
-
-			return newSession(ctx, cc, config)
-		}),
-		pool.WithTrace[*Session, Session](&pool.Trace[*Session, Session]{
-			OnNew: func(ctx *context.Context, call stack.Caller) func(limit int) {
-				return func(limit int) {
-					onDone(limit)
-				}
-			},
-			OnPut: func(ctx *context.Context, call stack.Caller, item *Session) func(err error) {
-				onDone := gtrace.TableOnPoolPut(config.Trace(), ctx, call, safe.SessionInfo(item))
-
-				return func(err error) {
-					onDone(err)
-				}
-			},
-			OnGet: func(ctx *context.Context, call stack.Caller) func(
-				session *Session,
-				hintInfo *trace.NodeHintInfo,
-				attempts int,
-				err error,
-			) {
-				onDone := gtrace.TableOnPoolGet(config.Trace(), ctx, call)
-
-				return func(session *Session, hintInfo *trace.NodeHintInfo, attempts int, err error) {
-					onDone(safe.SessionInfo(session), attempts, hintInfo, err)
-				}
-			},
-			OnWith: func(ctx *context.Context, call stack.Caller) func(attempts int, err error) {
-				onDone := gtrace.TableOnPoolWith(config.Trace(), ctx, call)
-
-				return func(attempts int, err error) {
-					onDone(attempts, err)
-				}
-			},
-			OnChange: func(stats pool.Stats) {
-				gtrace.TableOnPoolStateChange(config.Trace(),
-					stats.Limit, stats.Idle, stats.CreateInProgress, stats.Concurrency, stats.Size,
-				)
-			},
-		}),
-		)
-		if err != nil {
-			return nil, xerrors.WithStackTrace(err)
-		}
+	if clientOpts.sessionPool == nil {
+		return nil, xerrors.WithStackTrace(errNilPool)
 	}
 
 	return &Client{
@@ -124,7 +58,11 @@ func New(ctx context.Context, cc grpc.ClientConnInterface, config *config.Config
 		build: func(ctx context.Context) (s *Session, err error) {
 			return newSession(ctx, cc, config)
 		},
-		pool: sessionPool,
+		pool: &sessionPoolAdapter{
+			sessionPool: clientOpts.sessionPool,
+			cc:          cc,
+			cfg:         config,
+		},
 		done: make(chan struct{}),
 	}, nil
 }

--- a/internal/table/client_options.go
+++ b/internal/table/client_options.go
@@ -6,12 +6,12 @@ import "github.com/ydb-platform/ydb-go-sdk/v3/internal/query"
 type NewClientOption func(*newClientOptions)
 
 type newClientOptions struct {
-	sharedSessionPool *query.SharedSessionPool
+	sessionPool *query.SessionPool
 }
 
-// WithSharedSessionPool leases sessions from the driver-level pool.
-func WithSharedSessionPool(pool *query.SharedSessionPool) NewClientOption {
+// WithSessionPool leases sessions from the driver-level pool.
+func WithSessionPool(pool *query.SessionPool) NewClientOption {
 	return func(o *newClientOptions) {
-		o.sharedSessionPool = pool
+		o.sessionPool = pool
 	}
 }

--- a/internal/table/client_options.go
+++ b/internal/table/client_options.go
@@ -1,0 +1,17 @@
+package table
+
+import "github.com/ydb-platform/ydb-go-sdk/v3/internal/query"
+
+// NewClientOption configures table client construction.
+type NewClientOption func(*newClientOptions)
+
+type newClientOptions struct {
+	sharedSessionPool *query.SharedSessionPool
+}
+
+// WithSharedSessionPool leases sessions from the driver-level pool.
+func WithSharedSessionPool(pool *query.SharedSessionPool) NewClientOption {
+	return func(o *newClientOptions) {
+		o.sharedSessionPool = pool
+	}
+}

--- a/internal/table/errors.go
+++ b/internal/table/errors.go
@@ -7,6 +7,7 @@ import (
 )
 
 var (
+	errNilPool   = xerrors.Wrap(errors.New("table client required session pool"))
 	errNilClient = xerrors.Wrap(errors.New("table client is not initialized"))
 
 	// errClosedClient returned by a Client instance to indicate

--- a/internal/table/gtrace/table_gtrace.go
+++ b/internal/table/gtrace/table_gtrace.go
@@ -1217,14 +1217,15 @@ func onPoolStateChange(t *trace.Table, t1 trace.TablePoolStateChangeInfo) {
 	fn(t1)
 }
 // Internals: https://github.com/ydb-platform/ydb-go-sdk/blob/master/VERSIONING.md#internals
-func TableOnInit(t *trace.Table, c *context.Context, c1 trace.Call) func(limit int) {
+func TableOnInit(t *trace.Table, c *context.Context, c1 trace.Call) func(limit int, _ error) {
 	var p trace.TableInitStartInfo
 	p.Context = c
 	p.Call = c1
 	res := onInit(t, p)
-	return func(limit int) {
+	return func(limit int, e error) {
 		var p trace.TableInitDoneInfo
 		p.Limit = limit
+		p.Error = e
 		res(p)
 	}
 }

--- a/internal/table/shared_session_pool_adapter.go
+++ b/internal/table/shared_session_pool_adapter.go
@@ -1,0 +1,94 @@
+package table
+
+import (
+	"context"
+
+	"github.com/ydb-platform/ydb-go-genproto/Ydb_Table_V1"
+	"google.golang.org/grpc"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/conn"
+	balancerContext "github.com/ydb-platform/ydb-go-sdk/v3/internal/endpoint"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/meta"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/pool"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/query"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/table/config"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
+	"github.com/ydb-platform/ydb-go-sdk/v3/retry"
+	"github.com/ydb-platform/ydb-go-sdk/v3/table"
+)
+
+type sharedSessionPoolAdapter struct {
+	shared *query.SharedSessionPool
+	cc     grpc.ClientConnInterface
+	cfg    *config.Config
+}
+
+func newSharedSessionPoolAdapter(
+	shared *query.SharedSessionPool,
+	cc grpc.ClientConnInterface,
+	cfg *config.Config,
+) sessionPool {
+	return &sharedSessionPoolAdapter{
+		shared: shared,
+		cc:     cc,
+		cfg:    cfg,
+	}
+}
+
+func (a *sharedSessionPoolAdapter) Stats() pool.Stats {
+	return a.shared.Stats()
+}
+
+func (a *sharedSessionPoolAdapter) Close(ctx context.Context) error {
+	// The driver owns the shared pool lifecycle.
+	return nil
+}
+
+func (a *sharedSessionPoolAdapter) With(
+	ctx context.Context,
+	f func(ctx context.Context, s *Session) error,
+	opts ...retry.Option,
+) error {
+	return a.shared.WithCore(ctx, func(ctx context.Context, core query.Core) error {
+		s := sessionFromQueryCore(a.cc, a.cfg, core)
+
+		if err := f(ctx, s); err != nil {
+			return xerrors.WithStackTrace(err)
+		}
+
+		return nil
+	}, opts...)
+}
+
+func sessionFromQueryCore(
+	cc grpc.ClientConnInterface,
+	cfg *config.Config,
+	core query.Core,
+) *Session {
+	s := &Session{
+		config: cfg,
+		status: table.SessionReady,
+		id:     core.ID(),
+	}
+	s.nodeID.Store(core.NodeID())
+
+	s.client = Ydb_Table_V1.NewTableServiceClient(
+		conn.WithContextModifier(cc, func(ctx context.Context) context.Context {
+			return meta.WithTrailerCallback(balancerContext.WithNodeID(ctx, s.NodeID()), s.checkCloseHint)
+		}),
+	)
+
+	if cfg.ExecuteDataQueryOverQueryService() {
+		s.dataQuery = queryClientExecutor{
+			core:   core,
+			client: query.QueryServiceClientFromCore(core),
+		}
+	} else {
+		s.dataQuery = tableClientExecutor{
+			client:          s.client,
+			ignoreTruncated: cfg.IgnoreTruncated(),
+		}
+	}
+
+	return s
+}

--- a/internal/table/shared_session_pool_adapter.go
+++ b/internal/table/shared_session_pool_adapter.go
@@ -17,39 +17,26 @@ import (
 	"github.com/ydb-platform/ydb-go-sdk/v3/table"
 )
 
-type sharedSessionPoolAdapter struct {
-	shared *query.SharedSessionPool
-	cc     grpc.ClientConnInterface
-	cfg    *config.Config
+type sessionPoolAdapter struct {
+	sessionPool *query.SessionPool
+	cc          grpc.ClientConnInterface
+	cfg         *config.Config
 }
 
-func newSharedSessionPoolAdapter(
-	shared *query.SharedSessionPool,
-	cc grpc.ClientConnInterface,
-	cfg *config.Config,
-) sessionPool {
-	return &sharedSessionPoolAdapter{
-		shared: shared,
-		cc:     cc,
-		cfg:    cfg,
-	}
+func (a *sessionPoolAdapter) Stats() pool.Stats {
+	return a.sessionPool.Stats()
 }
 
-func (a *sharedSessionPoolAdapter) Stats() pool.Stats {
-	return a.shared.Stats()
+func (a *sessionPoolAdapter) Close(ctx context.Context) error {
+	return a.sessionPool.Close(ctx)
 }
 
-func (a *sharedSessionPoolAdapter) Close(ctx context.Context) error {
-	// The driver owns the shared pool lifecycle.
-	return nil
-}
-
-func (a *sharedSessionPoolAdapter) With(
+func (a *sessionPoolAdapter) With(
 	ctx context.Context,
 	f func(ctx context.Context, s *Session) error,
 	opts ...retry.Option,
 ) error {
-	return a.shared.WithCore(ctx, func(ctx context.Context, core query.Core) error {
+	return a.sessionPool.WithCore(ctx, func(ctx context.Context, core query.Core) error {
 		s := sessionFromQueryCore(a.cc, a.cfg, core)
 
 		if err := f(ctx, s); err != nil {
@@ -81,7 +68,7 @@ func sessionFromQueryCore(
 	if cfg.ExecuteDataQueryOverQueryService() {
 		s.dataQuery = queryClientExecutor{
 			core:   core,
-			client: query.QueryServiceClientFromCore(core),
+			client: query.ClientFromCore(core),
 		}
 	} else {
 		s.dataQuery = tableClientExecutor{

--- a/options.go
+++ b/options.go
@@ -529,12 +529,13 @@ func WithQueryConfigOption(option queryConfig.Option) Option {
 	}
 }
 
-// WithSessionPoolSizeLimit set max size of internal sessions pool in table.Client
+// WithSessionPoolSizeLimit sets the max size of the driver session pool shared by table and query clients.
 // If sizeLimit is less than or equal to zero then the default pool size limit is used.
 func WithSessionPoolSizeLimit(sizeLimit int) Option {
 	return func(ctx context.Context, d *Driver) error {
-		d.tableOptions = append(d.tableOptions, tableConfig.WithSizeLimit(sizeLimit))
-		d.queryOptions = append(d.queryOptions, queryConfig.WithPoolLimit(sizeLimit))
+		if sizeLimit > 0 {
+			d.sessionPoolConfig.limit = sizeLimit
+		}
 
 		return nil
 	}
@@ -545,8 +546,12 @@ func WithSessionPoolSizeLimit(sizeLimit int) Option {
 // - if argument type is time.Duration - WithSessionPoolSessionUsageLimit limits max time to live of pool session
 func WithSessionPoolSessionUsageLimit[T interface{ uint64 | time.Duration }](limit T) Option {
 	return func(ctx context.Context, d *Driver) error {
-		d.tableOptions = append(d.tableOptions, tableConfig.WithSessionPoolSessionUsageLimit(limit))
-		d.queryOptions = append(d.queryOptions, queryConfig.WithSessionPoolSessionUsageLimit(limit))
+		switch v := any(limit).(type) {
+		case uint64:
+			d.sessionPoolConfig.itemUsageLimit = v
+		case time.Duration:
+			d.sessionPoolConfig.itemUsageTTL = v
+		}
 
 		return nil
 	}
@@ -566,10 +571,13 @@ func WithLazyTx(lazyTx bool) Option {
 	}
 }
 
-// WithSessionPoolIdleThreshold defines interval for idle sessions
+// WithSessionPoolIdleThreshold defines interval for idle sessions in the driver session pool.
 func WithSessionPoolIdleThreshold(idleThreshold time.Duration) Option {
 	return func(ctx context.Context, d *Driver) error {
-		d.tableOptions = append(d.tableOptions, tableConfig.WithIdleThreshold(idleThreshold))
+		if idleThreshold < 0 {
+			idleThreshold = 0
+		}
+		d.sessionPoolConfig.idleTTL = idleThreshold
 		d.databaseSQLOptions = append(d.databaseSQLOptions,
 			xsql.WithIdleThreshold(idleThreshold),
 		)
@@ -590,42 +598,47 @@ func WithExecuteDataQueryOverQueryClient(b bool) Option {
 	}
 }
 
-// WithSessionPoolSessionIdleTimeToLive limits maximum time to live of idle session
+// WithSessionPoolSessionIdleTimeToLive limits maximum time to live of idle session in the driver session pool.
 // If idleTimeToLive is less than or equal to zero then sessions will not be closed by idle
 func WithSessionPoolSessionIdleTimeToLive(idleThreshold time.Duration) Option {
 	return func(ctx context.Context, d *Driver) error {
-		d.queryOptions = append(d.queryOptions, queryConfig.WithSessionIdleTimeToLive(idleThreshold))
+		if idleThreshold > 0 {
+			d.sessionPoolConfig.idleTTL = idleThreshold
+		}
 
 		return nil
 	}
 }
 
-// WithSessionPoolCreateSessionTimeout set timeout for new session creation process in table.Client
+// WithSessionPoolCreateSessionTimeout set timeout for new session creation in the driver session pool
 func WithSessionPoolCreateSessionTimeout(createSessionTimeout time.Duration) Option {
 	return func(ctx context.Context, d *Driver) error {
-		d.tableOptions = append(d.tableOptions, tableConfig.WithCreateSessionTimeout(createSessionTimeout))
-		d.queryOptions = append(d.queryOptions, queryConfig.WithSessionCreateTimeout(createSessionTimeout))
+		if createSessionTimeout > 0 {
+			d.sessionPoolConfig.createTimeout = createSessionTimeout
+		}
 
 		return nil
 	}
 }
 
-// WithSessionPoolDeleteTimeout set timeout to gracefully close deleting session in table.Client
+// WithSessionPoolDeleteTimeout set timeout to gracefully close deleting session in the driver session pool
 func WithSessionPoolDeleteTimeout(deleteTimeout time.Duration) Option {
 	return func(ctx context.Context, d *Driver) error {
-		d.tableOptions = append(d.tableOptions, tableConfig.WithDeleteTimeout(deleteTimeout))
-		d.queryOptions = append(d.queryOptions, queryConfig.WithSessionDeleteTimeout(deleteTimeout))
+		if deleteTimeout > 0 {
+			d.sessionPoolConfig.deleteTimeout = deleteTimeout
+		}
 
 		return nil
 	}
 }
 
-// WithSessionPoolWarmUpSessions sets the number of sessions to pre-create in session pools at driver initialization.
+// WithSessionPoolWarmUpSessions sets the number of sessions to pre-create in the driver session pool at initialization.
 // If warmUpSessions is less than or equal to zero, pool warm-up is disabled.
 func WithSessionPoolWarmUpSessions(warmUpSessions int) Option {
 	return func(ctx context.Context, d *Driver) error {
-		d.tableOptions = append(d.tableOptions, tableConfig.WithSessionPoolWarmUpSessions(warmUpSessions))
-		d.queryOptions = append(d.queryOptions, queryConfig.WithSessionPoolWarmUpSessions(warmUpSessions))
+		if warmUpSessions > 0 {
+			d.sessionPoolConfig.warmUp = warmUpSessions
+		}
 
 		return nil
 	}

--- a/session_pool.go
+++ b/session_pool.go
@@ -1,0 +1,20 @@
+package ydb
+
+import "github.com/ydb-platform/ydb-go-sdk/v3/internal/pool"
+
+// SessionPoolStats is a snapshot of driver session pool counters.
+type SessionPoolStats = pool.Stats
+
+// SessionPoolStats returns counters for the driver session pool shared by table and query clients.
+func (d *Driver) SessionPoolStats() (SessionPoolStats, error) {
+	if d.sharedSessionPool == nil {
+		return pool.Stats{}, nil
+	}
+
+	shared, err := d.sharedSessionPool.Get()
+	if err != nil {
+		return pool.Stats{}, err
+	}
+
+	return shared.Stats(), nil
+}

--- a/session_pool.go
+++ b/session_pool.go
@@ -7,11 +7,11 @@ type SessionPoolStats = pool.Stats
 
 // SessionPoolStats returns counters for the driver session pool shared by table and query clients.
 func (d *Driver) SessionPoolStats() (SessionPoolStats, error) {
-	if d.sharedSessionPool == nil {
+	if d.sessionPool == nil {
 		return pool.Stats{}, nil
 	}
 
-	shared, err := d.sharedSessionPool.Get()
+	shared, err := d.sessionPool.Get()
 	if err != nil {
 		return pool.Stats{}, err
 	}

--- a/trace/query.go
+++ b/trace/query.go
@@ -535,7 +535,10 @@ type (
 		Call    Call
 	}
 	// Internals: https://github.com/ydb-platform/ydb-go-sdk/blob/master/VERSIONING.md#internals
-	QueryNewDoneInfo struct{}
+	QueryNewDoneInfo struct {
+		Limit int
+		Error error
+	}
 	// Internals: https://github.com/ydb-platform/ydb-go-sdk/blob/master/VERSIONING.md#internals
 	QueryCloseStartInfo struct {
 		// Context make available context in trace callback function.

--- a/trace/table.go
+++ b/trace/table.go
@@ -356,6 +356,7 @@ type (
 	// Internals: https://github.com/ydb-platform/ydb-go-sdk/blob/master/VERSIONING.md#internals
 	TableInitDoneInfo struct {
 		Limit int
+		Error error
 	}
 	// Internals: https://github.com/ydb-platform/ydb-go-sdk/blob/master/VERSIONING.md#internals
 	TablePoolStateChangeInfo struct {


### PR DESCRIPTION
## Summary

Aligns ydb-go-sdk session pooling with [ydb-rs-sdk PR #501](https://github.com/ydb-platform/ydb-rs-sdk/pull/501):

- **Single driver-level pool** (`CreateSession` + `AttachSession`) shared by `table.Client` and `query.Client`
- **`WithSessionPool*`** driver options configure the shared pool (limit, warm-up, usage/idle TTL, create/delete timeouts)
- **`WithSessionPoolSizeLimit(N)`** now means **at most N concurrent sessions total** across table + query (previously up to N per client → up to 2N when both were used)
- **`Driver.SessionPoolStats()`** exposes pool counters
- Table pooled operations use **query session cores** (`UseQuerySession(true)` on driver-created table client)
- Query **implicit** session pool is unchanged (separate fake sessions)

## Architecture

```
Driver
  └── SharedSessionPool (query sessionCore)
        ├── table.Client  → sharedSessionPoolAdapter → table.Session
        └── query.Client  → sharedExplicitPoolAdapter → query.Session (explicit pool)
```

## Breaking changes

| Before | After |
|--------|-------|
| `WithSessionPoolSizeLimit(50)` → up to 50 table + 50 query explicit sessions | `WithSessionPoolSizeLimit(50)` → up to **50 shared** sessions |
| Pool warm-up ran separately in table and query clients | Warm-up runs **once** on the driver pool |
| Table pooled sessions via `TableService/CreateSession` (default) | Table pooled sessions via **Query** `CreateSession` + `AttachSession` |

Tune `WithSessionPoolSizeLimit` when migrating mixed table+query workloads.

## Migration

```go
db, err := ydb.Open(ctx, dsn,
    ydb.WithSessionPoolSizeLimit(200),
    ydb.WithSessionPoolWarmUpSessions(50),
)

stats, err := db.SessionPoolStats()
```

No changes to `table.Client` / `query.Client` public method signatures.

## Test plan

- [x] `go build ./...`
- [x] `go test . -short`
- [x] `go test ./internal/query/... ./internal/table/... -short`
- [ ] Integration tests / SLO (if applicable)


Made with [Cursor](https://cursor.com)