### PR TITLE
Collect SDK coverage from SLO workloads

### DIFF
--- a/.github/scripts/build-slo-image.sh
+++ b/.github/scripts/build-slo-image.sh
@@ -9,13 +9,15 @@ Usage:
     --context <path> \
     --tag <docker-tag> \
     --src-path <sdk-path> \
-    --fallback-image <docker-tag>
+    [--enable-coverage] \
+    [--fallback-image <docker-tag>]
 
 Options:
-  --context         Docker build context directory (e.g. $GITHUB_WORKSPACE/current).
-  --tag             Docker image tag to build (e.g. ydb-app-current).
-  --src-path        Value for Docker build arg SRC_PATH (e.g. native/table).
-  --fallback-image  Image tag to return if initial Docker image build fails
+  --context          Docker build context directory (e.g. $GITHUB_WORKSPACE/current).
+  --tag              Docker image tag to build (e.g. ydb-app-current).
+  --src-path         Value for Docker build arg SRC_PATH (e.g. native/table).
+  --enable-coverage  Build an instrumented workload binary that emits SDK coverage.
+  --fallback-image   Image tag to return if initial Docker image build fails
 EOF
 }
 
@@ -28,6 +30,7 @@ context_dir=""
 dockerfile="tests/slo/Dockerfile"
 tag=""
 src_path=""
+enable_coverage="false"
 fallback_image=""
 
 while [[ $# -gt 0 ]]; do
@@ -43,6 +46,10 @@ while [[ $# -gt 0 ]]; do
     --src-path)
       src_path="${2:-}"
       shift 2
+      ;;
+    --enable-coverage)
+      enable_coverage="true"
+      shift
       ;;
     --fallback-image)
       fallback_image="${2:-}"
@@ -69,8 +76,9 @@ context_dir="$(cd "$context_dir" && pwd)"
 [[ -f "$context_dir/$dockerfile" ]] || die "Dockerfile not found: $context_dir/$dockerfile"
 
 echo "Building SLO image..."
-echo "  TAG:        $tag"
-echo "  SRC_PATH:   $src_path"
+echo "  TAG:             $tag"
+echo "  SRC_PATH:        $src_path"
+echo "  ENABLE_COVERAGE: $enable_coverage"
 
 (
   set +e
@@ -78,6 +86,7 @@ echo "  SRC_PATH:   $src_path"
   docker build -t "$tag" \
     --platform linux/amd64 \
     --build-arg "SRC_PATH=$src_path" \
+    --build-arg "ENABLE_COVERAGE=$enable_coverage" \
     -f "$dockerfile" .
   exit_code=$?
   echo "Docker build exit code: $exit_code"

--- a/.github/scripts/collect-slo-coverage.sh
+++ b/.github/scripts/collect-slo-coverage.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage:
+  collect-slo-coverage.sh \
+    --output-dir <path> \
+    --workload <name>
+
+Collects Go coverage data from the stopped SLO workload-current container
+and converts it to the legacy text format for Codecov upload.
+EOF
+}
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+output_dir=""
+workload=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output-dir)
+      output_dir="${2:-}"
+      shift 2
+      ;;
+    --workload)
+      workload="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "Unknown argument: $1 (use --help)"
+      ;;
+  esac
+done
+
+if [[ -z "$output_dir" || -z "$workload" ]]; then
+  usage
+  die "Incomplete argument set"
+fi
+
+mkdir -p "$output_dir"
+
+container="ydb-workload-current"
+raw_dir="${output_dir}/${workload}-raw"
+profile="${output_dir}/${workload}.txt"
+
+if ! docker inspect "$container" >/dev/null 2>&1; then
+  echo "Container ${container} not found, skipping coverage collection"
+  exit 0
+fi
+
+rm -rf "$raw_dir"
+mkdir -p "$raw_dir"
+
+if ! docker cp "${container}:/coverage/." "$raw_dir/" 2>/dev/null; then
+  echo "Coverage data not found in ${container}, skipping"
+  exit 0
+fi
+
+if ! compgen -G "${raw_dir}/covmeta.*" >/dev/null; then
+  echo "Coverage directory in ${container} is empty, skipping"
+  exit 0
+fi
+
+echo "Converting coverage data for ${workload}..."
+if ! go tool covdata textfmt -i="$raw_dir" -o "$profile"; then
+  die "Failed to convert coverage data for ${workload}"
+fi
+
+if [[ ! -s "$profile" ]]; then
+  echo "Coverage profile for ${workload} is empty, skipping"
+  rm -f "$profile"
+  exit 0
+fi
+
+echo "Coverage profile written to ${profile}"

--- a/.github/workflows/slo.yml
+++ b/.github/workflows/slo.yml
@@ -156,7 +156,8 @@ jobs:
           bash "$SCRIPT" \
             --context "$GITHUB_WORKSPACE/current" \
             --tag "ydb-app-current" \
