### PR TITLE
[DO NOT MERGE] test: verify SLO label removal on fork PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,3 +156,5 @@ Next packages provide debug tooling:
 | `YDB_LOG_DETAILS`                | `string`  | `.*`    | regexp for lookup internal logger logs                                                                                   |
 | `GRPC_GO_LOG_VERBOSITY_LEVEL`    | `integer` |         | set to `99` to see grpc logs                                                                                             |
 | `GRPC_GO_LOG_SEVERITY_LEVEL`     | `string`  |         | set to `info` to see grpc logs                                                                                           |
+
+<!-- CI test: SLO label removal on fork PRs (#2224) -->


### PR DESCRIPTION
Temporary test PR to validate #2224 (SLO label removal for fork PRs).

**Do not merge.**

Change: HTML comment in README only.

## What to verify

1. Add/maintain `SLO` label on this PR
2. Wait for `SLO` workflow to complete
3. Confirm `slo-report` → `Remove SLO Label` resolves this PR via `head=kprokopenko:ci/test-slo-label-removal-fork` and removes the label

Skip labels applied to avoid heavy CI:
- `no tests`, `no lint`, `no examples`, `no changelog`, `no integration tests`

Fixes #2224 (validation only)

Made with [Cursor](https://cursor.com)