### PR TITLE
Add Codecov coverage status gates

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,16 @@
 # all repositories on Codecov. You may adjust the settings
 # below in your own codecov.yml in your repository.
 #
+coverage:
+  status:
+    project:
+      default:
+        target: auto       # do not drop below the current level...
+        threshold: 1%      # ...by more than 1%
+    patch:
+      default:
+        target: 80%        # new/changed code in the PR diff must be >= 80% covered
+
 ignore:
   - spans
   - trace


### PR DESCRIPTION
Adds a `coverage.status` block to `codecov.yml` so Codecov posts blocking PR checks: the `project` status fails when overall coverage drops by more than 1% versus the base branch (`target: auto`, `threshold: 1%`), and the `patch` status requires the PR diff to be at least 80% covered.

Mirrors the gates already used in ydb-python-sdk, keeping coverage enforcement uniform across the native SDKs. Additive — the existing `ignore`/`component_management` config is untouched.