### PR TITLE
feat(balancer): add IPv6-only endpoint filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Added experimental `balancers.OnlyIPVersion` to use only IPv6 endpoints
+
 * Removed background connection parking (`connParker`), `conn.lastUsage` tracking and `xsync.LastUsage`
 * Deprecated `WithConnectionTTL`: the option is now a no-op
 

--- a/balancers/balancers.go
+++ b/balancers/balancers.go
@@ -1,6 +1,7 @@
 package balancers
 
 import (
+	"fmt"
 	"slices"
 	"sort"
 	"strings"
@@ -8,6 +9,18 @@ import (
 	balancerConfig "github.com/ydb-platform/ydb-go-sdk/v3/internal/balancer/config"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/endpoint"
 	"github.com/ydb-platform/ydb-go-sdk/v3/pkg/xstring"
+)
+
+// IPVersion identifies a requested IP address version.
+//
+// Experimental: https://github.com/ydb-platform/ydb-go-sdk/blob/master/VERSIONING.md#experimental
+type IPVersion = balancerConfig.IPVersion
+
+const (
+	// IPv6 selects IPv6 addresses.
+	//
+	// Experimental: https://github.com/ydb-platform/ydb-go-sdk/blob/master/VERSIONING.md#experimental
+	IPv6 = balancerConfig.IPv6
 )
 
 // Deprecated: RoundRobin is an alias to RandomChoice now
@@ -126,6 +139,23 @@ func PreferLocations(balancer *balancerConfig.Config, locations ...string) *bala
 func PreferLocationsWithFallback(balancer *balancerConfig.Config, locations ...string) *balancerConfig.Config {
 	balancer = PreferLocations(balancer, locations...)
 	balancer.AllowFallback = true
+
+	return balancer
+}
+
+// OnlyIPVersion creates a balancer that establishes connections only to addresses of the specified IP version.
+//
+// IPv6 is the only supported IP version. FQDNs received from discovery are resolved by gRPC and all IPv6
+// addresses are retained. IPv4 addresses are not passed to gRPC for connection attempts.
+//
+// Experimental: https://github.com/ydb-platform/ydb-go-sdk/blob/master/VERSIONING.md#experimental
+func OnlyIPVersion(balancer *balancerConfig.Config, version IPVersion) *balancerConfig.Config {
+	switch version {
+	case IPv6:
+		balancer.IPVersion = version
+	default:
+		panic(fmt.Sprintf("unsupported IP version: %d", version))
+	}
 
 	return balancer
 }

--- a/balancers/balancers_test.go
+++ b/balancers/balancers_test.go
@@ -23,6 +23,18 @@ func TestPreferLocalDC(t *testing.T) {
 	require.Equal(t, []conn.Conn{conns[1], conns[2]}, applyPreferFilter(balancerConfig.Info{SelfLocation: "2"}, rr, conns))
 }
 
+func TestOnlyIPVersion(t *testing.T) {
+	t.Run("IPv6", func(t *testing.T) {
+		balancer := OnlyIPVersion(RandomChoice(), IPv6)
+		require.Equal(t, IPv6, balancer.IPVersion)
+	})
+	t.Run("Unsupported", func(t *testing.T) {
+		require.Panics(t, func() {
+			OnlyIPVersion(RandomChoice(), IPVersion(2))
+		})
+	})
+}
+
 func TestPreferLocalDCWithFallBack(t *testing.T) {
 	conns := []conn.Conn{
 		&mock.Conn{AddrField: "1", LocationField: "1"},

--- a/internal/balancer/balancer.go
+++ b/internal/balancer/balancer.go
@@ -130,7 +130,7 @@ func (b *Balancer) discoveryConn(ctx context.Context) (*grpc.ClientConn, error) 
 		append(
 			b.driverConfig.GrpcDialOptions(),
 			grpc.WithResolvers(
-				xresolver.New("ydb", b.driverConfig.Trace()),
+				xresolver.New(b.driverConfig.Trace(), b.balancerConfig.IPVersion.AddressFilter()),
 			),
 			grpc.WithBlock(), //nolint:staticcheck,nolintlint
 		)...,
@@ -313,30 +313,34 @@ func New(ctx context.Context, driverConfig *config.Config, pool *conn.Pool, opts
 	}()
 
 	b = &Balancer{
-		driverConfig: driverConfig,
-		pool:         pool,
-		address:      "ydb:///" + driverConfig.Endpoint(),
-		discoveryConfig: discoveryConfig.New(append(opts,
-			discoveryConfig.With(driverConfig.Common),
-			discoveryConfig.WithEndpoint(driverConfig.Endpoint()),
-			discoveryConfig.WithDatabase(driverConfig.Database()),
-			discoveryConfig.WithSecure(driverConfig.Secure()),
-			discoveryConfig.WithMeta(driverConfig.Meta()),
-		)...),
+		driverConfig:    driverConfig,
+		pool:            pool,
+		address:         xresolver.Target(driverConfig.Endpoint()),
 		localDCDetector: detectLocalDC,
 	}
-
-	b.discover = makeDiscoveryFunc(b.driverConfig, b.discoveryConfig)
 
 	if config := driverConfig.Balancer(); config == nil {
 		b.balancerConfig = balancerConfig.Config{}
 	} else {
 		b.balancerConfig = *config
 	}
+	b.discoveryConfig = discoveryConfig.New(append(opts,
+		discoveryConfig.With(driverConfig.Common),
+		discoveryConfig.WithEndpoint(driverConfig.Endpoint()),
+		discoveryConfig.WithDatabase(driverConfig.Database()),
+		discoveryConfig.WithSecure(driverConfig.Secure()),
+		discoveryConfig.WithMeta(driverConfig.Meta()),
+		discoveryConfig.WithIPVersion(b.balancerConfig.IPVersion),
+	)...)
+	b.discover = makeDiscoveryFunc(b.driverConfig, b.discoveryConfig)
 
 	if b.balancerConfig.SingleConn {
+		opts := []endpoint.Option{}
+		if version := b.balancerConfig.IPVersion; version != balancerConfig.IPVersionUnspecified {
+			opts = append(opts, endpoint.WithAddressFilter(version.String(), version.AddressFilter()))
+		}
 		b.applyDiscoveredEndpoints(ctx, []endpoint.Endpoint{
-			endpoint.New(driverConfig.Endpoint()),
+			endpoint.New(driverConfig.Endpoint(), opts...),
 		}, "")
 	} else {
 		// initialization of balancer state

--- a/internal/balancer/config/routerconfig.go
+++ b/internal/balancer/config/routerconfig.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"fmt"
+	"net"
+	"net/netip"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/endpoint"
 	"github.com/ydb-platform/ydb-go-sdk/v3/pkg/xstring"
@@ -14,6 +16,49 @@ type Config struct {
 	AllowFallback   bool
 	SingleConn      bool
 	DetectNearestDC bool
+	IPVersion       IPVersion
+}
+
+type IPVersion uint8
+
+const (
+	IPVersionUnspecified IPVersion = iota
+	IPv6
+)
+
+func (v IPVersion) String() string {
+	switch v {
+	case IPVersionUnspecified:
+		return "Unspecified"
+	case IPv6:
+		return "IPv6"
+	default:
+		return fmt.Sprintf("IPVersion(%d)", v)
+	}
+}
+
+// AddressFilter returns a resolver address filter for the requested IP version.
+// A nil result means that no IP version restriction is configured.
+func (v IPVersion) AddressFilter() func(string) bool {
+	switch v {
+	case IPVersionUnspecified:
+		return nil
+	case IPv6:
+		return func(address string) bool {
+			host, _, err := net.SplitHostPort(address)
+			if err != nil {
+				return false
+			}
+
+			ip, err := netip.ParseAddr(host)
+
+			return err == nil && ip.Is6() && !ip.Is4In6()
+		}
+	default:
+		return func(string) bool {
+			return false
+		}
+	}
 }
 
 func (c Config) String() string {
@@ -31,6 +76,11 @@ func (c Config) String() string {
 
 	buffer.WriteString(",AllowFallback=")
 	fmt.Fprintf(buffer, "%t", c.AllowFallback)
+
+	if c.IPVersion != IPVersionUnspecified {
+		buffer.WriteString(",IPVersion=")
+		fmt.Fprint(buffer, c.IPVersion)
+	}
 
 	if c.Filter != nil {
 		buffer.WriteString(",Filter=")

--- a/internal/balancer/config/routerconfig_test.go
+++ b/internal/balancer/config/routerconfig_test.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIPVersionAddressFilter(t *testing.T) {
+	require.Equal(t, "Unspecified", IPVersionUnspecified.String())
+	require.Equal(t, "IPv6", IPv6.String())
+	require.Equal(t, "IPVersion(42)", IPVersion(42).String())
+	require.Contains(t, Config{IPVersion: IPv6}.String(), "IPVersion=IPv6")
+
+	require.Nil(t, IPVersionUnspecified.AddressFilter())
+
+	filter := IPv6.AddressFilter()
+	require.NotNil(t, filter)
+	for _, test := range []struct {
+		name    string
+		address string
+		allowed bool
+	}{
+		{name: "IPv6", address: "[2001:db8::1]:2135", allowed: true},
+		{name: "IPv4", address: "192.0.2.1:2135", allowed: false},
+		{name: "IPv4MappedIPv6", address: "[::ffff:192.0.2.1]:2135", allowed: false},
+		{name: "Hostname", address: "node.example:2135", allowed: false},
+		{name: "MissingPort", address: "[2001:db8::1]", allowed: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.allowed, filter(test.address))
+		})
+	}
+
+	unsupported := IPVersion(42).AddressFilter()
+	require.NotNil(t, unsupported)
+	require.False(t, unsupported("[2001:db8::1]:2135"))
+}

--- a/internal/conn/conn.go
+++ b/internal/conn/conn.go
@@ -24,6 +24,7 @@ import (
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/stack"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xcontext"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xresolver"
 	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
 )
 
@@ -50,6 +51,9 @@ type (
 		DialTimeout() time.Duration
 		GrpcDialOptions() []grpc.DialOption
 	}
+	resolverDialOptionConfig interface {
+		resolverDialOption(filter func(string) bool) grpc.DialOption
+	}
 	grpcClientConnInterface interface {
 		grpc.ClientConnInterface
 		io.Closer
@@ -62,6 +66,7 @@ type (
 		grpcConn                grpcClientConnInterface
 		done                    chan struct{}
 		endpoint                endpoint.Endpoint // ro access
+		addressFilter           func(string) bool
 		closed                  bool
 		state                   atomic.Uint32
 		lastClusterAnnouncement atomic.Int64
@@ -179,6 +184,12 @@ func (c *conn) dial(ctx context.Context) (cc grpcClientConnInterface, err error)
 	address := c.endpoint.Address()
 
 	dialOpts := append([]grpc.DialOption{}, c.config.GrpcDialOptions()...)
+	if c.addressFilter != nil {
+		address = xresolver.Target(address)
+		if config, ok := c.config.(resolverDialOptionConfig); ok {
+			dialOpts = append(dialOpts, config.resolverDialOption(c.addressFilter))
+		}
+	}
 
 	dialOpts = append(dialOpts, grpc.WithStatsHandler(statsHandler{}))
 
@@ -513,10 +524,12 @@ func withOnClose(onClose func(*conn)) option {
 
 func newConn(e endpoint.Endpoint, config connConfig, opts ...option) *conn {
 	c := &conn{
-		endpoint:     e,
-		config:       config,
-		done:         make(chan struct{}),
-		childStreams: xcontext.NewCancelsGuard(),
+		endpoint: e,
+		config:   config,
+		done:     make(chan struct{}),
+
+		addressFilter: endpoint.AddressFilter(e),
+		childStreams:  xcontext.NewCancelsGuard(),
 		onClose: []func(*conn){
 			func(c *conn) {
 				c.childStreams.Cancel()

--- a/internal/conn/pool.go
+++ b/internal/conn/pool.go
@@ -160,29 +160,29 @@ func NewPool(ctx context.Context, config Config) *Pool {
 		done:        make(chan struct{}),
 	}
 
-	p.dialOptions = append(p.dialOptions,
-		grpc.WithResolvers(
-			xresolver.New("", gtrace.Compose(config.Trace(), &trace.Driver{
-				OnResolve: func(info trace.DriverResolveStartInfo) func(trace.DriverResolveDoneInfo) {
-					target := info.Target
-					resolved := info.Resolved
-
-					return func(info trace.DriverResolveDoneInfo) {
-						if info.Error != nil || len(resolved) == 0 {
-							p.conns.Range(func(key endpoint.Key, cc *conn) bool {
-								if u, err := url.Parse(key.Address); err == nil && u.Host == target && cc.grpcConn != nil {
-									_ = cc.grpcConn.Close()
-									_ = p.conns.Delete(key)
-								}
-
-								return true
-							})
-						}
-					}
-				},
-			})),
-		),
-	)
-
 	return p
+}
+
+func (p *Pool) resolverDialOption(filter func(string) bool) grpc.DialOption {
+	return grpc.WithResolvers(
+		xresolver.New(gtrace.Compose(p.config.Trace(), &trace.Driver{
+			OnResolve: func(info trace.DriverResolveStartInfo) func(trace.DriverResolveDoneInfo) {
+				target := info.Target
+				resolved := info.Resolved
+
+				return func(info trace.DriverResolveDoneInfo) {
+					if info.Error != nil || len(resolved) == 0 {
+						p.conns.Range(func(key endpoint.Key, cc *conn) bool {
+							if u, err := url.Parse(key.Address); err == nil && u.Host == target && cc.grpcConn != nil {
+								_ = cc.grpcConn.Close()
+								_ = p.conns.Delete(key)
+							}
+
+							return true
+						})
+					}
+				}
+			},
+		}), filter),
+	)
 }

--- a/internal/conn/pool_test.go
+++ b/internal/conn/pool_test.go
@@ -80,6 +80,22 @@ func TestPool_Get(t *testing.T) {
 		// Should return different connections
 		require.NotEqual(t, conn1, conn2)
 	})
+
+	t.Run("DoesNotShareConnectionsWithDifferentAddressFilters", func(t *testing.T) {
+		ctx := context.Background()
+		pool := NewPool(ctx, &mockConfig{dialTimeout: 5 * time.Second})
+		defer func() {
+			_ = pool.Release(ctx)
+		}()
+
+		withoutFilter := endpoint.New("example.com:2135")
+		ipv6Only := endpoint.New("example.com:2135", endpoint.WithAddressFilter("IPv6", func(string) bool {
+			return true
+		}))
+
+		require.NotEqual(t, withoutFilter.Key(), ipv6Only.Key())
+		require.NotEqual(t, pool.Get(withoutFilter), pool.Get(ipv6Only))
+	})
 }
 
 func TestPool_TakeRelease(t *testing.T) {

--- a/internal/discovery/config/config.go
+++ b/internal/discovery/config/config.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/jonboulle/clockwork"
 
+	balancerConfig "github.com/ydb-platform/ydb-go-sdk/v3/internal/balancer/config"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/config"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/discovery/gtrace"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/meta"
@@ -24,6 +25,7 @@ type Config struct {
 	meta           *meta.Meta
 	addressMutator func(address string) string
 	clock          clockwork.Clock
+	ipVersion      balancerConfig.IPVersion
 
 	interval time.Duration
 	trace    *trace.Discovery
@@ -45,6 +47,10 @@ func New(opts ...Option) *Config {
 	}
 
 	return c
+}
+
+func (c *Config) IPVersion() balancerConfig.IPVersion {
+	return c.ipVersion
 }
 
 func (c *Config) MutateAddress(fqdn string) string {
@@ -105,6 +111,12 @@ func WithDatabase(database string) Option {
 func WithClock(clock clockwork.Clock) Option {
 	return func(c *Config) {
 		c.clock = clock
+	}
+}
+
+func WithIPVersion(version balancerConfig.IPVersion) Option {
+	return func(c *Config) {
+		c.ipVersion = version
 	}
 }
 

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/discovery"
+	balancerConfig "github.com/ydb-platform/ydb-go-sdk/v3/internal/balancer/config"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/discovery/config"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/discovery/gtrace"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/endpoint"
@@ -72,26 +73,46 @@ func Discover(
 	location = result.GetSelfLocation()
 	endpoints = make([]endpoint.Endpoint, 0, len(result.GetEndpoints()))
 	for _, e := range result.GetEndpoints() {
-		if e.GetSsl() == config.Secure() {
-			endpoints = append(endpoints, endpoint.New(
-				net.JoinHostPort(
-					config.MutateAddress(e.GetAddress()),
-					strconv.Itoa(int(e.GetPort())),
-				),
-				endpoint.WithLocation(e.GetLocation()),
-				endpoint.WithID(e.GetNodeId()),
-				endpoint.WithLoadFactor(e.GetLoadFactor()),
-				endpoint.WithLocalDC(e.GetLocation() == location),
-				endpoint.WithServices(e.GetService()),
-				endpoint.WithLastUpdated(config.Clock().Now()),
-				endpoint.WithIPV4(e.GetIpV4()),
-				endpoint.WithIPV6(e.GetIpV6()),
-				endpoint.WithSslTargetNameOverride(e.GetSslTargetNameOverride()),
-			))
+		if converted, ok := convertEndpoint(e, location, config); ok {
+			endpoints = append(endpoints, converted)
 		}
 	}
 
 	return endpoints, result.GetSelfLocation(), nil
+}
+
+func convertEndpoint(
+	e *Ydb_Discovery.EndpointInfo, location string, config *config.Config,
+) (endpoint.Endpoint, bool) {
+	if e.GetSsl() != config.Secure() {
+		return nil, false
+	}
+
+	opts := []endpoint.Option{
+		endpoint.WithLocation(e.GetLocation()),
+		endpoint.WithID(e.GetNodeId()),
+		endpoint.WithLoadFactor(e.GetLoadFactor()),
+		endpoint.WithLocalDC(e.GetLocation() == location),
+		endpoint.WithServices(e.GetService()),
+		endpoint.WithLastUpdated(config.Clock().Now()),
+		endpoint.WithSslTargetNameOverride(e.GetSslTargetNameOverride()),
+	}
+	if version := config.IPVersion(); version == balancerConfig.IPVersionUnspecified {
+		opts = append(opts,
+			endpoint.WithIPV4(e.GetIpV4()),
+			endpoint.WithIPV6(e.GetIpV6()),
+		)
+	} else {
+		opts = append(opts, endpoint.WithAddressFilter(version.String(), version.AddressFilter()))
+	}
+
+	return endpoint.New(
+		net.JoinHostPort(
+			config.MutateAddress(e.GetAddress()),
+			strconv.Itoa(int(e.GetPort())),
+		),
+		opts...,
+	), true
 }
 
 // Discover cluster endpoints

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/anypb"
 
+	balancerConfig "github.com/ydb-platform/ydb-go-sdk/v3/internal/balancer/config"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/discovery/config"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/endpoint"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
@@ -21,6 +22,34 @@ import (
 )
 
 func TestDiscover(t *testing.T) {
+	t.Run("IPv6UsesFQDNForResolver", func(t *testing.T) {
+		ctx := xtest.Context(t)
+		ctrl := gomock.NewController(t)
+		client := NewMockDiscoveryServiceClient(ctrl)
+		client.EXPECT().ListEndpoints(gomock.Any(), gomock.Any()).Return(&Ydb_Discovery.ListEndpointsResponse{
+			Operation: &Ydb_Operations.Operation{
+				Ready:  true,
+				Status: Ydb.StatusIds_SUCCESS,
+				Result: xtest.Must(anypb.New(&Ydb_Discovery.ListEndpointsResult{
+					Endpoints: []*Ydb_Discovery.EndpointInfo{
+						{Address: "dual-stack.example", Port: 2136, IpV4: []string{"192.0.2.1"}, IpV6: []string{"2001:db8::1"}},
+					},
+				})),
+			},
+		}, nil)
+
+		endpoints, _, err := Discover(ctx, client, config.New(
+			config.WithIPVersion(balancerConfig.IPv6),
+		))
+		require.NoError(t, err)
+		require.Equal(t, []string{"dual-stack.example:2136"}, []string{endpoints[0].Address()})
+
+		filter := endpoint.AddressFilter(endpoints[0])
+		require.NotNil(t, filter)
+		require.False(t, filter("192.0.2.1:2136"))
+		require.True(t, filter("[2001:db8::1]:2136"))
+	})
+
 	t.Run("HappyWay", func(t *testing.T) {
 		ctx := xtest.Context(t)
 		ctrl := gomock.NewController(t)

--- a/internal/endpoint/address_filter_test.go
+++ b/internal/endpoint/address_filter_test.go
@@ -1,0 +1,24 @@
+package endpoint
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddressFilter(t *testing.T) {
+	filter := func(address string) bool {
+		return address == "[2001:db8::1]:2135"
+	}
+	endpoint := New("node.example:2135", WithAddressFilter("IPv6", filter))
+
+	require.Equal(t, "IPv6", endpoint.Key().AddressFilterKey)
+	require.True(t, AddressFilter(endpoint)("[2001:db8::1]:2135"))
+	require.False(t, AddressFilter(endpoint)("192.0.2.1:2135"))
+
+	copy := endpoint.Copy()
+	require.Equal(t, endpoint.Key(), copy.Key())
+	require.True(t, AddressFilter(copy)("[2001:db8::1]:2135"))
+
+	require.Nil(t, AddressFilter(nil))
+}

--- a/internal/endpoint/endpoint.go
+++ b/internal/endpoint/endpoint.go
@@ -28,6 +28,8 @@ type (
 		Address      string
 		NodeID       uint32
 		HostOverride string
+
+		AddressFilterKey string
 	}
 	Endpoint interface {
 		Info
@@ -50,6 +52,9 @@ type endpoint struct {
 	ipv6            []string
 	sslNameOverride string
 
+	addressFilter    func(string) bool
+	addressFilterKey string
+
 	loadFactor  float32
 	lastUpdated time.Time
 
@@ -61,6 +66,8 @@ func (e *endpoint) Key() Key {
 		Address:      e.Address(),
 		NodeID:       e.id,
 		HostOverride: e.sslNameOverride,
+
+		AddressFilterKey: e.addressFilterKey,
 	}
 }
 
@@ -76,9 +83,12 @@ func (e *endpoint) Copy(opts ...Option) Endpoint {
 		ipv4:            append(make([]string, 0, len(e.ipv4)), e.ipv4...),
 		ipv6:            append(make([]string, 0, len(e.ipv6)), e.ipv6...),
 		sslNameOverride: e.sslNameOverride,
-		loadFactor:      e.loadFactor,
-		local:           e.local,
-		lastUpdated:     e.lastUpdated,
+
+		addressFilter:    e.addressFilter,
+		addressFilterKey: e.addressFilterKey,
+		loadFactor:       e.loadFactor,
+		local:            e.local,
+		lastUpdated:      e.lastUpdated,
 	}
 
 	for _, opt := range opts {
@@ -156,6 +166,13 @@ func (e *endpoint) OverrideHost() string {
 	defer e.mu.RUnlock()
 
 	return e.sslNameOverride
+}
+
+func (e *endpoint) AddressFilter() func(string) bool {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	return e.addressFilter
 }
 
 func (e *endpoint) Location() string {
@@ -244,6 +261,25 @@ func WithSslTargetNameOverride(nameOverride string) Option {
 	return func(e *endpoint) {
 		e.sslNameOverride = nameOverride
 	}
+}
+
+func WithAddressFilter(key string, filter func(string) bool) Option {
+	return func(e *endpoint) {
+		e.addressFilterKey = key
+		e.addressFilter = filter
+	}
+}
+
+type addressFilterProvider interface {
+	AddressFilter() func(string) bool
+}
+
+func AddressFilter(e Endpoint) func(string) bool {
+	if provider, ok := e.(addressFilterProvider); ok {
+		return provider.AddressFilter()
+	}
+
+	return nil
 }
 
 func New(address string, opts ...Option) *endpoint {

--- a/internal/xresolver/xresolver.go
+++ b/internal/xresolver/xresolver.go
@@ -1,6 +1,7 @@
 package xresolver
 
 import (
+	"net/url"
 	"strings"
 
 	"google.golang.org/grpc/resolver"
@@ -11,11 +12,13 @@ import (
 	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
 )
 
+const Scheme = "ydb"
+
 type dnsBuilder struct {
 	resolver.Builder
 
-	scheme string
 	trace  *trace.Driver
+	filter func(string) bool
 }
 
 type clientConn struct {
@@ -23,6 +26,14 @@ type clientConn struct {
 
 	target resolver.Target
 	trace  *trace.Driver
+	filter func(string) bool
+}
+
+func Target(endpoint string) string {
+	return (&url.URL{
+		Scheme: Scheme,
+		Path:   "/" + endpoint,
+	}).String()
 }
 
 func (c *clientConn) Endpoint() string {
@@ -35,15 +46,14 @@ func (c *clientConn) Endpoint() string {
 }
 
 func (c *clientConn) UpdateState(state resolver.State) (err error) {
+	if c.filter != nil {
+		state.Addresses = filterAddresses(state.Addresses, c.filter)
+		state.Endpoints = filterEndpoints(state.Endpoints, c.filter)
+	}
+
 	onDone := gtrace.DriverOnResolve(c.trace,
 		stack.FunctionID("github.com/ydb-platform/ydb-go-sdk/v3/internal/xresolver.(*clientConn).UpdateState"),
-		c.Endpoint(), func() (addrs []string) {
-			for i := range state.Addresses {
-				addrs = append(addrs, state.Addresses[i].Addr)
-			}
-
-			return
-		}(),
+		c.Endpoint(), stateAddresses(state),
 	)
 	defer func() {
 		onDone(err)
@@ -57,6 +67,51 @@ func (c *clientConn) UpdateState(state resolver.State) (err error) {
 	return nil
 }
 
+func filterAddresses(addresses []resolver.Address, filter func(string) bool) []resolver.Address {
+	if len(addresses) == 0 {
+		return addresses
+	}
+
+	filtered := make([]resolver.Address, 0, len(addresses))
+	for _, address := range addresses {
+		if filter(address.Addr) {
+			filtered = append(filtered, address)
+		}
+	}
+
+	return filtered
+}
+
+func filterEndpoints(endpoints []resolver.Endpoint, filter func(string) bool) []resolver.Endpoint {
+	if len(endpoints) == 0 {
+		return endpoints
+	}
+
+	filtered := make([]resolver.Endpoint, 0, len(endpoints))
+	for _, endpoint := range endpoints {
+		endpoint.Addresses = filterAddresses(endpoint.Addresses, filter)
+		if len(endpoint.Addresses) != 0 {
+			filtered = append(filtered, endpoint)
+		}
+	}
+
+	return filtered
+}
+
+func stateAddresses(state resolver.State) []string {
+	addresses := make([]string, 0, len(state.Addresses))
+	for _, address := range state.Addresses {
+		addresses = append(addresses, address.Addr)
+	}
+	for _, endpoint := range state.Endpoints {
+		for _, address := range endpoint.Addresses {
+			addresses = append(addresses, address.Addr)
+		}
+	}
+
+	return addresses
+}
+
 func (d *dnsBuilder) Build(
 	target resolver.Target, //nolint:gocritic
 	cc resolver.ClientConn,
@@ -66,17 +121,19 @@ func (d *dnsBuilder) Build(
 		ClientConn: cc,
 		target:     target,
 		trace:      d.trace,
+		filter:     d.filter,
 	}, opts)
 }
 
 func (d *dnsBuilder) Scheme() string {
-	return d.scheme
+	return Scheme
 }
 
-func New(scheme string, trace *trace.Driver) resolver.Builder {
+// New creates a resolver that filters the addresses returned by the DNS resolver.
+func New(trace *trace.Driver, filter func(string) bool) resolver.Builder {
 	return &dnsBuilder{
 		Builder: resolver.Get("dns"),
-		scheme:  scheme,
 		trace:   trace,
+		filter:  filter,
 	}
 }

--- a/internal/xresolver/xresolver_test.go
+++ b/internal/xresolver/xresolver_test.go
@@ -1,0 +1,57 @@
+package xresolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/resolver"
+
+	balancerConfig "github.com/ydb-platform/ydb-go-sdk/v3/internal/balancer/config"
+	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
+)
+
+type fakeClientConn struct {
+	resolver.ClientConn
+
+	state resolver.State
+}
+
+func (c *fakeClientConn) UpdateState(state resolver.State) error {
+	c.state = state
+
+	return nil
+}
+
+func TestClientConnUpdateStateFiltersAddresses(t *testing.T) {
+	fakeConn := &fakeClientConn{}
+	resolverConn := &clientConn{
+		ClientConn: fakeConn,
+		trace:      &trace.Driver{},
+		filter:     balancerConfig.IPv6.AddressFilter(),
+	}
+
+	err := resolverConn.UpdateState(resolver.State{Addresses: []resolver.Address{
+		{Addr: "192.0.2.1:2135"},
+		{Addr: "[2001:db8::1]:2135"},
+		{Addr: "[2001:db8::2]:2135"},
+		{Addr: "[::ffff:192.0.2.2]:2135"},
+		{Addr: "not-an-ip:2135"},
+	}, Endpoints: []resolver.Endpoint{
+		{Addresses: []resolver.Address{{Addr: "192.0.2.3:2135"}}},
+		{Addresses: []resolver.Address{{Addr: "[2001:db8::3]:2135"}}},
+	}})
+	require.NoError(t, err)
+	require.Equal(t, []resolver.Address{
+		{Addr: "[2001:db8::1]:2135"},
+		{Addr: "[2001:db8::2]:2135"},
+	}, fakeConn.state.Addresses)
+	require.Equal(t, []resolver.Endpoint{
+		{Addresses: []resolver.Address{{Addr: "[2001:db8::3]:2135"}}},
+	}, fakeConn.state.Endpoints)
+}
+
+func TestTarget(t *testing.T) {
+	require.Equal(t, "ydb:///example.com:2135", Target("example.com:2135"))
+	require.Equal(t, "ydb:///%5B2001:db8::1%5D:2135", Target("[2001:db8::1]:2135"))
+	require.Equal(t, Scheme, New(&trace.Driver{}, nil).Scheme())
+}

--- a/tests/integration/ipv6_test.go
+++ b/tests/integration/ipv6_test.go
@@ -1,0 +1,72 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3"
+	"github.com/ydb-platform/ydb-go-sdk/v3/balancers"
+	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
+)
+
+func TestOnlyIPVersion(t *testing.T) {
+	scope := newScope(t)
+	ctx, cancel := context.WithTimeout(scope.Ctx, time.Second)
+	defer cancel()
+
+	resolutions := make(chan []string, 1)
+	// The bootstrap resolver update is delivered while ydb.Open is blocked. Canceling it avoids waiting for
+	// the IPv6 connection attempt to time out against the IPv4-only Docker YDB instance.
+	opts := []ydb.Option{
+		ydb.WithBalancer(balancers.OnlyIPVersion(balancers.RandomChoice(), balancers.IPv6)),
+		ydb.WithTraceDriver(trace.Driver{
+			OnResolve: func(info trace.DriverResolveStartInfo) func(trace.DriverResolveDoneInfo) {
+				return func(trace.DriverResolveDoneInfo) {
+					select {
+					case resolutions <- info.Resolved:
+						cancel()
+					default:
+					}
+				}
+			},
+		}),
+	}
+	if token := scope.AuthToken(); token == "" {
+		opts = append(opts, ydb.WithAnonymousCredentials())
+	} else {
+		opts = append(opts, ydb.WithAccessTokenCredentials(token))
+	}
+	if cert := scope.CertFile(); cert == "" {
+		opts = append(opts, ydb.WithTLSSInsecureSkipVerify())
+	} else {
+		opts = append(opts, ydb.WithCertificatesFromFile(cert))
+	}
+
+	db, err := ydb.Open(ctx, scope.ConnectionString(), opts...)
+
+	require.Nil(t, db)
+	require.ErrorIs(t, err, context.Canceled)
+
+	select {
+	case addresses := <-resolutions:
+		require.NotEmpty(t, addresses)
+		for _, address := range addresses {
+			host, _, splitErr := net.SplitHostPort(address)
+			require.NoError(t, splitErr)
+
+			ip, parseErr := netip.ParseAddr(host)
+			require.NoError(t, parseErr)
+			require.True(t, ip.Is6() && !ip.Is4In6())
+		}
+	default:
+		t.Fatal("resolver update was not traced")
+	}
+}


### PR DESCRIPTION
## Pull request type

- [x] Feature
- [ ] Bugfix
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

Discovery may return FQDN endpoints without `ip_v6` values. In this case gRPC resolves the name itself and can establish a connection over IPv4.

Issue Number: N/A

## What is the new behavior?

- Added experimental `balancers.OnlyIPVersion(..., balancers.IPv6)`.
- FQDN endpoints are resolved to IPv6 during Discovery.
- Endpoints without IPv6 addresses are excluded.

## Other information

Validated with:

- `go test ./balancers ./internal/discovery ./internal/balancer`
- `go test -race -tags integration ./tests/integration -run '^TestOnlyIPVersion$' -count=1`
- `golangci-lint run ./...`