### PR TITLE
fix(conn): close gRPC connections removed from Discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed gRPC connections to cluster nodes removed from Discovery staying open in the connection pool
+
 ## v3.143.0
 * Added experimental helper `sugar.NewKVClientBuilder(ctx, db)` to use `YDB` with Redis-like commands: `Get`, `Set`, `Del` and `Keys`.
 

--- a/driver.go
+++ b/driver.go
@@ -551,6 +551,7 @@ func (d *Driver) connect(ctx context.Context) error {
 	})
 
 	d.discovery = xsync.OnceValue(func() (*internalDiscovery.Client, error) {
+		// Permanent discovery ref: must not be reaped by closeUnreferencedEndpoints.
 		return internalDiscovery.New(xcontext.ValueOnly(ctx),
 			d.pool.AcquireConn(endpoint.New(d.config.Endpoint())),
 			discoveryConfig.New(

--- a/driver.go
+++ b/driver.go
@@ -552,7 +552,7 @@ func (d *Driver) connect(ctx context.Context) error {
 
 	d.discovery = xsync.OnceValue(func() (*internalDiscovery.Client, error) {
 		return internalDiscovery.New(xcontext.ValueOnly(ctx),
-			d.pool.Get(endpoint.New(d.config.Endpoint())),
+			d.pool.AcquireConn(endpoint.New(d.config.Endpoint())),
 			discoveryConfig.New(
 				append(
 					// prepend common params from root config

--- a/driver.go
+++ b/driver.go
@@ -551,7 +551,6 @@ func (d *Driver) connect(ctx context.Context) error {
 	})
 
 	d.discovery = xsync.OnceValue(func() (*internalDiscovery.Client, error) {
-		// Permanent discovery ref: must not be reaped by closeUnreferencedEndpoints.
 		return internalDiscovery.New(xcontext.ValueOnly(ctx),
 			d.pool.AcquireConn(endpoint.New(d.config.Endpoint())),
 			discoveryConfig.New(

--- a/driver.go
+++ b/driver.go
@@ -552,6 +552,8 @@ func (d *Driver) connect(ctx context.Context) error {
 
 	d.discovery = xsync.OnceValue(func() (*internalDiscovery.Client, error) {
 		return internalDiscovery.New(xcontext.ValueOnly(ctx),
+			// Permanent ref: bootstrap discovery conn must survive endpoint cleanup
+			// until [conn.Pool.Release] on driver shutdown (see [conn.Pool.AcquireConn]).
 			d.pool.AcquireConn(endpoint.New(d.config.Endpoint())),
 			discoveryConfig.New(
 				append(

--- a/internal/balancer/balancer.go
+++ b/internal/balancer/balancer.go
@@ -257,9 +257,6 @@ func (b *Balancer) Close(ctx context.Context) (err error) {
 		b.discoveryRepeater.Stop()
 	}
 
-	// Release marks for endpoints this balancer no longer needs.
-	b.pool.ReleaseEndpoints(ctx, b.connections().All())
-
 	if cc := b.cc.Load(); cc != nil {
 		_ = cc.Close()
 	}

--- a/internal/balancer/balancer.go
+++ b/internal/balancer/balancer.go
@@ -257,6 +257,12 @@ func (b *Balancer) Close(ctx context.Context) (err error) {
 		b.discoveryRepeater.Stop()
 	}
 
+	if current := b.connections().All(); len(current) > 0 {
+		// Drop discovery refs held by this balancer so a shared pool can close
+		// endpoints once every balancer releases them.
+		b.pool.DiscoveryConnections(ctx, nil, current, nil)
+	}
+
 	if cc := b.cc.Load(); cc != nil {
 		_ = cc.Close()
 	}

--- a/internal/balancer/balancer.go
+++ b/internal/balancer/balancer.go
@@ -224,8 +224,10 @@ func (b *Balancer) applyDiscoveredEndpoints(ctx context.Context, newest []endpoi
 		)
 	}()
 
-	// Otherwise the shared pool keeps gRPC connections to nodes that left the cluster.
-	connections := b.pool.DiscoveryConnections(ctx, added, dropped, newest)
+	// Drop refs for endpoints this balancer no longer needs so a shared pool can
+	// close gRPC connections once every balancer releases them.
+	b.pool.UpdateEndpointUsage(ctx, dropped, added)
+	connections := conn.EndpointsToConnections(b.pool, newest)
 	for _, c := range connections {
 		b.pool.Allow(ctx, c)
 		c.Endpoint().Touch()
@@ -258,9 +260,9 @@ func (b *Balancer) Close(ctx context.Context) (err error) {
 	}
 
 	if current := b.connections().All(); len(current) > 0 {
-		// Drop discovery refs held by this balancer so a shared pool can close
-		// endpoints once every balancer releases them.
-		b.pool.DiscoveryConnections(ctx, nil, current, nil)
+		// Release every endpoint this balancer held; without this, the last balancer
+		// on a shared pool would leave gRPC connections open until driver shutdown.
+		b.pool.UpdateEndpointUsage(ctx, current, nil)
 	}
 
 	if cc := b.cc.Load(); cc != nil {

--- a/internal/balancer/balancer.go
+++ b/internal/balancer/balancer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"strings"
 	"sync/atomic"
 
 	"github.com/ydb-platform/ydb-go-genproto/Ydb_Discovery_V1"
@@ -215,19 +214,8 @@ func (b *Balancer) applyDiscoveredEndpoints(ctx context.Context, newest []endpoi
 		)
 		previous = b.connections().All()
 	)
+	_, added, dropped := xslices.Diff(previous, newest, endpoint.Compare)
 	defer func() {
-		_, added, dropped := xslices.Diff(previous, newest, func(lhs, rhs endpoint.Endpoint) int {
-			cmp := strings.Compare(lhs.Address(), rhs.Address())
-			if cmp != 0 {
-				return cmp
-			}
-			cmp = int(lhs.NodeID()) - int(rhs.NodeID())
-			if cmp != 0 {
-				return cmp
-			}
-
-			return strings.Compare(lhs.OverrideHost(), rhs.OverrideHost())
-		})
 		onDone(
 			xslices.Transform(newest, func(t endpoint.Endpoint) trace.EndpointInfo { return t }),
 			xslices.Transform(added, func(t endpoint.Endpoint) trace.EndpointInfo { return t }),
@@ -236,7 +224,8 @@ func (b *Balancer) applyDiscoveredEndpoints(ctx context.Context, newest []endpoi
 		)
 	}()
 
-	connections := conn.EndpointsToConnections(b.pool, newest)
+	// Otherwise the shared pool keeps gRPC connections to nodes that left the cluster.
+	connections := b.pool.DiscoveryConnections(ctx, added, dropped, newest)
 	for _, c := range connections {
 		b.pool.Allow(ctx, c)
 		c.Endpoint().Touch()
@@ -267,6 +256,9 @@ func (b *Balancer) Close(ctx context.Context) (err error) {
 	if b.discoveryRepeater != nil {
 		b.discoveryRepeater.Stop()
 	}
+
+	// Release marks for endpoints this balancer no longer needs.
+	b.pool.ReleaseEndpoints(ctx, b.connections().All())
 
 	if cc := b.cc.Load(); cc != nil {
 		_ = cc.Close()

--- a/internal/balancer/balancer_test.go
+++ b/internal/balancer/balancer_test.go
@@ -231,7 +231,7 @@ func TestPessimizationOnOverloaded(t *testing.T) {
 			defer func() { _ = pool.Release(ctx) }()
 
 			e1 := endpoint.New("node1:2135", endpoint.WithID(1))
-			poolConn := pool.Get(e1)
+			poolConn := pool.AcquireConn(e1)
 			poolConn.SetState(ctx, state.Online)
 
 			cc1 := &poolRegisteredConn{

--- a/internal/conn/conn.go
+++ b/internal/conn/conn.go
@@ -77,7 +77,6 @@ type (
 
 		// discoveryRefs tracks [Pool.AcquireConn] / [Pool.ReleaseEndpoint] pairing.
 		// Zero or negative value means the connection is not in use.
-		// guarded by [Pool.discoveryMu]
 		discoveryRefs atomic.Int64
 	}
 	nopLastUsage struct{}

--- a/internal/conn/conn.go
+++ b/internal/conn/conn.go
@@ -76,7 +76,9 @@ type (
 		onClose      []func(*conn)
 
 		// discoveryRefs tracks [Pool.AcquireConn] / [Pool.ReleaseEndpoint] pairing.
-		discoveryRefs int64
+		// Zero or negative value means the connection is not in use.
+		// guarded by [Pool.discoveryMu]
+		discoveryRefs atomic.Int64
 	}
 	nopLastUsage struct{}
 )

--- a/internal/conn/conn.go
+++ b/internal/conn/conn.go
@@ -76,7 +76,7 @@ type (
 		onClose      []func(*conn)
 
 		// discoveryRefs tracks [Pool.AcquireConn] / [Pool.ReleaseEndpoint] pairing.
-		discoveryRefs atomic.Int64
+		discoveryRefs int64
 	}
 	nopLastUsage struct{}
 )

--- a/internal/conn/conn.go
+++ b/internal/conn/conn.go
@@ -75,9 +75,9 @@ type (
 		lastUsage    xsync.LastUsage
 		onClose      []func(*conn)
 
-		// discoveryRefs tracks endpoint usage by [Pool.AcquireConn] and [Pool.DiscoveryConnections].
-		// Zero or negative value means the connection is not in use.
-		discoveryRefs atomic.Int64
+		// useCount tracks endpoint usage by [Pool.AcquireConn] and [Pool.DiscoveryConnections].
+		// Zero means the connection is not in use; negative indicates a ref-count bug.
+		useCount atomic.Int64
 	}
 	nopLastUsage struct{}
 )

--- a/internal/conn/conn.go
+++ b/internal/conn/conn.go
@@ -75,8 +75,14 @@ type (
 		lastUsage    xsync.LastUsage
 		onClose      []func(*conn)
 
-		// useCount tracks endpoint usage by [Pool.AcquireConn] and [Pool.DiscoveryConnections].
-		// Zero means the connection is not in use; negative indicates a ref-count bug.
+		// useCount is how many pool users (balancers, driver bootstrap conn, etc.) keep
+		// this endpoint open. When it drops to zero, the next [Pool.UpdateEndpointUsage]
+		// cleanup pass may close the gRPC connection. Separate from lastUsage, which
+		// tracks RPC activity for ConnectionTTL parking — different lifecycle, different
+		// purpose. Stored on the conn (not in a side map) because cleanup iterates
+		// pool entries and must decide per connection whether to close.
+		// Atomic so reads in the cleanup loop do not require per-conn locking; all
+		// writes happen under [Pool.usageMu].
 		useCount atomic.Int64
 	}
 	nopLastUsage struct{}

--- a/internal/conn/conn.go
+++ b/internal/conn/conn.go
@@ -74,6 +74,9 @@ type (
 		childStreams *xcontext.CancelsGuard
 		lastUsage    xsync.LastUsage
 		onClose      []func(*conn)
+
+		// discoveryRefs tracks [Pool.AcquireConn] / [Pool.ReleaseEndpoint] pairing.
+		discoveryRefs atomic.Int64
 	}
 	nopLastUsage struct{}
 )

--- a/internal/conn/conn.go
+++ b/internal/conn/conn.go
@@ -75,7 +75,7 @@ type (
 		lastUsage    xsync.LastUsage
 		onClose      []func(*conn)
 
-		// discoveryRefs tracks [Pool.AcquireConn] / [Pool.ReleaseEndpoint] pairing.
+		// discoveryRefs tracks endpoint usage by [Pool.AcquireConn] and [Pool.DiscoveryConnections].
 		// Zero or negative value means the connection is not in use.
 		discoveryRefs atomic.Int64
 	}

--- a/internal/conn/pool.go
+++ b/internal/conn/pool.go
@@ -30,6 +30,7 @@ type Pool struct {
 	dialOptions []grpc.DialOption
 	conns       xsync.Map[endpoint.Key, *conn]
 	done        chan struct{}
+	discoveryMu sync.Mutex
 }
 
 func (p *Pool) DialTimeout() time.Duration {
@@ -71,6 +72,13 @@ func (p *Pool) conn(endpoint endpoint.Endpoint) *conn {
 // AcquireConn returns a pooled connection and marks the endpoint as in use.
 // Pair each call with [Pool.ReleaseEndpoint], or use [Pool.DiscoveryConnections] instead.
 func (p *Pool) AcquireConn(e endpoint.Endpoint) Conn {
+	p.discoveryMu.Lock()
+	defer p.discoveryMu.Unlock()
+
+	return p.acquireDiscoveryRef(e)
+}
+
+func (p *Pool) acquireDiscoveryRef(e endpoint.Endpoint) Conn {
 	cc := p.conn(e)
 	cc.discoveryRefs.Add(1)
 
@@ -84,6 +92,13 @@ func (p *Pool) remove(c *conn) {
 // ReleaseEndpoint pairs with [Pool.AcquireConn].
 // For discovery-driven updates use [Pool.DiscoveryConnections] instead.
 func (p *Pool) ReleaseEndpoint(_ context.Context, e endpoint.Endpoint) {
+	p.discoveryMu.Lock()
+	defer p.discoveryMu.Unlock()
+
+	p.releaseDiscoveryRef(e)
+}
+
+func (p *Pool) releaseDiscoveryRef(e endpoint.Endpoint) {
 	if p.isClosed() {
 		return
 	}
@@ -121,14 +136,17 @@ func (p *Pool) DiscoveryConnections(
 		return nil
 	}
 
+	p.discoveryMu.Lock()
+	defer p.discoveryMu.Unlock()
+
 	p.closeUnreferencedEndpoints(ctx)
 
 	for _, e := range dropped {
-		p.ReleaseEndpoint(ctx, e)
+		p.releaseDiscoveryRef(e)
 	}
 
 	for _, e := range added {
-		p.AcquireConn(e)
+		p.acquireDiscoveryRef(e)
 	}
 
 	return xslices.Transform(newest, p.get)
@@ -136,8 +154,11 @@ func (p *Pool) DiscoveryConnections(
 
 // ReleaseEndpoints is a batch [Pool.ReleaseEndpoint] (part of the [Pool.AcquireConn] lifecycle).
 func (p *Pool) ReleaseEndpoints(ctx context.Context, endpoints []endpoint.Endpoint) {
+	p.discoveryMu.Lock()
+	defer p.discoveryMu.Unlock()
+
 	for _, e := range endpoints {
-		p.ReleaseEndpoint(ctx, e)
+		p.releaseDiscoveryRef(e)
 	}
 }
 

--- a/internal/conn/pool.go
+++ b/internal/conn/pool.go
@@ -129,12 +129,16 @@ func (p *Pool) DiscoveryConnections(
 	p.discoveryMu.Lock()
 	defer p.discoveryMu.Unlock()
 
-	// Close synchronously: grpc.ClientConn.Close may block on transport
-	// shutdown (GOAWAY, TCP teardown), especially when the peer left the cluster but the
-	// socket is still half-open. With our grpc-go version that wait is bounded (on the order
-	// of seconds per connection, not indefinitely). Never-dialed connections close instantly.
-	// We do not spawn a goroutine here: the conn is already removed from the pool, so a
-	// bounded Close is enough to release resources without complicating lifecycle tracking.
+	// Close unreferenced connections synchronously while discoveryMu is held.
+	// grpc.ClientConn.Close may block on transport shutdown (GOAWAY, TCP teardown),
+	// especially when the peer left the cluster but the socket is still half-open.
+	// With our grpc-go version that wait is bounded (on the order of seconds per
+	// connection, not indefinitely). Never-dialed connections close instantly.
+	//
+	// We keep discoveryMu across Close on purpose: releasing it before Close would
+	// reopen the race between ref updates, map removal, and a replacement *conn for
+	// the same endpoint key. Discovery runs on a background repeater, so a bounded
+	// stall here is acceptable and preferable to async cleanup complexity.
 	p.conns.Range(func(key endpoint.Key, c *conn) bool {
 		if c.discoveryRefs.Load() <= 0 {
 			_ = c.Close(ctx)

--- a/internal/conn/pool.go
+++ b/internal/conn/pool.go
@@ -69,21 +69,20 @@ func (p *Pool) conn(endpoint endpoint.Endpoint) *conn {
 	return cc
 }
 
-// AcquireConn returns a pooled connection and increments discoveryRefs for the endpoint.
-// The ref is held for the lifetime of the driver (for example the discovery client) and is
+// AcquireConn returns a pooled connection and increments useCount for the endpoint.
+// The count is held for the lifetime of the driver (for example the discovery client) and is
 // released only when [Pool.Release] closes the pool. For balancer discovery updates use
 // [Pool.DiscoveryConnections] instead.
 func (p *Pool) AcquireConn(e endpoint.Endpoint) Conn {
 	p.discoveryMu.Lock()
 	defer p.discoveryMu.Unlock()
 
-	return p.acquireDiscoveryRef(e)
+	return p.acquireUseCount(e)
 }
 
-// acquireDiscoveryRef marks the endpoint as in use.
-func (p *Pool) acquireDiscoveryRef(e endpoint.Endpoint) Conn {
+func (p *Pool) acquireUseCount(e endpoint.Endpoint) Conn {
 	cc := p.conn(e)
-	cc.discoveryRefs.Add(+1)
+	cc.useCount.Add(+1)
 
 	return cc
 }
@@ -98,10 +97,10 @@ func (p *Pool) remove(c *conn) {
 	}
 }
 
-// releaseDiscoveryRef drops one in-use mark for the endpoint.
-func (p *Pool) releaseDiscoveryRef(e endpoint.Endpoint) {
+// releaseUseCount drops one use mark for the endpoint.
+func (p *Pool) releaseUseCount(e endpoint.Endpoint) {
 	if cc, ok := p.conns.Get(e.Key()); ok {
-		cc.discoveryRefs.Add(-1)
+		cc.useCount.Add(-1)
 	}
 }
 
@@ -131,7 +130,7 @@ func (p *Pool) DiscoveryConnections(
 	var wg sync.WaitGroup
 
 	p.conns.Range(func(_ endpoint.Key, c *conn) bool {
-		if c.discoveryRefs.Load() <= 0 {
+		if c.useCount.Load() <= 0 {
 			wg.Add(1)
 			go func(c closer.Closer) {
 				defer wg.Done()
@@ -144,11 +143,11 @@ func (p *Pool) DiscoveryConnections(
 	wg.Wait()
 
 	for _, e := range dropped {
-		p.releaseDiscoveryRef(e)
+		p.releaseUseCount(e)
 	}
 
 	for _, e := range added {
-		p.acquireDiscoveryRef(e)
+		p.acquireUseCount(e)
 	}
 
 	return xslices.Transform(newest, p.get)

--- a/internal/conn/pool.go
+++ b/internal/conn/pool.go
@@ -69,8 +69,10 @@ func (p *Pool) conn(endpoint endpoint.Endpoint) *conn {
 	return cc
 }
 
-// AcquireConn returns a pooled connection and marks the endpoint as in use.
-// Pair each call with [Pool.ReleaseEndpoint], or use [Pool.DiscoveryConnections] instead.
+// AcquireConn returns a pooled connection and increments discoveryRefs for the endpoint.
+// The ref is held for the lifetime of the driver (for example the discovery client) and is
+// released only when [Pool.Release] closes the pool. For balancer discovery updates use
+// [Pool.DiscoveryConnections] instead.
 func (p *Pool) AcquireConn(e endpoint.Endpoint) Conn {
 	p.discoveryMu.Lock()
 	defer p.discoveryMu.Unlock()
@@ -96,19 +98,6 @@ func (p *Pool) remove(c *conn) {
 	}
 }
 
-// ReleaseEndpoint pairs with [Pool.AcquireConn].
-// For discovery-driven updates use [Pool.DiscoveryConnections] instead.
-func (p *Pool) ReleaseEndpoint(_ context.Context, e endpoint.Endpoint) {
-	if p.isClosed() {
-		return
-	}
-
-	p.discoveryMu.Lock()
-	defer p.discoveryMu.Unlock()
-
-	p.releaseDiscoveryRef(e)
-}
-
 // releaseDiscoveryRef drops one in-use mark for the endpoint.
 func (p *Pool) releaseDiscoveryRef(e endpoint.Endpoint) {
 	if cc, ok := p.conns.Get(e.Key()); ok {
@@ -116,8 +105,8 @@ func (p *Pool) releaseDiscoveryRef(e endpoint.Endpoint) {
 	}
 }
 
-// DiscoveryConnections is the preferred API for discovery-driven pool updates.
-// Alternatively pair [Pool.AcquireConn] with [Pool.ReleaseEndpoint].
+// DiscoveryConnections applies a discovery diff: releases dropped endpoints, acquires added
+// ones, and closes unreferenced connections.
 func (p *Pool) DiscoveryConnections(
 	ctx context.Context,
 	added, dropped, newest []endpoint.Endpoint,

--- a/internal/conn/pool.go
+++ b/internal/conn/pool.go
@@ -19,7 +19,6 @@ import (
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xresolver"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xsync"
-	"github.com/ydb-platform/ydb-go-sdk/v3/pkg/xslices"
 	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
 )
 
@@ -30,7 +29,23 @@ type Pool struct {
 	dialOptions []grpc.DialOption
 	conns       xsync.Map[endpoint.Key, *conn]
 	done        chan struct{}
-	discoveryMu sync.Mutex
+	// usageMu serializes useCount updates and the unused-connection cleanup pass.
+	// A shared pool may serve several balancers; without the lock their discovery
+	// repeaters can interleave ref changes with Close and map removal, closing a
+	// freshly acquired connection or deleting a replacement *conn for the same key.
+	// The mutex stays held across grpc Close in cleanup: releasing it earlier would
+	// reopen that race. Discovery runs off the request path, so a bounded stall is
+	// acceptable.
+	usageMu sync.Mutex
+}
+
+func EndpointsToConnections(p *Pool, endpoints []endpoint.Endpoint) []Conn {
+	conns := make([]Conn, 0, len(endpoints))
+	for _, e := range endpoints {
+		conns = append(conns, p.Get(e))
+	}
+
+	return conns
 }
 
 func (p *Pool) DialTimeout() time.Duration {
@@ -45,10 +60,13 @@ func (p *Pool) GrpcDialOptions() []grpc.DialOption {
 	return p.dialOptions
 }
 
-func (p *Pool) get(endpoint endpoint.Endpoint) Conn {
+func (p *Pool) Get(endpoint endpoint.Endpoint) Conn {
 	return p.conn(endpoint)
 }
 
+// conn returns the pooled *conn for the endpoint, creating one if needed.
+// Split from [Pool.Get] so ref-count paths work with the concrete type without
+// interface assertions; [Pool.Get] remains the public Conn-facing entry point.
 func (p *Pool) conn(endpoint endpoint.Endpoint) *conn {
 	var (
 		cc  *conn
@@ -69,64 +87,79 @@ func (p *Pool) conn(endpoint endpoint.Endpoint) *conn {
 	return cc
 }
 
-// AcquireConn returns a pooled connection and increments useCount for the endpoint.
-// The count is held for the lifetime of the driver (for example the discovery client) and is
-// released only when [Pool.Release] closes the pool. For balancer discovery updates use
-// [Pool.DiscoveryConnections] instead.
+// AcquireConn returns a pooled connection and marks the endpoint as in use.
+//
+// Use it when a connection must stay open for the whole driver lifetime and must
+// not be closed by discovery cleanup — for example the bootstrap discovery client
+// in [github.com/ydb-platform/ydb-go-sdk/v3.Driver.connect]. There is no matching
+// release call: [Pool.Release] closes the entire pool on driver shutdown.
+//
+// Balancers should not call AcquireConn directly; they report endpoint diffs via
+// [Pool.UpdateEndpointUsage] instead.
 func (p *Pool) AcquireConn(e endpoint.Endpoint) Conn {
-	p.discoveryMu.Lock()
-	defer p.discoveryMu.Unlock()
+	p.usageMu.Lock()
+	defer p.usageMu.Unlock()
 
-	return p.acquireUseCount(e)
+	c := p.conn(e)
+	c.useCount.Add(+1)
+
+	return c
 }
 
-func (p *Pool) acquireUseCount(e endpoint.Endpoint) Conn {
-	cc := p.conn(e)
-	cc.useCount.Add(+1)
+// UpdateEndpointUsage applies a batch of release/acquire marks and closes idle gRPC
+// connections that nobody references anymore.
+//
+// Callers (typically a balancer) compute release and acquire from their own endpoint
+// snapshot diff; the pool only tracks how many users hold each endpoint open and
+// performs cleanup. Keeping diff logic in the caller avoids discovery-specific names
+// and responsibilities in the pool API.
+//
+// Order is intentional: close connections with useCount <= 0 first, then release,
+// then acquire. Endpoints dropped in this call still have useCount > 0 during the
+// close pass and are removed at the start of the next call — see
+// TestPool_EndpointUsage/DropsRemovedEndpointsOnNextDiscovery.
+func (p *Pool) UpdateEndpointUsage(ctx context.Context, release, acquire []endpoint.Endpoint) {
+	if p.isClosed() {
+		return
+	}
 
-	return cc
-}
+	p.usageMu.Lock()
+	defer p.usageMu.Unlock()
 
-// remove is called from conn onClose after grpc shutdown.
-// Compare pointers: the close loop in DiscoveryConnections may remove the conn from the map and
-// install a new *conn for the same endpoint key before Close returns;
-// Delete by key alone would evict the replacement.
-func (p *Pool) remove(c *conn) {
-	if cc, ok := p.conns.Get(c.endpoint.Key()); ok && cc == c {
-		p.conns.Delete(c.endpoint.Key())
+	p.closeUnusedLocked(ctx)
+
+	for _, e := range release {
+		p.releaseUseCount(e)
+	}
+	for _, e := range acquire {
+		p.acquireUseCount(e)
 	}
 }
 
+// acquireUseCount marks the endpoint as held by one more pool user.
+// Caller must hold usageMu; returns the connection so the caller can route traffic.
+func (p *Pool) acquireUseCount(e endpoint.Endpoint) Conn {
+	c := p.conn(e)
+	c.useCount.Add(+1)
+
+	return c
+}
+
 // releaseUseCount drops one use mark for the endpoint.
+// Caller must hold usageMu. Missing map entries are ignored — the connection may
+// already have been closed and removed by a prior cleanup pass.
 func (p *Pool) releaseUseCount(e endpoint.Endpoint) {
 	if cc, ok := p.conns.Get(e.Key()); ok {
 		cc.useCount.Add(-1)
 	}
 }
 
-// DiscoveryConnections applies a discovery diff: releases dropped endpoints, acquires added
-// ones, and closes unreferenced connections.
-func (p *Pool) DiscoveryConnections(
-	ctx context.Context,
-	added, dropped, newest []endpoint.Endpoint,
-) []Conn {
-	if p.isClosed() {
-		return nil
-	}
-
-	p.discoveryMu.Lock()
-	defer p.discoveryMu.Unlock()
-
-	// Close unreferenced connections in parallel, but wait for every Close to finish
-	// before proceeding. grpc.ClientConn.Close may block on transport shutdown (GOAWAY,
-	// TCP teardown), especially when the peer left the cluster but the socket is still
-	// half-open. With our grpc-go version that wait is bounded (on the order of seconds
-	// per connection, not indefinitely). Never-dialed connections close instantly.
-	//
-	// discoveryMu is held across wg.Wait on purpose: releasing it before Close would
-	// reopen the race between ref updates, map removal, and a replacement *conn for the
-	// same endpoint key. Discovery runs on a background repeater, so a bounded stall
-	// here is acceptable.
+// closeUnusedLocked closes every connection with useCount <= 0.
+// Caller must hold usageMu. Closes run in parallel but wg.Wait blocks until all
+// finish so the following ref updates see a stable map. grpc Close is bounded;
+// we do not release usageMu before Wait because async cleanup would race with
+// acquireUseCount and map replacement for the same endpoint key.
+func (p *Pool) closeUnusedLocked(ctx context.Context) {
 	var wg sync.WaitGroup
 
 	p.conns.Range(func(_ endpoint.Key, c *conn) bool {
@@ -141,16 +174,15 @@ func (p *Pool) DiscoveryConnections(
 		return true
 	})
 	wg.Wait()
+}
 
-	for _, e := range dropped {
-		p.releaseUseCount(e)
+// remove is called from conn onClose after grpc shutdown.
+// Compare pointers, not keys: cleanup may already have inserted a new *conn for the
+// same endpoint key; deleting by key alone would evict that replacement.
+func (p *Pool) remove(c *conn) {
+	if cc, ok := p.conns.Get(c.endpoint.Key()); ok && cc == c {
+		p.conns.Delete(c.endpoint.Key())
 	}
-
-	for _, e := range added {
-		p.acquireUseCount(e)
-	}
-
-	return xslices.Transform(newest, p.get)
 }
 
 func (p *Pool) isClosed() bool {
@@ -213,6 +245,8 @@ func (p *Pool) Release(ctx context.Context) (finalErr error) {
 
 	close(p.done)
 
+	// Collect close errors without pre-sizing: conns map has no Len() (removed due to
+	// incorrect size tracking); the final slice is small in practice.
 	var (
 		issues   []error
 		issuesMu sync.Mutex

--- a/internal/conn/pool.go
+++ b/internal/conn/pool.go
@@ -72,16 +72,13 @@ func (p *Pool) conn(endpoint endpoint.Endpoint) *conn {
 // AcquireConn returns a pooled connection and marks the endpoint as in use.
 // Pair each call with [Pool.ReleaseEndpoint], or use [Pool.DiscoveryConnections] instead.
 func (p *Pool) AcquireConn(e endpoint.Endpoint) Conn {
-	p.discoveryMu.Lock()
-	defer p.discoveryMu.Unlock()
-
 	return p.acquireDiscoveryRef(e)
 }
 
-// acquireDiscoveryRef marks the endpoint as in use. Caller must hold discoveryMu.
+// acquireDiscoveryRef marks the endpoint as in use.
 func (p *Pool) acquireDiscoveryRef(e endpoint.Endpoint) Conn {
 	cc := p.conn(e)
-	cc.discoveryRefs++
+	cc.discoveryRefs.Add(+1)
 
 	return cc
 }
@@ -99,9 +96,6 @@ func (p *Pool) remove(c *conn) {
 // ReleaseEndpoint pairs with [Pool.AcquireConn].
 // For discovery-driven updates use [Pool.DiscoveryConnections] instead.
 func (p *Pool) ReleaseEndpoint(_ context.Context, e endpoint.Endpoint) {
-	p.discoveryMu.Lock()
-	defer p.discoveryMu.Unlock()
-
 	if p.isClosed() {
 		return
 	}
@@ -109,29 +103,11 @@ func (p *Pool) ReleaseEndpoint(_ context.Context, e endpoint.Endpoint) {
 	p.releaseDiscoveryRef(e)
 }
 
-// releaseDiscoveryRef drops one in-use mark for the endpoint. Caller must hold discoveryMu.
+// releaseDiscoveryRef drops one in-use mark for the endpoint.
 func (p *Pool) releaseDiscoveryRef(e endpoint.Endpoint) {
 	if cc, ok := p.conns.Get(e.Key()); ok {
-		cc.discoveryRefs--
+		cc.discoveryRefs.Add(-1)
 	}
-}
-
-// extractUnreferencedEndpoints removes connections with no in-use marks from the pool.
-// Caller must hold discoveryMu. Close the result outside the lock.
-func (p *Pool) extractUnreferencedEndpoints() []*conn {
-	var toClose []*conn
-
-	p.conns.Range(func(key endpoint.Key, c *conn) bool {
-		if c.discoveryRefs <= 0 {
-			if extracted, ok := p.conns.Extract(key); ok {
-				toClose = append(toClose, extracted)
-			}
-		}
-
-		return true
-	})
-
-	return toClose
 }
 
 // DiscoveryConnections is the preferred API for discovery-driven pool updates.
@@ -145,7 +121,21 @@ func (p *Pool) DiscoveryConnections(
 	}
 
 	p.discoveryMu.Lock()
-	toClose := p.extractUnreferencedEndpoints()
+	defer p.discoveryMu.Unlock()
+
+	// Close synchronously: grpc.ClientConn.Close may block on transport
+	// shutdown (GOAWAY, TCP teardown), especially when the peer left the cluster but the
+	// socket is still half-open. With our grpc-go version that wait is bounded (on the order
+	// of seconds per connection, not indefinitely). Never-dialed connections close instantly.
+	// We do not spawn a goroutine here: the conn is already removed from the pool, so a
+	// bounded Close is enough to release resources without complicating lifecycle tracking.
+	p.conns.Range(func(key endpoint.Key, c *conn) bool {
+		if c.discoveryRefs.Load() <= 0 {
+			_ = c.Close(ctx)
+		}
+
+		return true
+	})
 
 	for _, e := range dropped {
 		p.releaseDiscoveryRef(e)
@@ -155,34 +145,7 @@ func (p *Pool) DiscoveryConnections(
 		p.acquireDiscoveryRef(e)
 	}
 
-	conns := xslices.Transform(newest, p.get)
-	p.discoveryMu.Unlock()
-
-	// Close synchronously outside discoveryMu: grpc.ClientConn.Close may block on transport
-	// shutdown (GOAWAY, TCP teardown), especially when the peer left the cluster but the
-	// socket is still half-open. With our grpc-go version that wait is bounded (on the order
-	// of seconds per connection, not indefinitely). Never-dialed connections close instantly.
-	// We do not spawn a goroutine here: the conn is already removed from the pool, so a
-	// bounded Close is enough to release resources without complicating lifecycle tracking.
-	for _, c := range toClose {
-		_ = c.Close(ctx)
-	}
-
-	return conns
-}
-
-// ReleaseEndpoints is a batch [Pool.ReleaseEndpoint] (part of the [Pool.AcquireConn] lifecycle).
-func (p *Pool) ReleaseEndpoints(ctx context.Context, endpoints []endpoint.Endpoint) {
-	p.discoveryMu.Lock()
-	defer p.discoveryMu.Unlock()
-
-	if p.isClosed() {
-		return
-	}
-
-	for _, e := range endpoints {
-		p.releaseDiscoveryRef(e)
-	}
+	return xslices.Transform(newest, p.get)
 }
 
 func (p *Pool) isClosed() bool {

--- a/internal/conn/pool.go
+++ b/internal/conn/pool.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xresolver"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xsync"
+	"github.com/ydb-platform/ydb-go-sdk/v3/pkg/xslices"
 	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
 )
 
@@ -29,15 +30,6 @@ type Pool struct {
 	dialOptions []grpc.DialOption
 	conns       xsync.Map[endpoint.Key, *conn]
 	done        chan struct{}
-}
-
-func EndpointsToConnections(p *Pool, endpoints []endpoint.Endpoint) []Conn {
-	conns := make([]Conn, 0, len(endpoints))
-	for _, e := range endpoints {
-		conns = append(conns, p.Get(e))
-	}
-
-	return conns
 }
 
 func (p *Pool) DialTimeout() time.Duration {
@@ -52,7 +44,7 @@ func (p *Pool) GrpcDialOptions() []grpc.DialOption {
 	return p.dialOptions
 }
 
-func (p *Pool) Get(endpoint endpoint.Endpoint) Conn {
+func (p *Pool) get(endpoint endpoint.Endpoint) Conn {
 	var (
 		cc  *conn
 		has bool
@@ -72,8 +64,77 @@ func (p *Pool) Get(endpoint endpoint.Endpoint) Conn {
 	return cc
 }
 
+// AcquireConn returns a pooled connection and marks the endpoint as in use.
+// Pair each call with [Pool.ReleaseEndpoint], or use [Pool.DiscoveryConnections] instead.
+func (p *Pool) AcquireConn(e endpoint.Endpoint) Conn {
+	cc := p.get(e).(*conn)
+	cc.discoveryRefs.Add(1)
+
+	return cc
+}
+
 func (p *Pool) remove(c *conn) {
 	p.conns.Delete(c.endpoint.Key())
+}
+
+// ReleaseEndpoint pairs with [Pool.AcquireConn].
+// For discovery-driven updates use [Pool.DiscoveryConnections] instead.
+func (p *Pool) ReleaseEndpoint(_ context.Context, e endpoint.Endpoint) {
+	if p.isClosed() {
+		return
+	}
+
+	cc, ok := p.conns.Get(e.Key())
+	if !ok {
+		return
+	}
+
+	cc.discoveryRefs.Add(-1)
+}
+
+// closeUnreferencedEndpoints closes connections that are no longer in use.
+func (p *Pool) closeUnreferencedEndpoints(ctx context.Context) {
+	if p.isClosed() {
+		return
+	}
+
+	p.conns.Range(func(_ endpoint.Key, c *conn) bool {
+		if c.discoveryRefs.Load() <= 0 {
+			_ = c.Close(ctx)
+		}
+
+		return true
+	})
+}
+
+// DiscoveryConnections is the preferred API for discovery-driven pool updates.
+// Alternatively pair [Pool.AcquireConn] with [Pool.ReleaseEndpoint].
+func (p *Pool) DiscoveryConnections(
+	ctx context.Context,
+	added, dropped, newest []endpoint.Endpoint,
+) []Conn {
+	if p.isClosed() {
+		return nil
+	}
+
+	p.closeUnreferencedEndpoints(ctx)
+
+	for _, e := range dropped {
+		p.ReleaseEndpoint(ctx, e)
+	}
+
+	for _, e := range added {
+		p.AcquireConn(e)
+	}
+
+	return xslices.Transform(newest, p.get)
+}
+
+// ReleaseEndpoints is a batch [Pool.ReleaseEndpoint] (part of the [Pool.AcquireConn] lifecycle).
+func (p *Pool) ReleaseEndpoints(ctx context.Context, endpoints []endpoint.Endpoint) {
+	for _, e := range endpoints {
+		p.ReleaseEndpoint(ctx, e)
+	}
 }
 
 func (p *Pool) isClosed() bool {

--- a/internal/conn/pool.go
+++ b/internal/conn/pool.go
@@ -45,6 +45,10 @@ func (p *Pool) GrpcDialOptions() []grpc.DialOption {
 }
 
 func (p *Pool) get(endpoint endpoint.Endpoint) Conn {
+	return p.conn(endpoint)
+}
+
+func (p *Pool) conn(endpoint endpoint.Endpoint) *conn {
 	var (
 		cc  *conn
 		has bool
@@ -67,7 +71,7 @@ func (p *Pool) get(endpoint endpoint.Endpoint) Conn {
 // AcquireConn returns a pooled connection and marks the endpoint as in use.
 // Pair each call with [Pool.ReleaseEndpoint], or use [Pool.DiscoveryConnections] instead.
 func (p *Pool) AcquireConn(e endpoint.Endpoint) Conn {
-	cc := p.get(e).(*conn)
+	cc := p.conn(e)
 	cc.discoveryRefs.Add(1)
 
 	return cc

--- a/internal/conn/pool.go
+++ b/internal/conn/pool.go
@@ -72,6 +72,9 @@ func (p *Pool) conn(endpoint endpoint.Endpoint) *conn {
 // AcquireConn returns a pooled connection and marks the endpoint as in use.
 // Pair each call with [Pool.ReleaseEndpoint], or use [Pool.DiscoveryConnections] instead.
 func (p *Pool) AcquireConn(e endpoint.Endpoint) Conn {
+	p.discoveryMu.Lock()
+	defer p.discoveryMu.Unlock()
+
 	return p.acquireDiscoveryRef(e)
 }
 
@@ -99,6 +102,9 @@ func (p *Pool) ReleaseEndpoint(_ context.Context, e endpoint.Endpoint) {
 	if p.isClosed() {
 		return
 	}
+
+	p.discoveryMu.Lock()
+	defer p.discoveryMu.Unlock()
 
 	p.releaseDiscoveryRef(e)
 }

--- a/internal/conn/pool.go
+++ b/internal/conn/pool.go
@@ -87,9 +87,9 @@ func (p *Pool) acquireDiscoveryRef(e endpoint.Endpoint) Conn {
 }
 
 // remove is called from conn onClose after grpc shutdown.
-// Compare pointers: extractUnreferencedEndpoints may remove the conn from the map and
-// DiscoveryConnections may install a new *conn for the same endpoint key before
-// Close returns; Delete by key alone would evict the replacement.
+// Compare pointers: the close loop in DiscoveryConnections may remove the conn from the map and
+// install a new *conn for the same endpoint key before Close returns;
+// Delete by key alone would evict the replacement.
 func (p *Pool) remove(c *conn) {
 	if cc, ok := p.conns.Get(c.endpoint.Key()); ok && cc == c {
 		p.conns.Delete(c.endpoint.Key())

--- a/internal/conn/pool.go
+++ b/internal/conn/pool.go
@@ -86,8 +86,14 @@ func (p *Pool) acquireDiscoveryRef(e endpoint.Endpoint) Conn {
 	return cc
 }
 
+// remove is called from conn onClose after grpc shutdown.
+// Compare pointers: extractUnreferencedEndpoints may remove the conn from the map and
+// DiscoveryConnections may install a new *conn for the same endpoint key before
+// Close returns; Delete by key alone would evict the replacement.
 func (p *Pool) remove(c *conn) {
-	p.conns.Delete(c.endpoint.Key())
+	if cc, ok := p.conns.Get(c.endpoint.Key()); ok && cc == c {
+		p.conns.Delete(c.endpoint.Key())
+	}
 }
 
 // ReleaseEndpoint pairs with [Pool.AcquireConn].
@@ -110,20 +116,22 @@ func (p *Pool) releaseDiscoveryRef(e endpoint.Endpoint) {
 	}
 }
 
-// closeUnreferencedEndpoints closes connections that are no longer in use.
-// Caller must hold discoveryMu.
-func (p *Pool) closeUnreferencedEndpoints(ctx context.Context) {
-	if p.isClosed() {
-		return
-	}
+// extractUnreferencedEndpoints removes connections with no in-use marks from the pool.
+// Caller must hold discoveryMu. Close the result outside the lock.
+func (p *Pool) extractUnreferencedEndpoints() []*conn {
+	var toClose []*conn
 
-	p.conns.Range(func(_ endpoint.Key, c *conn) bool {
+	p.conns.Range(func(key endpoint.Key, c *conn) bool {
 		if c.discoveryRefs <= 0 {
-			_ = c.Close(ctx)
+			if extracted, ok := p.conns.Extract(key); ok {
+				toClose = append(toClose, extracted)
+			}
 		}
 
 		return true
 	})
+
+	return toClose
 }
 
 // DiscoveryConnections is the preferred API for discovery-driven pool updates.
@@ -137,9 +145,7 @@ func (p *Pool) DiscoveryConnections(
 	}
 
 	p.discoveryMu.Lock()
-	defer p.discoveryMu.Unlock()
-
-	p.closeUnreferencedEndpoints(ctx)
+	toClose := p.extractUnreferencedEndpoints()
 
 	for _, e := range dropped {
 		p.releaseDiscoveryRef(e)
@@ -149,7 +155,20 @@ func (p *Pool) DiscoveryConnections(
 		p.acquireDiscoveryRef(e)
 	}
 
-	return xslices.Transform(newest, p.get)
+	conns := xslices.Transform(newest, p.get)
+	p.discoveryMu.Unlock()
+
+	// Close synchronously outside discoveryMu: grpc.ClientConn.Close may block on transport
+	// shutdown (GOAWAY, TCP teardown), especially when the peer left the cluster but the
+	// socket is still half-open. With our grpc-go version that wait is bounded (on the order
+	// of seconds per connection, not indefinitely). Never-dialed connections close instantly.
+	// We do not spawn a goroutine here: the conn is already removed from the pool, so a
+	// bounded Close is enough to release resources without complicating lifecycle tracking.
+	for _, c := range toClose {
+		_ = c.Close(ctx)
+	}
+
+	return conns
 }
 
 // ReleaseEndpoints is a batch [Pool.ReleaseEndpoint] (part of the [Pool.AcquireConn] lifecycle).
@@ -227,28 +246,25 @@ func (p *Pool) Release(ctx context.Context) (finalErr error) {
 	close(p.done)
 
 	var (
-		errCh = make(chan error, p.conns.Len())
-		wg    sync.WaitGroup
+		issues   []error
+		issuesMu sync.Mutex
+		wg       sync.WaitGroup
 	)
 
-	wg.Add(cap(errCh))
 	p.conns.Range(func(_ endpoint.Key, c *conn) bool {
+		wg.Add(1)
 		go func(c closer.Closer) {
 			defer wg.Done()
 			if err := c.Close(ctx); err != nil {
-				errCh <- err
+				issuesMu.Lock()
+				issues = append(issues, err)
+				issuesMu.Unlock()
 			}
 		}(c)
 
 		return true
 	})
 	wg.Wait()
-	close(errCh)
-
-	issues := make([]error, 0, cap(errCh))
-	for err := range errCh {
-		issues = append(issues, err)
-	}
 
 	if len(issues) > 0 {
 		return xerrors.WithStackTrace(xerrors.NewWithIssues("connection pool close failed", issues...))

--- a/internal/conn/pool.go
+++ b/internal/conn/pool.go
@@ -129,23 +129,30 @@ func (p *Pool) DiscoveryConnections(
 	p.discoveryMu.Lock()
 	defer p.discoveryMu.Unlock()
 
-	// Close unreferenced connections synchronously while discoveryMu is held.
-	// grpc.ClientConn.Close may block on transport shutdown (GOAWAY, TCP teardown),
-	// especially when the peer left the cluster but the socket is still half-open.
-	// With our grpc-go version that wait is bounded (on the order of seconds per
-	// connection, not indefinitely). Never-dialed connections close instantly.
+	// Close unreferenced connections in parallel, but wait for every Close to finish
+	// before proceeding. grpc.ClientConn.Close may block on transport shutdown (GOAWAY,
+	// TCP teardown), especially when the peer left the cluster but the socket is still
+	// half-open. With our grpc-go version that wait is bounded (on the order of seconds
+	// per connection, not indefinitely). Never-dialed connections close instantly.
 	//
-	// We keep discoveryMu across Close on purpose: releasing it before Close would
-	// reopen the race between ref updates, map removal, and a replacement *conn for
-	// the same endpoint key. Discovery runs on a background repeater, so a bounded
-	// stall here is acceptable and preferable to async cleanup complexity.
-	p.conns.Range(func(key endpoint.Key, c *conn) bool {
+	// discoveryMu is held across wg.Wait on purpose: releasing it before Close would
+	// reopen the race between ref updates, map removal, and a replacement *conn for the
+	// same endpoint key. Discovery runs on a background repeater, so a bounded stall
+	// here is acceptable.
+	var wg sync.WaitGroup
+
+	p.conns.Range(func(_ endpoint.Key, c *conn) bool {
 		if c.discoveryRefs.Load() <= 0 {
-			_ = c.Close(ctx)
+			wg.Add(1)
+			go func(c closer.Closer) {
+				defer wg.Done()
+				_ = c.Close(ctx)
+			}(c)
 		}
 
 		return true
 	})
+	wg.Wait()
 
 	for _, e := range dropped {
 		p.releaseDiscoveryRef(e)

--- a/internal/conn/pool.go
+++ b/internal/conn/pool.go
@@ -78,9 +78,10 @@ func (p *Pool) AcquireConn(e endpoint.Endpoint) Conn {
 	return p.acquireDiscoveryRef(e)
 }
 
+// acquireDiscoveryRef marks the endpoint as in use. Caller must hold discoveryMu.
 func (p *Pool) acquireDiscoveryRef(e endpoint.Endpoint) Conn {
 	cc := p.conn(e)
-	cc.discoveryRefs.Add(1)
+	cc.discoveryRefs++
 
 	return cc
 }
@@ -95,30 +96,29 @@ func (p *Pool) ReleaseEndpoint(_ context.Context, e endpoint.Endpoint) {
 	p.discoveryMu.Lock()
 	defer p.discoveryMu.Unlock()
 
-	p.releaseDiscoveryRef(e)
-}
-
-func (p *Pool) releaseDiscoveryRef(e endpoint.Endpoint) {
 	if p.isClosed() {
 		return
 	}
 
-	cc, ok := p.conns.Get(e.Key())
-	if !ok {
-		return
-	}
+	p.releaseDiscoveryRef(e)
+}
 
-	cc.discoveryRefs.Add(-1)
+// releaseDiscoveryRef drops one in-use mark for the endpoint. Caller must hold discoveryMu.
+func (p *Pool) releaseDiscoveryRef(e endpoint.Endpoint) {
+	if cc, ok := p.conns.Get(e.Key()); ok {
+		cc.discoveryRefs--
+	}
 }
 
 // closeUnreferencedEndpoints closes connections that are no longer in use.
+// Caller must hold discoveryMu.
 func (p *Pool) closeUnreferencedEndpoints(ctx context.Context) {
 	if p.isClosed() {
 		return
 	}
 
 	p.conns.Range(func(_ endpoint.Key, c *conn) bool {
-		if c.discoveryRefs.Load() <= 0 {
+		if c.discoveryRefs <= 0 {
 			_ = c.Close(ctx)
 		}
 
@@ -156,6 +156,10 @@ func (p *Pool) DiscoveryConnections(
 func (p *Pool) ReleaseEndpoints(ctx context.Context, endpoints []endpoint.Endpoint) {
 	p.discoveryMu.Lock()
 	defer p.discoveryMu.Unlock()
+
+	if p.isClosed() {
+		return
+	}
 
 	for _, e := range endpoints {
 		p.releaseDiscoveryRef(e)

--- a/internal/conn/pool_test.go
+++ b/internal/conn/pool_test.go
@@ -2,6 +2,7 @@ package conn
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -536,6 +537,37 @@ func TestPool_DiscoveryConnectionsRefs(t *testing.T) {
 		_, ok = pool.conns.Get(e.Key())
 		require.False(t, ok)
 	})
+}
+
+func TestPool_DiscoveryConnectionsConcurrent(t *testing.T) {
+	ctx := context.Background()
+	pool := NewPool(ctx, &mockConfig{})
+	defer func() {
+		_ = pool.Release(ctx)
+	}()
+
+	e := endpoint.New("concurrent:2135", endpoint.WithID(1))
+
+	const workers = 8
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for range workers {
+		go func() {
+			defer wg.Done()
+			for range 50 {
+				pool.DiscoveryConnections(
+					ctx,
+					[]endpoint.Endpoint{e},
+					nil,
+					[]endpoint.Endpoint{e},
+				)
+				pool.DiscoveryConnections(ctx, nil, []endpoint.Endpoint{e}, nil)
+			}
+		}()
+	}
+	wg.Wait()
+
+	require.LessOrEqual(t, pool.conns.Len(), 1)
 }
 
 func TestPool_AcquireConnNotClosedByDiscoveryCleanup(t *testing.T) {

--- a/internal/conn/pool_test.go
+++ b/internal/conn/pool_test.go
@@ -611,7 +611,7 @@ func TestPool_AcquireConnReleaseClosedOnDiscovery(t *testing.T) {
 	conn := pool.AcquireConn(e)
 	require.NotNil(t, conn)
 
-	pool.ReleaseEndpoint(ctx, e)
+	pool.DiscoveryConnections(ctx, nil, []endpoint.Endpoint{e}, nil)
 	pool.DiscoveryConnections(ctx, nil, nil, nil)
 
 	_, ok := pool.conns.Get(e.Key())

--- a/internal/conn/pool_test.go
+++ b/internal/conn/pool_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/conn/state"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/endpoint"
+	"github.com/ydb-platform/ydb-go-sdk/v3/pkg/xslices"
 	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
 )
 
@@ -56,10 +57,10 @@ func TestPool_Get(t *testing.T) {
 
 		e := endpoint.New("test-endpoint:2135")
 
-		conn1 := pool.Get(e)
+		conn1 := pool.get(e)
 		require.NotNil(t, conn1)
 
-		conn2 := pool.Get(e)
+		conn2 := pool.get(e)
 		require.NotNil(t, conn2)
 
 		// Should return the same connection
@@ -80,10 +81,10 @@ func TestPool_Get(t *testing.T) {
 		e1 := endpoint.New("endpoint1:2135")
 		e2 := endpoint.New("endpoint2:2135")
 
-		conn1 := pool.Get(e1)
+		conn1 := pool.get(e1)
 		require.NotNil(t, conn1)
 
-		conn2 := pool.Get(e2)
+		conn2 := pool.get(e2)
 		require.NotNil(t, conn2)
 
 		// Should return different connections
@@ -147,7 +148,7 @@ func TestPool_TakeRelease(t *testing.T) {
 
 		// Get a connection to ensure the pool has something to close
 		e := endpoint.New("test-endpoint:2135")
-		conn := pool.Get(e)
+		conn := pool.get(e)
 		require.NotNil(t, conn)
 
 		// Final release should close the pool
@@ -257,7 +258,7 @@ func TestPool_ConnParker(t *testing.T) {
 
 		// Create a connection and set it to Online
 		e := endpoint.New("test-endpoint:2135")
-		conn := pool.Get(e)
+		conn := pool.get(e)
 		require.NotNil(t, conn)
 
 		conn.SetState(ctx, state.Online)
@@ -297,7 +298,7 @@ func TestPool_ConnParker(t *testing.T) {
 
 		// Create a connection and set it to Banned
 		e := endpoint.New("test-endpoint:2135")
-		conn := pool.Get(e)
+		conn := pool.get(e)
 		require.NotNil(t, conn)
 
 		conn.SetState(ctx, state.Banned)
@@ -337,7 +338,7 @@ func TestPool_ConnParker(t *testing.T) {
 
 		// Create a connection and set it to Online
 		e := endpoint.New("test-endpoint:2135")
-		conn := pool.Get(e)
+		conn := pool.get(e)
 		require.NotNil(t, conn)
 
 		conn.SetState(ctx, state.Online)
@@ -377,7 +378,7 @@ func TestPool_ConnParker(t *testing.T) {
 
 		// Create a connection (default state is Created)
 		e := endpoint.New("test-endpoint:2135")
-		conn := pool.Get(e)
+		conn := pool.get(e)
 		require.NotNil(t, conn)
 		require.Equal(t, state.Created, conn.GetState())
 
@@ -452,7 +453,7 @@ func TestPool_ConnParker(t *testing.T) {
 
 		// Create connection to track parking attempts
 		e := endpoint.New("test-endpoint:2135")
-		conn := pool.Get(e)
+		conn := pool.get(e)
 		conn.SetState(ctx, state.Online)
 
 		// Start the parker
@@ -473,7 +474,136 @@ func TestPool_ConnParker(t *testing.T) {
 	})
 }
 
-func TestEndpointsToConnections(t *testing.T) {
+func TestPool_DiscoveryConnectionsRefs(t *testing.T) {
+	t.Run("KeepsConnectionWhileReferenced", func(t *testing.T) {
+		ctx := context.Background()
+		pool := NewPool(ctx, &mockConfig{})
+		defer func() {
+			_ = pool.Release(ctx)
+		}()
+
+		e := endpoint.New("test-endpoint:2135")
+		pool.DiscoveryConnections(ctx, []endpoint.Endpoint{e}, nil, []endpoint.Endpoint{e})
+		pool.DiscoveryConnections(ctx, []endpoint.Endpoint{e}, nil, []endpoint.Endpoint{e})
+
+		pool.DiscoveryConnections(ctx, nil, []endpoint.Endpoint{e}, []endpoint.Endpoint{e})
+		_, ok := pool.conns.Get(e.Key())
+		require.True(t, ok)
+
+		pool.DiscoveryConnections(ctx, nil, []endpoint.Endpoint{e}, nil)
+		_, ok = pool.conns.Get(e.Key())
+		require.True(t, ok)
+
+		pool.DiscoveryConnections(ctx, nil, nil, nil)
+		_, ok = pool.conns.Get(e.Key())
+		require.False(t, ok)
+	})
+
+	t.Run("ReListsEndpointAfterDrop", func(t *testing.T) {
+		ctx := context.Background()
+		pool := NewPool(ctx, &mockConfig{})
+		defer func() {
+			_ = pool.Release(ctx)
+		}()
+
+		e := endpoint.New("test-endpoint:2135")
+		pool.DiscoveryConnections(ctx, []endpoint.Endpoint{e}, nil, []endpoint.Endpoint{e})
+		pool.DiscoveryConnections(ctx, nil, []endpoint.Endpoint{e}, nil)
+
+		pool.DiscoveryConnections(ctx, []endpoint.Endpoint{e}, nil, []endpoint.Endpoint{e})
+		_, ok := pool.conns.Get(e.Key())
+		require.True(t, ok)
+	})
+
+	t.Run("SharedPoolMultipleBalancers", func(t *testing.T) {
+		ctx := context.Background()
+		pool := NewPool(ctx, &mockConfig{})
+		defer func() {
+			_ = pool.Release(ctx)
+		}()
+
+		e := endpoint.New("shared-endpoint:2135")
+		pool.DiscoveryConnections(ctx, []endpoint.Endpoint{e}, nil, []endpoint.Endpoint{e})
+		pool.DiscoveryConnections(ctx, []endpoint.Endpoint{e}, nil, []endpoint.Endpoint{e})
+
+		pool.DiscoveryConnections(ctx, nil, []endpoint.Endpoint{e}, []endpoint.Endpoint{e})
+		pool.DiscoveryConnections(ctx, nil, nil, nil)
+		_, ok := pool.conns.Get(e.Key())
+		require.True(t, ok)
+
+		pool.DiscoveryConnections(ctx, nil, []endpoint.Endpoint{e}, nil)
+		pool.DiscoveryConnections(ctx, nil, []endpoint.Endpoint{e}, nil)
+		_, ok = pool.conns.Get(e.Key())
+		require.False(t, ok)
+	})
+}
+
+func TestPool_AcquireConnNotClosedByDiscoveryCleanup(t *testing.T) {
+	ctx := context.Background()
+	pool := NewPool(ctx, &mockConfig{})
+	defer func() {
+		_ = pool.Release(ctx)
+	}()
+
+	e := endpoint.New("bootstrap:2135")
+	conn := pool.AcquireConn(e)
+	require.NotNil(t, conn)
+
+	pool.DiscoveryConnections(ctx, nil, nil, nil)
+
+	got, ok := pool.conns.Get(e.Key())
+	require.True(t, ok)
+	require.Equal(t, conn, got)
+}
+
+func TestPool_AcquireConnReleaseClosedOnDiscovery(t *testing.T) {
+	ctx := context.Background()
+	pool := NewPool(ctx, &mockConfig{})
+	defer func() {
+		_ = pool.Release(ctx)
+	}()
+
+	e := endpoint.New("acquire-release:2135")
+	conn := pool.AcquireConn(e)
+	require.NotNil(t, conn)
+
+	pool.ReleaseEndpoint(ctx, e)
+	pool.DiscoveryConnections(ctx, nil, nil, nil)
+
+	_, ok := pool.conns.Get(e.Key())
+	require.False(t, ok)
+}
+
+func TestPool_DiscoveryEndpointLifecycle(t *testing.T) {
+	t.Run("DropsRemovedEndpointsOnNextDiscovery", func(t *testing.T) {
+		ctx := context.Background()
+		pool := NewPool(ctx, &mockConfig{})
+		defer func() {
+			_ = pool.Release(ctx)
+		}()
+
+		e1 := endpoint.New("node1:2135", endpoint.WithID(1))
+		e2 := endpoint.New("node2:2135", endpoint.WithID(2))
+
+		apply := func(previous, newest []endpoint.Endpoint) {
+			_, added, dropped := xslices.Diff(previous, newest, endpoint.Compare)
+			pool.DiscoveryConnections(ctx, added, dropped, newest)
+		}
+
+		apply(nil, []endpoint.Endpoint{e1, e2})
+		require.Equal(t, 2, pool.conns.Len())
+
+		apply([]endpoint.Endpoint{e1, e2}, []endpoint.Endpoint{e1})
+		require.Equal(t, 2, pool.conns.Len())
+
+		apply([]endpoint.Endpoint{e1}, []endpoint.Endpoint{e1})
+		require.Equal(t, 1, pool.conns.Len())
+		_, ok := pool.conns.Get(e2.Key())
+		require.False(t, ok)
+	})
+}
+
+func TestPool_DiscoveryConnections(t *testing.T) {
 	t.Run("CreatesConnectionsForEndpoints", func(t *testing.T) {
 		ctx := context.Background()
 		config := &mockConfig{
@@ -490,13 +620,14 @@ func TestEndpointsToConnections(t *testing.T) {
 		e1 := endpoint.New("e1:2135")
 		e2 := endpoint.New("e2:2135")
 
-		conns := EndpointsToConnections(pool, []endpoint.Endpoint{e1, e2})
+		conns := pool.DiscoveryConnections(ctx, []endpoint.Endpoint{e1, e2}, nil, []endpoint.Endpoint{e1, e2})
 
 		require.Len(t, conns, 2)
 		require.Equal(t, 2, pool.conns.Len())
 
-		require.Equal(t, pool.Get(e1), conns[0])
-		require.Equal(t, pool.Get(e2), conns[1])
+		same := pool.DiscoveryConnections(ctx, nil, nil, []endpoint.Endpoint{e1, e2})
+		require.Equal(t, conns[0], same[0])
+		require.Equal(t, conns[1], same[1])
 	})
 
 	t.Run("ReusesExistingConnections", func(t *testing.T) {
@@ -512,12 +643,12 @@ func TestEndpointsToConnections(t *testing.T) {
 
 		e := endpoint.New("reuse:2135")
 
-		existing := pool.Get(e)
+		existing := pool.DiscoveryConnections(ctx, []endpoint.Endpoint{e}, nil, []endpoint.Endpoint{e})[0]
 		require.NotNil(t, existing)
 
 		initialLen := pool.conns.Len()
 
-		conns := EndpointsToConnections(pool, []endpoint.Endpoint{e})
+		conns := pool.DiscoveryConnections(ctx, nil, nil, []endpoint.Endpoint{e})
 
 		require.Len(t, conns, 1)
 		require.Equal(t, existing, conns[0])
@@ -554,7 +685,7 @@ func TestEndpointsToConnections(t *testing.T) {
 		e5 := endpoint.New("example.com:2135", endpoint.WithIPV6([]string{"2001:db8::1"}), endpoint.WithID(1))
 
 		endpoints := []endpoint.Endpoint{e1, e2, e3, e4, e5}
-		conns := EndpointsToConnections(pool, endpoints)
+		conns := pool.DiscoveryConnections(ctx, endpoints, nil, endpoints)
 
 		require.Len(t, conns, len(endpoints))
 		require.Equal(t, 5, pool.conns.Len())
@@ -562,7 +693,6 @@ func TestEndpointsToConnections(t *testing.T) {
 		for i, e := range endpoints {
 			got := conns[i]
 			require.NotNil(t, got)
-			require.Equal(t, pool.Get(e), got)
 			cc, ok := pool.conns.Get(e.Key())
 			require.True(t, ok)
 			require.Equal(t, cc, got)
@@ -589,27 +719,31 @@ func TestEndpointsToConnections(t *testing.T) {
 		e2 := endpoint.New("e2.example:2135", endpoint.WithIPV6([]string{"2001:db8::2"}), endpoint.WithID(2))
 
 		// create initial connections
-		initialConns := EndpointsToConnections(pool, []endpoint.Endpoint{e1, e2})
+		initialConns := pool.DiscoveryConnections(
+			ctx, []endpoint.Endpoint{e1, e2}, nil, []endpoint.Endpoint{e1, e2},
+		)
 		require.Len(t, initialConns, 2)
 		require.Equal(t, 2, pool.conns.Len())
-		require.Equal(t, pool.Get(e1), initialConns[0])
-		require.Equal(t, pool.Get(e2), initialConns[1])
 
 		// add a new unique endpoint e3 -> pool should grow
 		e3 := endpoint.New("e3.example:2135", endpoint.WithIPV6([]string{"2001:db8::3"}), endpoint.WithID(3))
-		connsAfterE3 := EndpointsToConnections(pool, []endpoint.Endpoint{e1, e2, e3})
+		connsAfterE3 := pool.DiscoveryConnections(
+			ctx, []endpoint.Endpoint{e3}, nil, []endpoint.Endpoint{e1, e2, e3},
+		)
 		require.Len(t, connsAfterE3, 3)
 		require.Equal(t, 3, pool.conns.Len())
-		require.Equal(t, pool.Get(e3), connsAfterE3[2])
+		require.Equal(t, initialConns[0], connsAfterE3[0])
+		require.Equal(t, initialConns[1], connsAfterE3[1])
+		require.NotEqual(t, initialConns[0], connsAfterE3[2])
 
 		// now use same address as e1 but different NodeID (and same ipv6) -> should create new conn
 		e1DifferentNode := endpoint.New("e1.example:2135", endpoint.WithIPV6([]string{"2001:db8::1"}), endpoint.WithID(99))
-		connsAfterNodeChange := EndpointsToConnections(pool, []endpoint.Endpoint{e1DifferentNode})
+		connsAfterNodeChange := pool.DiscoveryConnections(
+			ctx, []endpoint.Endpoint{e1DifferentNode}, nil, []endpoint.Endpoint{e1DifferentNode},
+		)
 		require.Len(t, connsAfterNodeChange, 1)
 		// pool size must increase by one
 		require.Equal(t, 4, pool.conns.Len())
-		// returned conn corresponds to the new endpoint key
-		require.Equal(t, pool.Get(e1DifferentNode), connsAfterNodeChange[0])
-		require.Equal(t, pool.Get(e1), initialConns[0])
+		require.Equal(t, initialConns[0], connsAfterE3[0])
 	})
 }

--- a/internal/conn/pool_test.go
+++ b/internal/conn/pool_test.go
@@ -44,6 +44,16 @@ func (m *mockConfig) GrpcDialOptions() []grpc.DialOption {
 	return m.grpcDialOpts
 }
 
+func countPoolConns(pool *Pool) (n int) {
+	pool.conns.Range(func(_ endpoint.Key, _ *conn) bool {
+		n++
+
+		return true
+	})
+
+	return n
+}
+
 func TestPool_Get(t *testing.T) {
 	t.Run("GetSameConnectionTwice", func(t *testing.T) {
 		ctx := context.Background()
@@ -567,7 +577,7 @@ func TestPool_DiscoveryConnectionsConcurrent(t *testing.T) {
 	}
 	wg.Wait()
 
-	require.LessOrEqual(t, pool.conns.Len(), 1)
+	require.LessOrEqual(t, countPoolConns(pool), 1)
 }
 
 func TestPool_AcquireConnNotClosedByDiscoveryCleanup(t *testing.T) {
@@ -623,14 +633,21 @@ func TestPool_DiscoveryEndpointLifecycle(t *testing.T) {
 		}
 
 		apply(nil, []endpoint.Endpoint{e1, e2})
-		require.Equal(t, 2, pool.conns.Len())
+		_, ok := pool.conns.Get(e1.Key())
+		require.True(t, ok)
+		_, ok = pool.conns.Get(e2.Key())
+		require.True(t, ok)
 
 		apply([]endpoint.Endpoint{e1, e2}, []endpoint.Endpoint{e1})
-		require.Equal(t, 2, pool.conns.Len())
+		_, ok = pool.conns.Get(e1.Key())
+		require.True(t, ok)
+		_, ok = pool.conns.Get(e2.Key())
+		require.True(t, ok)
 
 		apply([]endpoint.Endpoint{e1}, []endpoint.Endpoint{e1})
-		require.Equal(t, 1, pool.conns.Len())
-		_, ok := pool.conns.Get(e2.Key())
+		_, ok = pool.conns.Get(e1.Key())
+		require.True(t, ok)
+		_, ok = pool.conns.Get(e2.Key())
 		require.False(t, ok)
 	})
 }
@@ -647,15 +664,16 @@ func TestPool_DiscoveryConnections(t *testing.T) {
 			_ = pool.Release(ctx)
 		}()
 
-		require.Equal(t, 0, pool.conns.Len())
-
 		e1 := endpoint.New("e1:2135")
 		e2 := endpoint.New("e2:2135")
 
 		conns := pool.DiscoveryConnections(ctx, []endpoint.Endpoint{e1, e2}, nil, []endpoint.Endpoint{e1, e2})
 
 		require.Len(t, conns, 2)
-		require.Equal(t, 2, pool.conns.Len())
+		_, ok := pool.conns.Get(e1.Key())
+		require.True(t, ok)
+		_, ok = pool.conns.Get(e2.Key())
+		require.True(t, ok)
 
 		same := pool.DiscoveryConnections(ctx, nil, nil, []endpoint.Endpoint{e1, e2})
 		require.Equal(t, conns[0], same[0])
@@ -678,14 +696,14 @@ func TestPool_DiscoveryConnections(t *testing.T) {
 		existing := pool.DiscoveryConnections(ctx, []endpoint.Endpoint{e}, nil, []endpoint.Endpoint{e})[0]
 		require.NotNil(t, existing)
 
-		initialLen := pool.conns.Len()
-
 		conns := pool.DiscoveryConnections(ctx, nil, nil, []endpoint.Endpoint{e})
 
 		require.Len(t, conns, 1)
 		require.Equal(t, existing, conns[0])
 
-		require.Equal(t, initialLen, pool.conns.Len())
+		got, ok := pool.conns.Get(e.Key())
+		require.True(t, ok)
+		require.Equal(t, existing, got)
 	})
 
 	t.Run("IPv6AndHostOverrideUniqueKeys", func(t *testing.T) {
@@ -698,9 +716,6 @@ func TestPool_DiscoveryConnections(t *testing.T) {
 		defer func() {
 			_ = pool.Release(ctx)
 		}()
-
-		// ensure empty pool
-		require.Equal(t, 0, pool.conns.Len())
 
 		// address is a dns-style host:port, ipv6 provides resolved ip used in Key.Address()
 		e1 := endpoint.New("example.com:2135", endpoint.WithIPV6([]string{"2001:db8::1"}))
@@ -720,7 +735,6 @@ func TestPool_DiscoveryConnections(t *testing.T) {
 		conns := pool.DiscoveryConnections(ctx, endpoints, nil, endpoints)
 
 		require.Len(t, conns, len(endpoints))
-		require.Equal(t, 5, pool.conns.Len())
 
 		for i, e := range endpoints {
 			got := conns[i]
@@ -755,7 +769,8 @@ func TestPool_DiscoveryConnections(t *testing.T) {
 			ctx, []endpoint.Endpoint{e1, e2}, nil, []endpoint.Endpoint{e1, e2},
 		)
 		require.Len(t, initialConns, 2)
-		require.Equal(t, 2, pool.conns.Len())
+		require.True(t, pool.conns.Has(e1.Key()))
+		require.True(t, pool.conns.Has(e2.Key()))
 
 		// add a new unique endpoint e3 -> pool should grow
 		e3 := endpoint.New("e3.example:2135", endpoint.WithIPV6([]string{"2001:db8::3"}), endpoint.WithID(3))
@@ -763,7 +778,7 @@ func TestPool_DiscoveryConnections(t *testing.T) {
 			ctx, []endpoint.Endpoint{e3}, nil, []endpoint.Endpoint{e1, e2, e3},
 		)
 		require.Len(t, connsAfterE3, 3)
-		require.Equal(t, 3, pool.conns.Len())
+		require.True(t, pool.conns.Has(e3.Key()))
 		require.Equal(t, initialConns[0], connsAfterE3[0])
 		require.Equal(t, initialConns[1], connsAfterE3[1])
 		require.NotEqual(t, initialConns[0], connsAfterE3[2])
@@ -774,8 +789,7 @@ func TestPool_DiscoveryConnections(t *testing.T) {
 			ctx, []endpoint.Endpoint{e1DifferentNode}, nil, []endpoint.Endpoint{e1DifferentNode},
 		)
 		require.Len(t, connsAfterNodeChange, 1)
-		// pool size must increase by one
-		require.Equal(t, 4, pool.conns.Len())
+		require.True(t, pool.conns.Has(e1DifferentNode.Key()))
 		require.Equal(t, initialConns[0], connsAfterE3[0])
 	})
 }

--- a/internal/conn/pool_test.go
+++ b/internal/conn/pool_test.go
@@ -2,7 +2,6 @@ package conn
 
 import (
 	"context"
-	"sync"
 	"testing"
 	"time"
 
@@ -12,7 +11,6 @@ import (
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/conn/state"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/endpoint"
-	"github.com/ydb-platform/ydb-go-sdk/v3/pkg/xslices"
 	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
 )
 
@@ -44,16 +42,6 @@ func (m *mockConfig) GrpcDialOptions() []grpc.DialOption {
 	return m.grpcDialOpts
 }
 
-func countPoolConns(pool *Pool) (n int) {
-	pool.conns.Range(func(_ endpoint.Key, _ *conn) bool {
-		n++
-
-		return true
-	})
-
-	return n
-}
-
 func TestPool_Get(t *testing.T) {
 	t.Run("GetSameConnectionTwice", func(t *testing.T) {
 		ctx := context.Background()
@@ -68,10 +56,10 @@ func TestPool_Get(t *testing.T) {
 
 		e := endpoint.New("test-endpoint:2135")
 
-		conn1 := pool.get(e)
+		conn1 := pool.Get(e)
 		require.NotNil(t, conn1)
 
-		conn2 := pool.get(e)
+		conn2 := pool.Get(e)
 		require.NotNil(t, conn2)
 
 		// Should return the same connection
@@ -92,10 +80,10 @@ func TestPool_Get(t *testing.T) {
 		e1 := endpoint.New("endpoint1:2135")
 		e2 := endpoint.New("endpoint2:2135")
 
-		conn1 := pool.get(e1)
+		conn1 := pool.Get(e1)
 		require.NotNil(t, conn1)
 
-		conn2 := pool.get(e2)
+		conn2 := pool.Get(e2)
 		require.NotNil(t, conn2)
 
 		// Should return different connections
@@ -159,7 +147,7 @@ func TestPool_TakeRelease(t *testing.T) {
 
 		// Get a connection to ensure the pool has something to close
 		e := endpoint.New("test-endpoint:2135")
-		conn := pool.get(e)
+		conn := pool.Get(e)
 		require.NotNil(t, conn)
 
 		// Final release should close the pool
@@ -269,7 +257,7 @@ func TestPool_ConnParker(t *testing.T) {
 
 		// Create a connection and set it to Online
 		e := endpoint.New("test-endpoint:2135")
-		conn := pool.get(e)
+		conn := pool.Get(e)
 		require.NotNil(t, conn)
 
 		conn.SetState(ctx, state.Online)
@@ -309,7 +297,7 @@ func TestPool_ConnParker(t *testing.T) {
 
 		// Create a connection and set it to Banned
 		e := endpoint.New("test-endpoint:2135")
-		conn := pool.get(e)
+		conn := pool.Get(e)
 		require.NotNil(t, conn)
 
 		conn.SetState(ctx, state.Banned)
@@ -349,7 +337,7 @@ func TestPool_ConnParker(t *testing.T) {
 
 		// Create a connection and set it to Online
 		e := endpoint.New("test-endpoint:2135")
-		conn := pool.get(e)
+		conn := pool.Get(e)
 		require.NotNil(t, conn)
 
 		conn.SetState(ctx, state.Online)
@@ -389,7 +377,7 @@ func TestPool_ConnParker(t *testing.T) {
 
 		// Create a connection (default state is Created)
 		e := endpoint.New("test-endpoint:2135")
-		conn := pool.get(e)
+		conn := pool.Get(e)
 		require.NotNil(t, conn)
 		require.Equal(t, state.Created, conn.GetState())
 
@@ -464,7 +452,7 @@ func TestPool_ConnParker(t *testing.T) {
 
 		// Create connection to track parking attempts
 		e := endpoint.New("test-endpoint:2135")
-		conn := pool.get(e)
+		conn := pool.Get(e)
 		conn.SetState(ctx, state.Online)
 
 		// Start the parker
@@ -485,176 +473,7 @@ func TestPool_ConnParker(t *testing.T) {
 	})
 }
 
-func TestPool_DiscoveryConnectionsRefs(t *testing.T) {
-	t.Run("KeepsConnectionWhileReferenced", func(t *testing.T) {
-		ctx := context.Background()
-		pool := NewPool(ctx, &mockConfig{})
-		defer func() {
-			_ = pool.Release(ctx)
-		}()
-
-		e := endpoint.New("test-endpoint:2135")
-		pool.DiscoveryConnections(ctx, []endpoint.Endpoint{e}, nil, []endpoint.Endpoint{e})
-		pool.DiscoveryConnections(ctx, []endpoint.Endpoint{e}, nil, []endpoint.Endpoint{e})
-
-		pool.DiscoveryConnections(ctx, nil, []endpoint.Endpoint{e}, []endpoint.Endpoint{e})
-		_, ok := pool.conns.Get(e.Key())
-		require.True(t, ok)
-
-		pool.DiscoveryConnections(ctx, nil, []endpoint.Endpoint{e}, nil)
-		_, ok = pool.conns.Get(e.Key())
-		require.True(t, ok)
-
-		pool.DiscoveryConnections(ctx, nil, nil, nil)
-		_, ok = pool.conns.Get(e.Key())
-		require.False(t, ok)
-	})
-
-	t.Run("ReListsEndpointAfterDrop", func(t *testing.T) {
-		ctx := context.Background()
-		pool := NewPool(ctx, &mockConfig{})
-		defer func() {
-			_ = pool.Release(ctx)
-		}()
-
-		e := endpoint.New("test-endpoint:2135")
-		pool.DiscoveryConnections(ctx, []endpoint.Endpoint{e}, nil, []endpoint.Endpoint{e})
-		pool.DiscoveryConnections(ctx, nil, []endpoint.Endpoint{e}, nil)
-
-		pool.DiscoveryConnections(ctx, []endpoint.Endpoint{e}, nil, []endpoint.Endpoint{e})
-		_, ok := pool.conns.Get(e.Key())
-		require.True(t, ok)
-	})
-
-	t.Run("SharedPoolMultipleBalancers", func(t *testing.T) {
-		ctx := context.Background()
-		pool := NewPool(ctx, &mockConfig{})
-		defer func() {
-			_ = pool.Release(ctx)
-		}()
-
-		e := endpoint.New("shared-endpoint:2135")
-		pool.DiscoveryConnections(ctx, []endpoint.Endpoint{e}, nil, []endpoint.Endpoint{e})
-		pool.DiscoveryConnections(ctx, []endpoint.Endpoint{e}, nil, []endpoint.Endpoint{e})
-
-		pool.DiscoveryConnections(ctx, nil, []endpoint.Endpoint{e}, []endpoint.Endpoint{e})
-		pool.DiscoveryConnections(ctx, nil, nil, nil)
-		_, ok := pool.conns.Get(e.Key())
-		require.True(t, ok)
-
-		// Each call models [balancer.Balancer.Close] on a shared pool.
-		pool.DiscoveryConnections(ctx, nil, []endpoint.Endpoint{e}, nil)
-		pool.DiscoveryConnections(ctx, nil, []endpoint.Endpoint{e}, nil)
-		pool.DiscoveryConnections(ctx, nil, nil, nil)
-		_, ok = pool.conns.Get(e.Key())
-		require.False(t, ok)
-	})
-}
-
-func TestPool_DiscoveryConnectionsConcurrent(t *testing.T) {
-	ctx := context.Background()
-	pool := NewPool(ctx, &mockConfig{})
-	defer func() {
-		_ = pool.Release(ctx)
-	}()
-
-	e := endpoint.New("concurrent:2135", endpoint.WithID(1))
-
-	const workers = 8
-	var wg sync.WaitGroup
-	wg.Add(workers)
-	for range workers {
-		go func() {
-			defer wg.Done()
-			for range 50 {
-				pool.DiscoveryConnections(
-					ctx,
-					[]endpoint.Endpoint{e},
-					nil,
-					[]endpoint.Endpoint{e},
-				)
-				pool.DiscoveryConnections(ctx, nil, []endpoint.Endpoint{e}, nil)
-			}
-		}()
-	}
-	wg.Wait()
-
-	require.LessOrEqual(t, countPoolConns(pool), 1)
-}
-
-func TestPool_AcquireConnNotClosedByDiscoveryCleanup(t *testing.T) {
-	ctx := context.Background()
-	pool := NewPool(ctx, &mockConfig{})
-	defer func() {
-		_ = pool.Release(ctx)
-	}()
-
-	e := endpoint.New("bootstrap:2135")
-	conn := pool.AcquireConn(e)
-	require.NotNil(t, conn)
-
-	pool.DiscoveryConnections(ctx, nil, nil, nil)
-
-	got, ok := pool.conns.Get(e.Key())
-	require.True(t, ok)
-	require.Equal(t, conn, got)
-}
-
-func TestPool_AcquireConnReleaseClosedOnDiscovery(t *testing.T) {
-	ctx := context.Background()
-	pool := NewPool(ctx, &mockConfig{})
-	defer func() {
-		_ = pool.Release(ctx)
-	}()
-
-	e := endpoint.New("acquire-release:2135")
-	conn := pool.AcquireConn(e)
-	require.NotNil(t, conn)
-
-	pool.DiscoveryConnections(ctx, nil, []endpoint.Endpoint{e}, nil)
-	pool.DiscoveryConnections(ctx, nil, nil, nil)
-
-	_, ok := pool.conns.Get(e.Key())
-	require.False(t, ok)
-}
-
-func TestPool_DiscoveryEndpointLifecycle(t *testing.T) {
-	t.Run("DropsRemovedEndpointsOnNextDiscovery", func(t *testing.T) {
-		ctx := context.Background()
-		pool := NewPool(ctx, &mockConfig{})
-		defer func() {
-			_ = pool.Release(ctx)
-		}()
-
-		e1 := endpoint.New("node1:2135", endpoint.WithID(1))
-		e2 := endpoint.New("node2:2135", endpoint.WithID(2))
-
-		apply := func(previous, newest []endpoint.Endpoint) {
-			_, added, dropped := xslices.Diff(previous, newest, endpoint.Compare)
-			pool.DiscoveryConnections(ctx, added, dropped, newest)
-		}
-
-		apply(nil, []endpoint.Endpoint{e1, e2})
-		_, ok := pool.conns.Get(e1.Key())
-		require.True(t, ok)
-		_, ok = pool.conns.Get(e2.Key())
-		require.True(t, ok)
-
-		apply([]endpoint.Endpoint{e1, e2}, []endpoint.Endpoint{e1})
-		_, ok = pool.conns.Get(e1.Key())
-		require.True(t, ok)
-		_, ok = pool.conns.Get(e2.Key())
-		require.True(t, ok)
-
-		apply([]endpoint.Endpoint{e1}, []endpoint.Endpoint{e1})
-		_, ok = pool.conns.Get(e1.Key())
-		require.True(t, ok)
-		_, ok = pool.conns.Get(e2.Key())
-		require.False(t, ok)
-	})
-}
-
-func TestPool_DiscoveryConnections(t *testing.T) {
+func TestEndpointsToConnections(t *testing.T) {
 	t.Run("CreatesConnectionsForEndpoints", func(t *testing.T) {
 		ctx := context.Background()
 		config := &mockConfig{
@@ -669,7 +488,7 @@ func TestPool_DiscoveryConnections(t *testing.T) {
 		e1 := endpoint.New("e1:2135")
 		e2 := endpoint.New("e2:2135")
 
-		conns := pool.DiscoveryConnections(ctx, []endpoint.Endpoint{e1, e2}, nil, []endpoint.Endpoint{e1, e2})
+		conns := EndpointsToConnections(pool, []endpoint.Endpoint{e1, e2})
 
 		require.Len(t, conns, 2)
 		_, ok := pool.conns.Get(e1.Key())
@@ -677,9 +496,8 @@ func TestPool_DiscoveryConnections(t *testing.T) {
 		_, ok = pool.conns.Get(e2.Key())
 		require.True(t, ok)
 
-		same := pool.DiscoveryConnections(ctx, nil, nil, []endpoint.Endpoint{e1, e2})
-		require.Equal(t, conns[0], same[0])
-		require.Equal(t, conns[1], same[1])
+		require.Equal(t, pool.Get(e1), conns[0])
+		require.Equal(t, pool.Get(e2), conns[1])
 	})
 
 	t.Run("ReusesExistingConnections", func(t *testing.T) {
@@ -695,10 +513,10 @@ func TestPool_DiscoveryConnections(t *testing.T) {
 
 		e := endpoint.New("reuse:2135")
 
-		existing := pool.DiscoveryConnections(ctx, []endpoint.Endpoint{e}, nil, []endpoint.Endpoint{e})[0]
+		existing := pool.Get(e)
 		require.NotNil(t, existing)
 
-		conns := pool.DiscoveryConnections(ctx, nil, nil, []endpoint.Endpoint{e})
+		conns := EndpointsToConnections(pool, []endpoint.Endpoint{e})
 
 		require.Len(t, conns, 1)
 		require.Equal(t, existing, conns[0])
@@ -734,13 +552,14 @@ func TestPool_DiscoveryConnections(t *testing.T) {
 		e5 := endpoint.New("example.com:2135", endpoint.WithIPV6([]string{"2001:db8::1"}), endpoint.WithID(1))
 
 		endpoints := []endpoint.Endpoint{e1, e2, e3, e4, e5}
-		conns := pool.DiscoveryConnections(ctx, endpoints, nil, endpoints)
+		conns := EndpointsToConnections(pool, endpoints)
 
 		require.Len(t, conns, len(endpoints))
 
 		for i, e := range endpoints {
 			got := conns[i]
 			require.NotNil(t, got)
+			require.Equal(t, pool.Get(e), got)
 			cc, ok := pool.conns.Get(e.Key())
 			require.True(t, ok)
 			require.Equal(t, cc, got)
@@ -767,18 +586,14 @@ func TestPool_DiscoveryConnections(t *testing.T) {
 		e2 := endpoint.New("e2.example:2135", endpoint.WithIPV6([]string{"2001:db8::2"}), endpoint.WithID(2))
 
 		// create initial connections
-		initialConns := pool.DiscoveryConnections(
-			ctx, []endpoint.Endpoint{e1, e2}, nil, []endpoint.Endpoint{e1, e2},
-		)
+		initialConns := EndpointsToConnections(pool, []endpoint.Endpoint{e1, e2})
 		require.Len(t, initialConns, 2)
 		require.True(t, pool.conns.Has(e1.Key()))
 		require.True(t, pool.conns.Has(e2.Key()))
 
 		// add a new unique endpoint e3 -> pool should grow
 		e3 := endpoint.New("e3.example:2135", endpoint.WithIPV6([]string{"2001:db8::3"}), endpoint.WithID(3))
-		connsAfterE3 := pool.DiscoveryConnections(
-			ctx, []endpoint.Endpoint{e3}, nil, []endpoint.Endpoint{e1, e2, e3},
-		)
+		connsAfterE3 := EndpointsToConnections(pool, []endpoint.Endpoint{e1, e2, e3})
 		require.Len(t, connsAfterE3, 3)
 		require.True(t, pool.conns.Has(e3.Key()))
 		require.Equal(t, initialConns[0], connsAfterE3[0])
@@ -787,11 +602,80 @@ func TestPool_DiscoveryConnections(t *testing.T) {
 
 		// now use same address as e1 but different NodeID (and same ipv6) -> should create new conn
 		e1DifferentNode := endpoint.New("e1.example:2135", endpoint.WithIPV6([]string{"2001:db8::1"}), endpoint.WithID(99))
-		connsAfterNodeChange := pool.DiscoveryConnections(
-			ctx, []endpoint.Endpoint{e1DifferentNode}, nil, []endpoint.Endpoint{e1DifferentNode},
-		)
+		connsAfterNodeChange := EndpointsToConnections(pool, []endpoint.Endpoint{e1DifferentNode})
 		require.Len(t, connsAfterNodeChange, 1)
 		require.True(t, pool.conns.Has(e1DifferentNode.Key()))
 		require.Equal(t, initialConns[0], connsAfterE3[0])
+	})
+}
+
+func applyEndpointUsage(
+	ctx context.Context,
+	pool *Pool,
+	added, dropped, newest []endpoint.Endpoint,
+) []Conn {
+	pool.UpdateEndpointUsage(ctx, dropped, added)
+
+	return EndpointsToConnections(pool, newest)
+}
+
+func TestPool_EndpointUsage(t *testing.T) {
+	t.Run("DropsRemovedEndpointsOnNextDiscovery", func(t *testing.T) {
+		ctx := context.Background()
+		pool := NewPool(ctx, &mockConfig{})
+		defer func() {
+			_ = pool.Release(ctx)
+		}()
+
+		e1 := endpoint.New("node1:2135", endpoint.WithID(1))
+		e2 := endpoint.New("node2:2135", endpoint.WithID(2))
+
+		applyEndpointUsage(ctx, pool, []endpoint.Endpoint{e1, e2}, nil, []endpoint.Endpoint{e1, e2})
+		require.True(t, pool.conns.Has(e1.Key()))
+		require.True(t, pool.conns.Has(e2.Key()))
+
+		applyEndpointUsage(ctx, pool, nil, []endpoint.Endpoint{e2}, []endpoint.Endpoint{e1})
+		require.True(t, pool.conns.Has(e1.Key()))
+		require.True(t, pool.conns.Has(e2.Key()))
+
+		applyEndpointUsage(ctx, pool, nil, nil, []endpoint.Endpoint{e1})
+		require.True(t, pool.conns.Has(e1.Key()))
+		require.False(t, pool.conns.Has(e2.Key()))
+	})
+
+	t.Run("SharedPoolMultipleBalancers", func(t *testing.T) {
+		ctx := context.Background()
+		pool := NewPool(ctx, &mockConfig{})
+		defer func() {
+			_ = pool.Release(ctx)
+		}()
+
+		e := endpoint.New("shared-endpoint:2135")
+		applyEndpointUsage(ctx, pool, []endpoint.Endpoint{e}, nil, []endpoint.Endpoint{e})
+		applyEndpointUsage(ctx, pool, []endpoint.Endpoint{e}, nil, []endpoint.Endpoint{e})
+		applyEndpointUsage(ctx, pool, nil, []endpoint.Endpoint{e}, []endpoint.Endpoint{e})
+		applyEndpointUsage(ctx, pool, nil, nil, nil)
+		require.True(t, pool.conns.Has(e.Key()))
+
+		applyEndpointUsage(ctx, pool, nil, []endpoint.Endpoint{e}, nil)
+		applyEndpointUsage(ctx, pool, nil, []endpoint.Endpoint{e}, nil)
+		applyEndpointUsage(ctx, pool, nil, nil, nil)
+		require.False(t, pool.conns.Has(e.Key()))
+	})
+
+	t.Run("AcquireConnNotClosedByCleanup", func(t *testing.T) {
+		ctx := context.Background()
+		pool := NewPool(ctx, &mockConfig{})
+		defer func() {
+			_ = pool.Release(ctx)
+		}()
+
+		e := endpoint.New("bootstrap:2135")
+		conn := pool.AcquireConn(e)
+		pool.UpdateEndpointUsage(ctx, nil, nil)
+
+		got, ok := pool.conns.Get(e.Key())
+		require.True(t, ok)
+		require.Equal(t, conn, got)
 	})
 }

--- a/internal/conn/pool_test.go
+++ b/internal/conn/pool_test.go
@@ -542,8 +542,10 @@ func TestPool_DiscoveryConnectionsRefs(t *testing.T) {
 		_, ok := pool.conns.Get(e.Key())
 		require.True(t, ok)
 
+		// Each call models [balancer.Balancer.Close] on a shared pool.
 		pool.DiscoveryConnections(ctx, nil, []endpoint.Endpoint{e}, nil)
 		pool.DiscoveryConnections(ctx, nil, []endpoint.Endpoint{e}, nil)
+		pool.DiscoveryConnections(ctx, nil, nil, nil)
 		_, ok = pool.conns.Get(e.Key())
 		require.False(t, ok)
 	})

--- a/internal/endpoint/endpoint.go
+++ b/internal/endpoint/endpoint.go
@@ -2,6 +2,7 @@ package endpoint
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 )
@@ -259,4 +260,24 @@ func New(address string, opts ...Option) *endpoint {
 	}
 
 	return e
+}
+
+// Compare orders two discovery endpoints lexicographically: Address, then NodeID,
+// then OverrideHost (each field compared like strings.Compare).
+// Use it as the cmp argument to xslices.Diff to split snapshots into added,
+// dropped, and unchanged endpoints.
+//
+// Return value follows strings.Compare: negative if lhs sorts before rhs, zero if
+// all three fields match (same pool entry), positive if lhs sorts after rhs.
+func Compare(lhs, rhs Endpoint) int {
+	cmp := strings.Compare(lhs.Address(), rhs.Address())
+	if cmp != 0 {
+		return cmp
+	}
+	cmp = int(lhs.NodeID()) - int(rhs.NodeID())
+	if cmp != 0 {
+		return cmp
+	}
+
+	return strings.Compare(lhs.OverrideHost(), rhs.OverrideHost())
 }

--- a/internal/endpoint/endpoint.go
+++ b/internal/endpoint/endpoint.go
@@ -262,10 +262,11 @@ func New(address string, opts ...Option) *endpoint {
 	return e
 }
 
-// Compare orders two discovery endpoints lexicographically: Address, then NodeID,
-// then OverrideHost (each field compared like strings.Compare).
-// Use it as the cmp argument to xslices.Diff to split snapshots into added,
-// dropped, and unchanged endpoints.
+// Compare orders two discovery endpoints for stable diffing of endpoint snapshots.
+//
+// Extracted from the balancer so xslices.Diff and the pool stay free of duplicate
+// comparison logic. NodeID is compared as uint32, not via int subtraction, to avoid
+// overflow on 32-bit platforms when NodeID exceeds math.MaxInt32.
 //
 // Return value follows strings.Compare: negative if lhs sorts before rhs, zero if
 // all three fields match (same pool entry), positive if lhs sorts after rhs.

--- a/internal/endpoint/endpoint.go
+++ b/internal/endpoint/endpoint.go
@@ -274,9 +274,11 @@ func Compare(lhs, rhs Endpoint) int {
 	if cmp != 0 {
 		return cmp
 	}
-	cmp = int(lhs.NodeID()) - int(rhs.NodeID())
-	if cmp != 0 {
-		return cmp
+	if lhs.NodeID() < rhs.NodeID() {
+		return -1
+	}
+	if lhs.NodeID() > rhs.NodeID() {
+		return 1
 	}
 
 	return strings.Compare(lhs.OverrideHost(), rhs.OverrideHost())

--- a/internal/xsync/map.go
+++ b/internal/xsync/map.go
@@ -3,12 +3,10 @@ package xsync
 import (
 	"fmt"
 	"sync"
-	"sync/atomic"
 )
 
 type Map[K comparable, V any] struct {
-	m    sync.Map
-	size atomic.Int32
+	m sync.Map
 }
 
 func (m *Map[K, V]) Get(key K) (value V, ok bool) {
@@ -41,25 +39,13 @@ func (m *Map[K, V]) Has(key K) bool {
 }
 
 func (m *Map[K, V]) Set(key K, value V) {
-	_, exists := m.m.LoadOrStore(key, value)
-
-	if !exists {
-		m.size.Add(1)
-	}
+	m.m.LoadOrStore(key, value)
 }
 
 func (m *Map[K, V]) Delete(key K) bool {
 	_, exists := m.Extract(key)
 
-	if !exists {
-		m.size.Add(-1)
-	}
-
 	return exists
-}
-
-func (m *Map[K, V]) Len() int {
-	return int(m.size.Load())
 }
 
 func (m *Map[K, V]) Extract(key K) (value V, ok bool) {
@@ -67,8 +53,6 @@ func (m *Map[K, V]) Extract(key K) (value V, ok bool) {
 	if !exists {
 		return value, false
 	}
-
-	m.size.Add(-1)
 
 	value, ok = v.(V)
 
@@ -89,8 +73,6 @@ func (m *Map[K, V]) Clear() (removed int) {
 
 		return true
 	})
-
-	m.size.Add(int32(-removed))
 
 	return removed
 }

--- a/internal/xsync/map.go
+++ b/internal/xsync/map.go
@@ -64,15 +64,3 @@ func (m *Map[K, V]) Range(f func(key K, value V) bool) {
 		return f(k.(K), v.(V)) //nolint:forcetypeassert
 	})
 }
-
-func (m *Map[K, V]) Clear() (removed int) {
-	m.m.Range(func(k, v any) bool {
-		removed++
-
-		m.m.Delete(k)
-
-		return true
-	})
-
-	return removed
-}

--- a/internal/xsync/map_test.go
+++ b/internal/xsync/map_test.go
@@ -42,7 +42,6 @@ func TestMap(t *testing.T) {
 		2: "two",
 		3: "three",
 	}
-	require.Equal(t, 2, m.Len())
 	var unexp map[int]string
 	m.Range(func(key int, value string) bool {
 		if v, ok := exp[key]; ok && v == value {
@@ -56,7 +55,6 @@ func TestMap(t *testing.T) {
 	require.Empty(t, exp)
 	require.Empty(t, unexp)
 	m.Clear()
-	require.Zero(t, m.Len())
 	empty := true
 	m.Range(func(key int, value string) bool {
 		empty = false

--- a/internal/xsync/map_test.go
+++ b/internal/xsync/map_test.go
@@ -54,12 +54,4 @@ func TestMap(t *testing.T) {
 	})
 	require.Empty(t, exp)
 	require.Empty(t, unexp)
-	m.Clear()
-	empty := true
-	m.Range(func(key int, value string) bool {
-		empty = false
-
-		return false
-	})
-	require.True(t, empty)
 }


### PR DESCRIPTION
## Summary
- Close idle gRPC connections to cluster nodes that disappear from Discovery results
- Track endpoint usage in the shared connection pool via `AcquireConn` / `ReleaseEndpoint`, with `DiscoveryConnections` applying discovery diffs on each balancer update
- Release pool marks when a balancer shuts down so shared drivers do not leak connections

## Test plan
- [x] `go test -race ./internal/conn/...`
- [x] `go test -race ./internal/balancer/...`


Made with [Cursor](https://cursor.com)