### PR TITLE
refactor(conn): simplify Conn interface and endpoint API

### DIFF
--- a/balancers/balancers_test.go
+++ b/balancers/balancers_test.go
@@ -15,8 +15,8 @@ import (
 func TestPreferLocalDC(t *testing.T) {
 	conns := []conn.Conn{
 		&mock.Conn{AddrField: "1", LocationField: "1"},
-		&mock.Conn{AddrField: "2", State: state.Online, LocationField: "2"},
-		&mock.Conn{AddrField: "3", State: state.Online, LocationField: "2"},
+		&mock.Conn{AddrField: "2", StateField: state.Online, LocationField: "2"},
+		&mock.Conn{AddrField: "3", StateField: state.Online, LocationField: "2"},
 	}
 	rr := PreferNearestDC(RandomChoice())
 	require.False(t, rr.AllowFallback)
@@ -26,8 +26,8 @@ func TestPreferLocalDC(t *testing.T) {
 func TestPreferLocalDCWithFallBack(t *testing.T) {
 	conns := []conn.Conn{
 		&mock.Conn{AddrField: "1", LocationField: "1"},
-		&mock.Conn{AddrField: "2", State: state.Online, LocationField: "2"},
-		&mock.Conn{AddrField: "3", State: state.Online, LocationField: "2"},
+		&mock.Conn{AddrField: "2", StateField: state.Online, LocationField: "2"},
+		&mock.Conn{AddrField: "3", StateField: state.Online, LocationField: "2"},
 	}
 	rr := PreferNearestDCWithFallBack(RandomChoice())
 	require.True(t, rr.AllowFallback)
@@ -36,9 +36,9 @@ func TestPreferLocalDCWithFallBack(t *testing.T) {
 
 func TestPreferLocations(t *testing.T) {
 	conns := []conn.Conn{
-		&mock.Conn{AddrField: "1", LocationField: "zero", State: state.Online},
-		&mock.Conn{AddrField: "2", State: state.Online, LocationField: "one"},
-		&mock.Conn{AddrField: "3", State: state.Online, LocationField: "two"},
+		&mock.Conn{AddrField: "1", LocationField: "zero", StateField: state.Online},
+		&mock.Conn{AddrField: "2", StateField: state.Online, LocationField: "one"},
+		&mock.Conn{AddrField: "3", StateField: state.Online, LocationField: "two"},
 	}
 
 	rr := PreferLocations(RandomChoice(), "zero", "two")
@@ -48,9 +48,9 @@ func TestPreferLocations(t *testing.T) {
 
 func TestPreferLocationsWithFallback(t *testing.T) {
 	conns := []conn.Conn{
-		&mock.Conn{AddrField: "1", LocationField: "zero", State: state.Online},
-		&mock.Conn{AddrField: "2", State: state.Online, LocationField: "one"},
-		&mock.Conn{AddrField: "3", State: state.Online, LocationField: "two"},
+		&mock.Conn{AddrField: "1", LocationField: "zero", StateField: state.Online},
+		&mock.Conn{AddrField: "2", StateField: state.Online, LocationField: "one"},
+		&mock.Conn{AddrField: "3", StateField: state.Online, LocationField: "two"},
 	}
 
 	rr := PreferLocationsWithFallback(RandomChoice(), "zero", "two")

--- a/internal/balancer/balancer.go
+++ b/internal/balancer/balancer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"strings"
 	"sync/atomic"
 
 	"github.com/ydb-platform/ydb-go-genproto/Ydb_Discovery_V1"
@@ -216,41 +215,31 @@ func (b *Balancer) applyDiscoveredEndpoints(ctx context.Context, newest []endpoi
 		previous = b.connections().All()
 	)
 	defer func() {
-		_, added, dropped := xslices.Diff(previous, newest, func(lhs, rhs endpoint.Endpoint) int {
-			cmp := strings.Compare(lhs.Address(), rhs.Address())
-			if cmp != 0 {
-				return cmp
-			}
-			cmp = int(lhs.NodeID()) - int(rhs.NodeID())
-			if cmp != 0 {
-				return cmp
-			}
-
-			return strings.Compare(lhs.OverrideHost(), rhs.OverrideHost())
-		})
+		_, added, dropped := xslices.Diff(
+			xslices.Transform(previous, func(cc conn.Conn) endpoint.Endpoint {
+				return cc.Endpoint()
+			}),
+			newest,
+			endpoint.Compare,
+		)
 		onDone(
-			xslices.Transform(newest, func(t endpoint.Endpoint) trace.EndpointInfo { return t }),
-			xslices.Transform(added, func(t endpoint.Endpoint) trace.EndpointInfo { return t }),
-			xslices.Transform(dropped, func(t endpoint.Endpoint) trace.EndpointInfo { return t }),
+			xslices.Transform(newest, func(e endpoint.Endpoint) trace.EndpointInfo { return e }),
+			xslices.Transform(added, func(e endpoint.Endpoint) trace.EndpointInfo { return e }),
+			xslices.Transform(dropped, func(e endpoint.Endpoint) trace.EndpointInfo { return e }),
 			localDC,
 		)
 	}()
 
 	connections := conn.EndpointsToConnections(b.pool, newest)
 	for _, c := range connections {
-		b.pool.Allow(ctx, c)
-		c.Endpoint().Touch()
+		c.Unban(ctx)
 	}
 
-	info := balancerConfig.Info{SelfLocation: localDC}
-	state := newConnectionsState(connections, b.balancerConfig.Filter, info, b.balancerConfig.AllowFallback)
-
-	endpointsInfo := make([]endpoint.Info, len(newest))
-	for i, e := range newest {
-		endpointsInfo[i] = e
-	}
-
-	b.connectionsState.Store(state)
+	b.connectionsState.Store(newConnectionsState(connections,
+		b.balancerConfig.Filter,
+		balancerConfig.Info{SelfLocation: localDC},
+		b.balancerConfig.AllowFallback,
+	))
 }
 
 func (b *Balancer) Close(ctx context.Context) (err error) {
@@ -423,7 +412,7 @@ func (b *Balancer) wrapCall(ctx context.Context, f func(ctx context.Context, cc 
 	}
 
 	defer func() {
-		if err != nil && cc.GetState() != state.Banned &&
+		if err != nil && cc.State() != state.Banned &&
 			IsBadConn(ctx, err, b.driverConfig.ExcludeGRPCCodesForPessimization()...) {
 			b.pool.Ban(ctx, cc, err)
 		}

--- a/internal/balancer/balancer_test.go
+++ b/internal/balancer/balancer_test.go
@@ -36,20 +36,20 @@ type poolRegisteredConn struct {
 	inner conn.Conn
 }
 
+func (c *poolRegisteredConn) Ban(ctx context.Context) {
+	c.inner.Ban(ctx)
+}
+
 func (c *poolRegisteredConn) Endpoint() endpoint.Endpoint {
 	return c.inner.Endpoint()
 }
 
-func (c *poolRegisteredConn) GetState() state.State {
-	return c.inner.GetState()
+func (c *poolRegisteredConn) State() state.State {
+	return c.inner.State()
 }
 
-func (c *poolRegisteredConn) SetState(ctx context.Context, s state.State) state.State {
-	return c.inner.SetState(ctx, s)
-}
-
-func (c *poolRegisteredConn) Unban(ctx context.Context) state.State {
-	return c.inner.Unban(ctx)
+func (c *poolRegisteredConn) Unban(ctx context.Context) {
+	c.inner.Unban(ctx)
 }
 
 func TestBalancer_discoveryConn(t *testing.T) {
@@ -134,10 +134,10 @@ func TestApplyDiscoveredEndpoints(t *testing.T) {
 	require.NotNil(t, after)
 	all := after.All()
 	require.Equal(t, 2, len(all))
-	require.Equal(t, e1.Address(), all[0].Address())
-	require.Equal(t, e1.NodeID(), all[0].NodeID())
-	require.Equal(t, e2.Address(), all[1].Address())
-	require.Equal(t, e2.NodeID(), all[1].NodeID())
+	require.Equal(t, e1.Address(), all[0].Endpoint().Address())
+	require.Equal(t, e1.NodeID(), all[0].Endpoint().NodeID())
+	require.Equal(t, e2.Address(), all[1].Endpoint().Address())
+	require.Equal(t, e2.NodeID(), all[1].Endpoint().NodeID())
 
 	// partially replace endpoints
 	e3 := endpoint.New("e3.example:2135", endpoint.WithIPV6([]string{"2001:db8::3"}), endpoint.WithID(1))
@@ -147,10 +147,10 @@ func TestApplyDiscoveredEndpoints(t *testing.T) {
 	require.NotNil(t, after)
 	all = after.All()
 	require.Equal(t, 2, len(all))
-	require.Equal(t, e2.Address(), all[0].Address())
-	require.Equal(t, e2.NodeID(), all[0].NodeID())
-	require.Equal(t, e3.Address(), all[1].Address())
-	require.Equal(t, e3.NodeID(), all[1].NodeID())
+	require.Equal(t, e2.Address(), all[0].Endpoint().Address())
+	require.Equal(t, e2.NodeID(), all[0].Endpoint().NodeID())
+	require.Equal(t, e3.Address(), all[1].Endpoint().Address())
+	require.Equal(t, e3.NodeID(), all[1].Endpoint().NodeID())
 }
 
 // Mock resolver
@@ -228,7 +228,7 @@ func TestPessimizationOnOverloaded(t *testing.T) {
 
 			e1 := endpoint.New("node1:2135", endpoint.WithID(1))
 			poolConn := pool.Get(e1)
-			poolConn.SetState(ctx, state.Online)
+			conn.SetState(ctx, poolConn, state.Online)
 
 			cc1 := &poolRegisteredConn{
 				inner:               poolConn,
@@ -247,11 +247,11 @@ func TestPessimizationOnOverloaded(t *testing.T) {
 
 			err := b.Invoke(nodeCtx, "/test.Service/Method", nil, nil)
 			require.NoError(t, err)
-			assert.Equal(t, state.Banned, cc1.GetState())
+			assert.Equal(t, state.Banned, cc1.State())
 
 			err = b.Invoke(nodeCtx, "/test.Service/Method", nil, nil)
 			require.NoError(t, err)
-			assert.Equal(t, state.Banned, cc1.GetState(),
+			assert.Equal(t, state.Banned, cc1.State(),
 				"hint-based ban must remain after a successful RPC when the connection is in the pool",
 			)
 		})
@@ -275,10 +275,10 @@ func TestPessimizationOnOverloaded(t *testing.T) {
 			ClientConnInterface: cc,
 			AddrField:           "node1:2135",
 			NodeIDField:         1,
-			State:               state.Online,
+			StateField:          state.Online,
 		}
 		cc2 := &mock.Conn{
-			AddrField: "node2:2135", NodeIDField: 2, State: state.Online,
+			AddrField: "node2:2135", NodeIDField: 2, StateField: state.Online,
 		}
 
 		cfg := config.New()
@@ -295,7 +295,7 @@ func TestPessimizationOnOverloaded(t *testing.T) {
 
 		err := b.Invoke(endpoint.WithNodeID(ctx, cc1.NodeIDField), "/test.Service/Method", nil, nil)
 		require.NoError(t, err)
-		require.Equal(t, state.Banned, cc1.GetState())
+		require.Equal(t, state.Banned, cc1.State())
 
 		for range 10 {
 			c, nextErr := b.nextConn(ctx)
@@ -318,7 +318,7 @@ func TestPessimizationOnOverloaded(t *testing.T) {
 
 		cc1 := &mock.Conn{
 			ClientConnInterface: cc,
-			AddrField:           "node1:2135", NodeIDField: 1, State: state.Online,
+			AddrField:           "node1:2135", NodeIDField: 1, StateField: state.Online,
 		}
 
 		cfg := config.New()
@@ -335,7 +335,7 @@ func TestPessimizationOnOverloaded(t *testing.T) {
 
 		err := b.Invoke(ctx, "/test.Service/Method", nil, nil)
 		require.NoError(t, err)
-		require.NotEqual(t, state.Banned, cc1.GetState())
+		require.NotEqual(t, state.Banned, cc1.State())
 	})
 
 	t.Run("PessimizedConnectionExcludedFromBalancing", func(t *testing.T) {
@@ -354,13 +354,13 @@ func TestPessimizationOnOverloaded(t *testing.T) {
 			ClientConnInterface: cc,
 			AddrField:           "node1:2135",
 			NodeIDField:         1,
-			State:               state.Online,
+			StateField:          state.Online,
 		}
 		cc2 := &mock.Conn{
 			ClientConnInterface: cc,
 			AddrField:           "node2:2135",
 			NodeIDField:         2,
-			State:               state.Online,
+			StateField:          state.Online,
 		}
 
 		cfg := config.New()
@@ -385,7 +385,7 @@ func TestPessimizationOnOverloaded(t *testing.T) {
 		require.True(t, xerrors.IsOperationError(err, Ydb.StatusIds_OVERLOADED))
 
 		// cc1 must be Banned now.
-		require.Equal(t, state.Banned, cc1.GetState())
+		require.Equal(t, state.Banned, cc1.State())
 
 		// nextConn must only return cc2 now.
 		for range 100 {
@@ -411,7 +411,7 @@ func TestPessimizationOnOverloaded(t *testing.T) {
 
 		cc1 := &mock.Conn{
 			ClientConnInterface: cc,
-			AddrField:           "node1:2135", NodeIDField: 1, State: state.Online,
+			AddrField:           "node1:2135", NodeIDField: 1, StateField: state.Online,
 		}
 
 		cfg := config.New()
@@ -430,7 +430,7 @@ func TestPessimizationOnOverloaded(t *testing.T) {
 		invokeCtx := BanOnOperationError(ctx, Ydb.StatusIds_OVERLOADED)
 		err := b.Invoke(invokeCtx, "/test.Service/Method", nil, nil)
 		require.Error(t, err)
-		require.NotEqual(t, state.Banned, cc1.GetState())
+		require.NotEqual(t, state.Banned, cc1.State())
 	})
 
 	t.Run("BansConnectionOnUnavailableForSessionCreate", func(t *testing.T) {
@@ -452,13 +452,13 @@ func TestPessimizationOnOverloaded(t *testing.T) {
 			ClientConnInterface: cc,
 			AddrField:           "node1:2135",
 			NodeIDField:         1,
-			State:               state.Online,
+			StateField:          state.Online,
 		}
 		cc2 := &mock.Conn{
 			ClientConnInterface: cc,
 			AddrField:           "node2:2135",
 			NodeIDField:         2,
-			State:               state.Online,
+			StateField:          state.Online,
 		}
 
 		cfg := config.New()
@@ -476,7 +476,7 @@ func TestPessimizationOnOverloaded(t *testing.T) {
 		invokeCtx := BanOnSessionCreate(endpoint.WithNodeID(ctx, cc1.NodeIDField))
 		err := b.Invoke(invokeCtx, "/Ydb.Query.V1.QueryService/CreateSession", nil, nil)
 		require.Error(t, err)
-		require.Equal(t, state.Banned, cc1.GetState())
+		require.Equal(t, state.Banned, cc1.State())
 
 		for range 10 {
 			c, nextErr := b.nextConn(ctx)
@@ -501,13 +501,13 @@ func TestPessimizationOnOverloaded(t *testing.T) {
 			ClientConnInterface: cc,
 			AddrField:           "node1:2135",
 			NodeIDField:         1,
-			State:               state.Online,
+			StateField:          state.Online,
 		}
 		cc2 := &mock.Conn{
 			ClientConnInterface: cc,
 			AddrField:           "node2:2135",
 			NodeIDField:         2,
-			State:               state.Online,
+			StateField:          state.Online,
 		}
 
 		cfg := config.New()
@@ -525,7 +525,7 @@ func TestPessimizationOnOverloaded(t *testing.T) {
 		invokeCtx := BanOnSessionCreate(endpoint.WithNodeID(ctx, cc1.NodeIDField))
 		err := b.Invoke(invokeCtx, "/Ydb.Query.V1.QueryService/CreateSession", nil, nil)
 		require.Error(t, err)
-		require.Equal(t, state.Banned, cc1.GetState())
+		require.Equal(t, state.Banned, cc1.State())
 
 		for range 10 {
 			c, nextErr := b.nextConn(ctx)
@@ -548,11 +548,11 @@ func TestPessimizationOnOverloaded(t *testing.T) {
 
 		cc1 := &mock.Conn{
 			ClientConnInterface: cc,
-			AddrField:           "node1:2135", NodeIDField: 1, State: state.Online,
+			AddrField:           "node1:2135", NodeIDField: 1, StateField: state.Online,
 		}
 		cc2 := &mock.Conn{
 			ClientConnInterface: cc,
-			AddrField:           "node2:2135", NodeIDField: 2, State: state.Online,
+			AddrField:           "node2:2135", NodeIDField: 2, StateField: state.Online,
 		}
 
 		cfg := config.New()
@@ -571,19 +571,19 @@ func TestPessimizationOnOverloaded(t *testing.T) {
 		cc1Ctx := BanOnOperationError(endpoint.WithNodeID(ctx, cc1.NodeIDField), Ydb.StatusIds_OVERLOADED)
 		err := b.Invoke(cc1Ctx, "/test.Service/Method", nil, nil)
 		require.Error(t, err)
-		require.Equal(t, state.Banned, cc1.GetState())
+		require.Equal(t, state.Banned, cc1.State())
 
 		cc2Ctx := BanOnOperationError(endpoint.WithNodeID(ctx, cc2.NodeIDField), Ydb.StatusIds_OVERLOADED)
 		err = b.Invoke(cc2Ctx, "/test.Service/Method", nil, nil)
 		require.Error(t, err)
-		require.Equal(t, state.Banned, cc2.GetState())
+		require.Equal(t, state.Banned, cc2.State())
 
 		// When all connections are banned, the balancer must still return a connection
 		// (falling back to the banned connections pool so callers can retry).
 		c, err := b.nextConn(ctx)
 		require.NoError(t, err)
 		require.NotNil(t, c)
-		require.Equal(t, state.Banned, c.GetState())
+		require.Equal(t, state.Banned, c.State())
 	})
 
 	t.Run("StreamSendMsgErrorBansConnection", func(t *testing.T) {
@@ -604,9 +604,9 @@ func TestPessimizationOnOverloaded(t *testing.T) {
 
 		cc1 := &mock.Conn{
 			ClientConnInterface: cc,
-			AddrField:           "node1:2135", NodeIDField: 1, State: state.Online,
+			AddrField:           "node1:2135", NodeIDField: 1, StateField: state.Online,
 		}
-		cc2 := &mock.Conn{AddrField: "node2:2135", NodeIDField: 2, State: state.Online}
+		cc2 := &mock.Conn{AddrField: "node2:2135", NodeIDField: 2, StateField: state.Online}
 
 		cfg := config.New()
 		pool := conn.NewPool(ctx, cfg)
@@ -631,7 +631,7 @@ func TestPessimizationOnOverloaded(t *testing.T) {
 		err = stream.SendMsg(nil)
 		require.Error(t, err)
 		require.True(t, xerrors.IsOperationError(err, Ydb.StatusIds_OVERLOADED))
-		require.Equal(t, state.Banned, cc1.GetState())
+		require.Equal(t, state.Banned, cc1.State())
 
 		for range 10 {
 			c, nextErr := b.nextConn(ctx)
@@ -658,9 +658,9 @@ func TestPessimizationOnOverloaded(t *testing.T) {
 
 		cc1 := &mock.Conn{
 			ClientConnInterface: cc,
-			AddrField:           "node1:2135", NodeIDField: 1, State: state.Online,
+			AddrField:           "node1:2135", NodeIDField: 1, StateField: state.Online,
 		}
-		cc2 := &mock.Conn{AddrField: "node2:2135", NodeIDField: 2, State: state.Online}
+		cc2 := &mock.Conn{AddrField: "node2:2135", NodeIDField: 2, StateField: state.Online}
 
 		cfg := config.New()
 		pool := conn.NewPool(ctx, cfg)
@@ -685,7 +685,7 @@ func TestPessimizationOnOverloaded(t *testing.T) {
 		err = stream.RecvMsg(nil)
 		require.Error(t, err)
 		require.True(t, xerrors.IsOperationError(err, Ydb.StatusIds_OVERLOADED))
-		require.Equal(t, state.Banned, cc1.GetState())
+		require.Equal(t, state.Banned, cc1.State())
 
 		for range 10 {
 			c, nextErr := b.nextConn(ctx)

--- a/internal/balancer/connections_state.go
+++ b/internal/balancer/connections_state.go
@@ -2,6 +2,7 @@ package balancer
 
 import (
 	"context"
+	"slices"
 
 	balancerConfig "github.com/ydb-platform/ydb-go-sdk/v3/internal/balancer/config"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/conn"
@@ -45,17 +46,12 @@ func (s *connectionsState) PreferredCount() int {
 	return len(s.prefer)
 }
 
-func (s *connectionsState) All() (all []endpoint.Endpoint) {
+func (s *connectionsState) All() []conn.Conn {
 	if s == nil {
 		return nil
 	}
 
-	all = make([]endpoint.Endpoint, len(s.all))
-	for i, c := range s.all {
-		all[i] = c.Endpoint()
-	}
-
-	return all
+	return slices.Clone(s.all)
 }
 
 func (s *connectionsState) GetConnection(ctx context.Context) (_ conn.Conn, failedCount int) {
@@ -172,7 +168,7 @@ func sortPreferConnections(
 }
 
 func isOkConnection(c conn.Conn, bannedIsOk bool) bool {
-	switch c.GetState() {
+	switch c.State() {
 	case state.Online, state.Created, state.Offline:
 		return true
 	case state.Banned:

--- a/internal/balancer/connections_state_test.go
+++ b/internal/balancer/connections_state_test.go
@@ -171,24 +171,24 @@ func TestSelectRandomConnection(t *testing.T) {
 
 	t.Run("One", func(t *testing.T) {
 		for _, goodState := range []state.State{state.Online, state.Offline, state.Created} {
-			c, failedCount := s.selectRandomConnection([]conn.Conn{&mock.Conn{AddrField: "asd", State: goodState}}, false)
-			require.Equal(t, &mock.Conn{AddrField: "asd", State: goodState}, c)
+			c, failedCount := s.selectRandomConnection([]conn.Conn{&mock.Conn{AddrField: "asd", StateField: goodState}}, false)
+			require.Equal(t, &mock.Conn{AddrField: "asd", StateField: goodState}, c)
 			require.Equal(t, 0, failedCount)
 		}
 	})
 	t.Run("OneBanned", func(t *testing.T) {
-		c, failedCount := s.selectRandomConnection([]conn.Conn{&mock.Conn{AddrField: "asd", State: state.Banned}}, false)
+		c, failedCount := s.selectRandomConnection([]conn.Conn{&mock.Conn{AddrField: "asd", StateField: state.Banned}}, false)
 		require.Nil(t, c)
 		require.Equal(t, 1, failedCount)
 
-		c, failedCount = s.selectRandomConnection([]conn.Conn{&mock.Conn{AddrField: "asd", State: state.Banned}}, true)
-		require.Equal(t, &mock.Conn{AddrField: "asd", State: state.Banned}, c)
+		c, failedCount = s.selectRandomConnection([]conn.Conn{&mock.Conn{AddrField: "asd", StateField: state.Banned}}, true)
+		require.Equal(t, &mock.Conn{AddrField: "asd", StateField: state.Banned}, c)
 		require.Equal(t, 0, failedCount)
 	})
 	t.Run("Two", func(t *testing.T) {
 		conns := []conn.Conn{
-			&mock.Conn{AddrField: "1", State: state.Online},
-			&mock.Conn{AddrField: "2", State: state.Online},
+			&mock.Conn{AddrField: "1", StateField: state.Online},
+			&mock.Conn{AddrField: "2", StateField: state.Online},
 		}
 		first := 0
 		second := 0
@@ -206,8 +206,8 @@ func TestSelectRandomConnection(t *testing.T) {
 	})
 	t.Run("TwoBanned", func(t *testing.T) {
 		conns := []conn.Conn{
-			&mock.Conn{AddrField: "1", State: state.Banned},
-			&mock.Conn{AddrField: "2", State: state.Banned},
+			&mock.Conn{AddrField: "1", StateField: state.Banned},
+			&mock.Conn{AddrField: "2", StateField: state.Banned},
 		}
 		totalFailed := 0
 		for range 100 {
@@ -219,9 +219,9 @@ func TestSelectRandomConnection(t *testing.T) {
 	})
 	t.Run("ThreeWithBanned", func(t *testing.T) {
 		conns := []conn.Conn{
-			&mock.Conn{AddrField: "1", State: state.Online},
-			&mock.Conn{AddrField: "2", State: state.Online},
-			&mock.Conn{AddrField: "3", State: state.Banned},
+			&mock.Conn{AddrField: "1", StateField: state.Online},
+			&mock.Conn{AddrField: "2", StateField: state.Online},
+			&mock.Conn{AddrField: "3", StateField: state.Banned},
 		}
 		first := 0
 		second := 0
@@ -397,8 +397,8 @@ func TestConnection(t *testing.T) {
 	})
 	t.Run("AllGood", func(t *testing.T) {
 		s := newConnectionsState([]conn.Conn{
-			&mock.Conn{AddrField: "1", State: state.Online},
-			&mock.Conn{AddrField: "2", State: state.Online},
+			&mock.Conn{AddrField: "1", StateField: state.Online},
+			&mock.Conn{AddrField: "2", StateField: state.Online},
 		}, nil, balancerConfig.Info{}, false)
 		c, failed := s.GetConnection(context.Background())
 		require.NotNil(t, c)
@@ -406,16 +406,16 @@ func TestConnection(t *testing.T) {
 	})
 	t.Run("WithBanned", func(t *testing.T) {
 		s := newConnectionsState([]conn.Conn{
-			&mock.Conn{AddrField: "1", State: state.Online},
-			&mock.Conn{AddrField: "2", State: state.Banned},
+			&mock.Conn{AddrField: "1", StateField: state.Online},
+			&mock.Conn{AddrField: "2", StateField: state.Banned},
 		}, nil, balancerConfig.Info{}, false)
 		c, _ := s.GetConnection(context.Background())
-		require.Equal(t, &mock.Conn{AddrField: "1", State: state.Online}, c)
+		require.Equal(t, &mock.Conn{AddrField: "1", StateField: state.Online}, c)
 	})
 	t.Run("AllBanned", func(t *testing.T) {
 		s := newConnectionsState([]conn.Conn{
-			&mock.Conn{AddrField: "t1", State: state.Banned, LocationField: "t"},
-			&mock.Conn{AddrField: "f2", State: state.Banned, LocationField: "f"},
+			&mock.Conn{AddrField: "t1", StateField: state.Banned, LocationField: "t"},
+			&mock.Conn{AddrField: "f2", StateField: state.Banned, LocationField: "f"},
 		}, filterFunc(func(info balancerConfig.Info, e endpoint.Info) bool {
 			return e.Location() == info.SelfLocation
 		}), balancerConfig.Info{}, true)
@@ -437,36 +437,36 @@ func TestConnection(t *testing.T) {
 	})
 	t.Run("PreferBannedWithFallback", func(t *testing.T) {
 		s := newConnectionsState([]conn.Conn{
-			&mock.Conn{AddrField: "t1", State: state.Banned, LocationField: "t"},
-			&mock.Conn{AddrField: "f2", State: state.Online, LocationField: "f"},
+			&mock.Conn{AddrField: "t1", StateField: state.Banned, LocationField: "t"},
+			&mock.Conn{AddrField: "f2", StateField: state.Online, LocationField: "f"},
 		}, filterFunc(func(info balancerConfig.Info, e endpoint.Info) bool {
 			return e.Location() == info.SelfLocation
 		}), balancerConfig.Info{SelfLocation: "t"}, true)
 		c, failed := s.GetConnection(context.Background())
-		require.Equal(t, &mock.Conn{AddrField: "f2", State: state.Online, LocationField: "f"}, c)
+		require.Equal(t, &mock.Conn{AddrField: "f2", StateField: state.Online, LocationField: "f"}, c)
 		require.Equal(t, 1, failed)
 	})
 	t.Run("PreferNodeID", func(t *testing.T) {
 		s := newConnectionsState([]conn.Conn{
-			&mock.Conn{AddrField: "1", State: state.Online, NodeIDField: 1},
-			&mock.Conn{AddrField: "2", State: state.Online, NodeIDField: 2},
+			&mock.Conn{AddrField: "1", StateField: state.Online, NodeIDField: 1},
+			&mock.Conn{AddrField: "2", StateField: state.Online, NodeIDField: 2},
 		}, nil, balancerConfig.Info{}, false)
 		c, failed := s.GetConnection(endpoint.WithNodeID(context.Background(), 2))
-		require.Equal(t, &mock.Conn{AddrField: "2", State: state.Online, NodeIDField: 2}, c)
+		require.Equal(t, &mock.Conn{AddrField: "2", StateField: state.Online, NodeIDField: 2}, c)
 		require.Equal(t, 0, failed)
 	})
 	t.Run("PreferNodeIDWithBadState", func(t *testing.T) {
 		s := newConnectionsState([]conn.Conn{
-			&mock.Conn{AddrField: "1", State: state.Online, NodeIDField: 1},
-			&mock.Conn{AddrField: "2", State: state.Unknown, NodeIDField: 2},
+			&mock.Conn{AddrField: "1", StateField: state.Online, NodeIDField: 1},
+			&mock.Conn{AddrField: "2", StateField: state.Unknown, NodeIDField: 2},
 		}, nil, balancerConfig.Info{}, false)
 		c, failed := s.GetConnection(endpoint.WithNodeID(context.Background(), 2))
-		require.Equal(t, &mock.Conn{AddrField: "1", State: state.Online, NodeIDField: 1}, c)
+		require.Equal(t, &mock.Conn{AddrField: "1", StateField: state.Online, NodeIDField: 1}, c)
 		require.Equal(t, 0, failed)
 	})
 	t.Run("FallbackDisabledMissingNode", func(t *testing.T) {
 		s := newConnectionsState([]conn.Conn{
-			&mock.Conn{AddrField: "1", State: state.Online, NodeIDField: 1},
+			&mock.Conn{AddrField: "1", StateField: state.Online, NodeIDField: 1},
 		}, nil, balancerConfig.Info{}, false)
 		c, failed := s.GetConnection(endpoint.WithNodeID(context.Background(), 2, endpoint.WithFallback(false)))
 		require.Nil(t, c)
@@ -474,8 +474,8 @@ func TestConnection(t *testing.T) {
 	})
 	t.Run("FallbackDisabledBadStateNoFallback", func(t *testing.T) {
 		s := newConnectionsState([]conn.Conn{
-			&mock.Conn{AddrField: "1", State: state.Online, NodeIDField: 1},
-			&mock.Conn{AddrField: "2", State: state.Unknown, NodeIDField: 2},
+			&mock.Conn{AddrField: "1", StateField: state.Online, NodeIDField: 1},
+			&mock.Conn{AddrField: "2", StateField: state.Unknown, NodeIDField: 2},
 		}, nil, balancerConfig.Info{}, false)
 		c, failed := s.GetConnection(endpoint.WithNodeID(context.Background(), 2, endpoint.WithFallback(false)))
 		require.Nil(t, c)
@@ -483,11 +483,11 @@ func TestConnection(t *testing.T) {
 	})
 	t.Run("FallbackDisabledUsesPreferredNode", func(t *testing.T) {
 		s := newConnectionsState([]conn.Conn{
-			&mock.Conn{AddrField: "1", State: state.Online, NodeIDField: 1},
-			&mock.Conn{AddrField: "2", State: state.Online, NodeIDField: 2},
+			&mock.Conn{AddrField: "1", StateField: state.Online, NodeIDField: 1},
+			&mock.Conn{AddrField: "2", StateField: state.Online, NodeIDField: 2},
 		}, nil, balancerConfig.Info{}, false)
 		c, failed := s.GetConnection(endpoint.WithNodeID(context.Background(), 2, endpoint.WithFallback(false)))
-		require.Equal(t, &mock.Conn{AddrField: "2", State: state.Online, NodeIDField: 2}, c)
+		require.Equal(t, &mock.Conn{AddrField: "2", StateField: state.Online, NodeIDField: 2}, c)
 		require.Equal(t, 0, failed)
 	})
 }

--- a/internal/conn/conn.go
+++ b/internal/conn/conn.go
@@ -39,9 +39,9 @@ type Conn interface {
 	grpc.ClientConnInterface
 
 	Endpoint() endpoint.Endpoint
-	GetState() state.State
-	SetState(ctx context.Context, state state.State) state.State
-	Unban(ctx context.Context) state.State
+	State() state.State
+	Unban(ctx context.Context)
+	Ban(ctx context.Context)
 }
 
 type (
@@ -57,15 +57,16 @@ type (
 		GetState() connectivity.State
 	}
 	conn struct {
-		mtx          sync.RWMutex
-		config       connConfig // ro access
-		grpcConn     grpcClientConnInterface
-		done         chan struct{}
-		endpoint     endpoint.Endpoint // ro access
-		closed       bool
-		state        atomic.Uint32
-		childStreams *xcontext.CancelsGuard
-		onClose      []func(*conn)
+		mtx                     sync.RWMutex
+		config                  connConfig // ro access
+		grpcConn                grpcClientConnInterface
+		done                    chan struct{}
+		endpoint                endpoint.Endpoint // ro access
+		closed                  bool
+		state                   atomic.Uint32
+		lastClusterAnnouncement atomic.Int64
+		childStreams            *xcontext.CancelsGuard
+		onClose                 []func(*conn)
 	}
 )
 
@@ -83,14 +84,20 @@ func (c *conn) NodeID() uint32 {
 
 func (c *conn) Endpoint() endpoint.Endpoint {
 	if c != nil {
-		return c.endpoint
+		return c.endpoint.Copy(
+			endpoint.WithLastUpdated(time.Unix(c.lastClusterAnnouncement.Load(), 0)),
+		)
 	}
 
 	return nil
 }
 
-func (c *conn) SetState(ctx context.Context, s state.State) state.State {
-	return c.setState(ctx, s)
+func SetState(ctx context.Context, c Conn, s state.State) state.State {
+	if cc, ok := c.(*conn); ok {
+		return cc.setState(ctx, s)
+	}
+
+	return s
 }
 
 func (c *conn) setState(ctx context.Context, s state.State) state.State {
@@ -98,14 +105,14 @@ func (c *conn) setState(ctx context.Context, s state.State) state.State {
 		gtrace.DriverOnConnStateChange(
 			c.config.Trace(), &ctx,
 			stack.FunctionID("github.com/ydb-platform/ydb-go-sdk/v3/internal/conn.(*conn).setState"),
-			c.endpoint.Copy(), state,
+			c.Endpoint(), state,
 		)(s)
 	}
 
 	return s
 }
 
-func (c *conn) Unban(ctx context.Context) state.State {
+func (c *conn) unban(ctx context.Context) state.State {
 	var newState state.State
 	c.mtx.RLock()
 	cc := c.grpcConn
@@ -121,7 +128,19 @@ func (c *conn) Unban(ctx context.Context) state.State {
 	return newState
 }
 
-func (c *conn) GetState() (s state.State) {
+func (c *conn) Unban(ctx context.Context) {
+	gtrace.DriverOnConnAllow(
+		c.config.Trace(), &ctx,
+		stack.FunctionID("github.com/ydb-platform/ydb-go-sdk/v3/internal/conn.(*conn).Unban"),
+		c.Endpoint(), c.State(),
+	)(c.unban(ctx))
+}
+
+func (c *conn) Ban(ctx context.Context) {
+	c.setState(ctx, state.Banned)
+}
+
+func (c *conn) State() (s state.State) {
 	return state.State(c.state.Load())
 }
 
@@ -145,7 +164,7 @@ func (c *conn) dial(ctx context.Context) (cc grpcClientConnInterface, err error)
 	onDone := gtrace.DriverOnConnDial(
 		c.config.Trace(), &ctx,
 		stack.FunctionID("github.com/ydb-platform/ydb-go-sdk/v3/internal/conn.(*conn).dial"),
-		c.endpoint.Copy(),
+		c.Endpoint(),
 	)
 	defer func() {
 		onDone(err)
@@ -377,14 +396,14 @@ func (c *conn) Invoke(
 		onDone = gtrace.DriverOnConnInvoke(
 			c.config.Trace(), &ctx,
 			stack.FunctionID("github.com/ydb-platform/ydb-go-sdk/v3/internal/conn.(*conn).Invoke"),
-			c.endpoint, trace.Method(method),
+			c.Endpoint(), trace.Method(method),
 		)
 		cc grpcClientConnInterface
 		md = metadata.MD{}
 	)
 	defer func() {
 		meta.CallTrailerCallback(ctx, md)
-		onDone(err, issues, opID, c.GetState(), md)
+		onDone(err, issues, opID, c.State(), md)
 	}()
 
 	cc, err = c.realConn(ctx)
@@ -417,13 +436,13 @@ func (c *conn) NewStream(
 		onDone = gtrace.DriverOnConnNewStream(
 			c.config.Trace(), &ctx,
 			stack.FunctionID("github.com/ydb-platform/ydb-go-sdk/v3/internal/conn.(*conn).NewStream"),
-			c.endpoint.Copy(), trace.Method(method),
+			c.Endpoint(), trace.Method(method),
 		)
 		useWrapping = UseWrapping(ctx)
 	)
 
 	defer func() {
-		onDone(finalErr, c.GetState())
+		onDone(finalErr, c.State())
 	}()
 
 	cc, err := c.realConn(ctx)
@@ -504,7 +523,10 @@ func newConn(e endpoint.Endpoint, config connConfig, opts ...option) *conn {
 			},
 		},
 	}
+
 	c.state.Store(uint32(state.Created))
+	c.lastClusterAnnouncement.Store(time.Now().Unix())
+
 	for _, opt := range opts {
 		if opt != nil {
 			opt(c)

--- a/internal/conn/conn_test.go
+++ b/internal/conn/conn_test.go
@@ -270,7 +270,7 @@ func TestConn_StateManagement(t *testing.T) {
 		}
 		e := endpoint.New("test-endpoint:2135")
 		c := newConn(e, config)
-		require.Equal(t, state.Created, c.GetState())
+		require.Equal(t, state.Created, c.State())
 	})
 
 	t.Run("EndpointMethodsWork", func(t *testing.T) {

--- a/internal/conn/pool.go
+++ b/internal/conn/pool.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/closer"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/conn/gtrace"
-	"github.com/ydb-platform/ydb-go-sdk/v3/internal/conn/state"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/endpoint"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/stack"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
@@ -56,6 +55,8 @@ func (p *Pool) Get(endpoint endpoint.Endpoint) Conn {
 	)
 
 	if cc, has = p.conns.Get(endpoint.Key()); has {
+		cc.lastClusterAnnouncement.Store(time.Now().Unix())
+
 		return cc
 	}
 
@@ -84,30 +85,15 @@ func (p *Pool) Ban(ctx context.Context, cc Conn, cause error) {
 		return
 	}
 
-	gtrace.DriverOnConnBan(
+	onDone := gtrace.DriverOnConnBan(
 		p.config.Trace(), &ctx,
 		stack.FunctionID("github.com/ydb-platform/ydb-go-sdk/v3/internal/conn.(*Pool).Ban"),
-		cc.Endpoint().Copy(), cc.GetState(), cause,
-	)(cc.SetState(ctx, state.Banned))
-}
+		cc.Endpoint(), cc.State(), cause,
+	)
 
-func (p *Pool) Allow(ctx context.Context, cc Conn) {
-	if p.isClosed() {
-		return
-	}
+	cc.Ban(ctx)
 
-	e := cc.Endpoint().Copy()
-
-	cc, ok := p.conns.Get(e.Key())
-	if !ok {
-		return
-	}
-
-	gtrace.DriverOnConnAllow(
-		p.config.Trace(), &ctx,
-		stack.FunctionID("github.com/ydb-platform/ydb-go-sdk/v3/internal/conn.(*Pool).Allow"),
-		e, cc.GetState(),
-	)(cc.Unban(ctx))
+	onDone(cc.State())
 }
 
 func (p *Pool) Take(context.Context) error {

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -107,7 +107,7 @@ func (c *Client) Discover(ctx context.Context) (endpoints []endpoint.Endpoint, f
 	defer func() {
 		nodes := make([]trace.EndpointInfo, 0, len(endpoints))
 		for _, e := range endpoints {
-			nodes = append(nodes, e.Copy())
+			nodes = append(nodes, e)
 		}
 		onDone(location, nodes, finalErr)
 	}()

--- a/internal/endpoint/endpoint.go
+++ b/internal/endpoint/endpoint.go
@@ -2,6 +2,7 @@ package endpoint
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 )
@@ -14,7 +15,6 @@ type (
 		NodeID
 		Address() string
 		Location() string
-		LastUpdated() time.Time
 		LoadFactor() float32
 		OverrideHost() string
 
@@ -33,9 +33,10 @@ type (
 		Info
 
 		String() string
-		Copy() Endpoint
-		Touch(opts ...Option)
 		Key() Key
+		LastUpdated() time.Time
+
+		Copy(opts ...Option) Endpoint
 	}
 )
 
@@ -63,11 +64,11 @@ func (e *endpoint) Key() Key {
 	}
 }
 
-func (e *endpoint) Copy() Endpoint {
+func (e *endpoint) Copy(opts ...Option) Endpoint {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 
-	return &endpoint{
+	c := &endpoint{
 		id:              e.id,
 		address:         e.address,
 		location:        e.location,
@@ -79,6 +80,14 @@ func (e *endpoint) Copy() Endpoint {
 		local:           e.local,
 		lastUpdated:     e.lastUpdated,
 	}
+
+	for _, opt := range opts {
+		if opt != nil {
+			opt(c)
+		}
+	}
+
+	return c
 }
 
 func (e *endpoint) String() string {
@@ -181,16 +190,6 @@ func (e *endpoint) LastUpdated() time.Time {
 	return e.lastUpdated
 }
 
-func (e *endpoint) Touch(opts ...Option) {
-	e.mu.Lock()
-	defer e.mu.Unlock()
-	for _, opt := range append([]Option{WithLastUpdated(time.Now())}, opts...) {
-		if opt != nil {
-			opt(e)
-		}
-	}
-}
-
 type Option func(e *endpoint)
 
 func WithID(id uint32) Option {
@@ -259,4 +258,20 @@ func New(address string, opts ...Option) *endpoint {
 	}
 
 	return e
+}
+
+// Compare orders two discovery endpoints for stable diffing of endpoint snapshots.
+func Compare(lhs, rhs Endpoint) int {
+	cmp := strings.Compare(lhs.Address(), rhs.Address())
+	if cmp != 0 {
+		return cmp
+	}
+	if lhs.NodeID() < rhs.NodeID() {
+		return -1
+	}
+	if lhs.NodeID() > rhs.NodeID() {
+		return 1
+	}
+
+	return strings.Compare(lhs.OverrideHost(), rhs.OverrideHost())
 }

--- a/internal/mock/conn.go
+++ b/internal/mock/conn.go
@@ -19,7 +19,7 @@ type Conn struct {
 	AddrField     string
 	LocationField string
 	NodeIDField   uint32
-	State         state.State
+	StateField    state.State
 	LocalDCField  bool
 }
 
@@ -32,20 +32,16 @@ func (c *Conn) Endpoint() endpoint.Endpoint {
 	}
 }
 
-func (c *Conn) GetState() state.State {
-	return c.State
+func (c *Conn) State() state.State {
+	return c.StateField
 }
 
-func (c *Conn) SetState(ctx context.Context, state state.State) state.State {
-	c.State = state
-
-	return c.State
+func (c *Conn) Unban(ctx context.Context) {
+	c.StateField = state.Online
 }
 
-func (c *Conn) Unban(ctx context.Context) state.State {
-	c.SetState(ctx, state.Online)
-
-	return state.Online
+func (c *Conn) Ban(ctx context.Context) {
+	c.StateField = state.Banned
 }
 
 type Endpoint struct {
@@ -103,11 +99,8 @@ func (e *Endpoint) String() string {
 	panic("not implemented in mock")
 }
 
-func (e *Endpoint) Copy() endpoint.Endpoint {
+func (e *Endpoint) Copy(...endpoint.Option) endpoint.Endpoint {
 	c := *e
 
 	return &c
-}
-
-func (e *Endpoint) Touch(opts ...endpoint.Option) {
 }


### PR DESCRIPTION
## Summary

Extracts interface and API cleanup from #2235 into a standalone PR to reduce review scope of the ref-counting/quarantine change.

- `conn.Conn`: `GetState` → `State`, `SetState` moved to package-level `conn.SetState`, `Unban`/`Ban` become void methods with tracing on `Unban`
- `endpoint.Endpoint`: `Copy(opts ...Option)` replaces parameterless `Copy`, `Touch` removed, `endpoint.Compare` added for stable discovery diffs
- `connectionsState.All()` returns `[]conn.Conn` instead of `[]endpoint.Endpoint`
- `pool.Allow` removed; discovery calls `conn.Unban` directly
- `lastUpdated` tracked on `conn` and exposed via `Endpoint().Copy(endpoint.WithLastUpdated(...))`

## Test plan

- [x] `go test -race ./internal/conn/...`
- [x] `go test -race ./internal/balancer/...`
- [x] `go test -race ./balancers/...`

## Related

- Prerequisite for #2235


Made with [Cursor](https://cursor.com)