-            --src-path "${{ matrix.sdk.path }}"
+            --src-path "${{ matrix.sdk.path }}" \
+            --enable-coverage
 
           # Keep workload code (and shared internal helpers) on current so baseline
           # runs the same workload against the baseline SDK via tests/slo/go.mod replace.
@@ -202,4 +203,23 @@ jobs:
           bash "$GITHUB_WORKSPACE/current/.github/scripts/collect-slo-flamegraphs.sh" \
             --output-dir "$GITHUB_WORKSPACE/.slo/extra/flamegraphs" \
             --workload "${{ matrix.sdk.name }}"
+
+      - name: Collect coverage
+        if: always()
+        run: |
+          chmod +x "$GITHUB_WORKSPACE/current/.github/scripts/collect-slo-coverage.sh"
+          bash "$GITHUB_WORKSPACE/current/.github/scripts/collect-slo-coverage.sh" \
+            --output-dir "$GITHUB_WORKSPACE/.slo/extra/coverage" \
+            --workload "${{ matrix.sdk.name }}"
+
+      - name: Upload SLO coverage report to Codecov
+        if: always() && hashFiles('.slo/extra/coverage/${{ matrix.sdk.name }}.txt') != ''
+        uses: codecov/codecov-action@v4
+        with:
+          file: ./.slo/extra/coverage/${{ matrix.sdk.name }}.txt
+          flags: slo,${{ matrix.sdk.name }}
+          name: slo-${{ matrix.sdk.name }}
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Added Codecov coverage collection from SLO workloads for SDK code exercised under chaos testing
 * Removed background connection parking (`connParker`), `conn.lastUsage` tracking and `xsync.LastUsage`
 * Deprecated `WithConnectionTTL`: the option is now a no-op
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-* Added Codecov coverage collection from SLO workloads for SDK code exercised under chaos testing
 * Removed background connection parking (`connParker`), `conn.lastUsage` tracking and `xsync.LastUsage`
 * Deprecated `WithConnectionTTL`: the option is now a no-op
 

--- a/tests/slo/Dockerfile
+++ b/tests/slo/Dockerfile
@@ -1,5 +1,6 @@
 FROM golang:1.26 AS build
 ARG SRC_PATH
+ARG ENABLE_COVERAGE=false
 
 # Copy dependency manifests first so module download is cached when only source changes.
 COPY go.mod go.sum /src/
@@ -11,8 +12,15 @@ RUN go mod download
 COPY . /src
 
 WORKDIR /src/tests/slo/${SRC_PATH}
-RUN CGO_ENABLED=0 go build -o /build/slo-go-workload .
+RUN if [ "$ENABLE_COVERAGE" = "true" ]; then \
+      CGO_ENABLED=0 go build -trimpath \
+        -cover -coverpkg=github.com/ydb-platform/ydb-go-sdk/v3/... \
+        -o /build/slo-go-workload .; \
+    else \
+      CGO_ENABLED=0 go build -trimpath -o /build/slo-go-workload .; \
+    fi
 
 FROM scratch
 COPY --from=build /build /
+ENV GOCOVERDIR=/coverage
 ENTRYPOINT ["/slo-go-workload"]

--- a/tests/slo/internal/framework/coverage.go
+++ b/tests/slo/internal/framework/coverage.go
@@ -1,0 +1,12 @@
+package framework
+
+import "os"
+
+func ensureCoverageDir() {
+	dir := os.Getenv("GOCOVERDIR")
+	if dir == "" {
+		return
+	}
+
+	_ = os.MkdirAll(dir, 0o755)
+}

--- a/tests/slo/internal/framework/framework.go
+++ b/tests/slo/internal/framework/framework.go
@@ -36,6 +36,8 @@ type WorkloadFactory func(ctx context.Context, fw *Framework) (Workload, error)
 func Run(factory WorkloadFactory) {
 	exitCode := 0
 
+	ensureCoverageDir()
+
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT, syscall.SIGQUIT)
 	defer cancel()
 


### PR DESCRIPTION
## Summary
- Build the current SLO workload image with Go coverage instrumentation (`-cover -coverpkg=github.com/ydb-platform/ydb-go-sdk/v3/...`) so chaos runs exercise the SDK under real failure scenarios.
- Collect coverage data from the `workload-current` container after each matrix job and convert it to the legacy text format via `go tool covdata textfmt`.
- Upload per-workload profiles to Codecov with `slo,<workload>` flags, alongside existing unit and integration coverage.

## Test plan
- [ ] Run SLO workflow on this PR (add `SLO` label) and verify `.slo/extra/coverage/*.txt` artifacts are produced.
- [ ] Confirm Codecov receives reports with `slo` flag for each workload matrix entry.
- [ ] Verify baseline workload image build remains unchanged (no coverage instrumentation).


Made with [Cursor](https://cursor.com)