### PR TITLE
docs: document non-positive WithSessionPoolSizeLimit behavior

### DIFF
--- a/options.go
+++ b/options.go
@@ -530,6 +530,7 @@ func WithQueryConfigOption(option queryConfig.Option) Option {
 }
 
 // WithSessionPoolSizeLimit set max size of internal sessions pool in table.Client
+// If sizeLimit is less than or equal to zero then the default pool size limit is used.
 func WithSessionPoolSizeLimit(sizeLimit int) Option {
 	return func(ctx context.Context, d *Driver) error {
 		d.tableOptions = append(d.tableOptions, tableConfig.WithSizeLimit(sizeLimit))


### PR DESCRIPTION
## Summary
- Document that `WithSessionPoolSizeLimit` keeps the default pool size limit when `sizeLimit` is less than or equal to zero.
- Aligns the public option comment with existing behavior in table and query session pool configuration.

## Test plan
- [x] Documentation-only change; CI skipped via labels.


Made with [Cursor](https://cursor.com)