### PR TITLE
Track driver connections by state

### DIFF
--- a/.agents/context/systemPatterns.md
+++ b/.agents/context/systemPatterns.md
@@ -66,6 +66,30 @@ This is the single production path for gRPC — do not dial around the balancer.
 - Refcount and map updates run under `p.mu` with `defer p.mu.Unlock()` in helpers (`tryPut`, `release`); blocking `Close()` runs **after** the helper returns. See mutex rules in [`.agents/rules/coding-standards.md`](../rules/coding-standards.md).
 - Used by balancer to obtain `grpc.ClientConn` for a chosen node.
 
+Connection state lifecycle:
+
+```text
+Created → Online ↔ Banned
+             ↕
+           Offline
+             ↓
+          Destroyed
+```
+
+- `newConn` stores `Created` directly; there is no state-change event at wrapper creation. The first successful lazy dial emits `Created → Online`.
+- `Ban` moves the wrapper to `Banned`; `Unban` chooses `Online` or `Offline` from the underlying gRPC transport readiness.
+- Closing the gRPC transport moves the wrapper to `Offline`; closing the wrapper finishes with `Destroyed`.
+- `conn.setState` is the central transition point and emits `trace.Driver.OnConnStateChange` with the previous and new states. `Online`, `Offline`, and `Banned` are valid operational states; `Created`, `Destroyed`, and `Unknown` are lifecycle sentinels.
+
+### Driver connection metrics
+
+- The `metrics.Registry` API is push-based (`Gauge.Add` / `Gauge.Set`); it has no scrape-time callback or connection-pool snapshot API.
+- Derive current connection state from the existing `OnConnStateChange` trace. Moving one connection between valid states decrements the old state and increments the new state, so `sum(conns)` remains invariant. Entering the first valid state increments the sum; moving to `Destroyed` decrements it.
+- Do not create a `Created` series from the first `Created → Online` transition: there was no preceding creation event, so decrementing it would produce `-1`.
+- A ban with `cause` is an event and belongs in a counter. Current banned connection cardinality belongs in the `state="banned"` partition of the connection gauge.
+- Adding `state` changes the raw `conns` series shape, but dashboards using only `sum(conns)` retain their query and intended total. Direct selectors, grouping, joins, and alerts must account for the new label.
+- The former dial/close event accounting could drift: redial could add twice after an internal transport reset, while closing a never-dialed wrapper could subtract without a prior add. State transitions avoid both cases.
+
 ### 2. YDB session pool (`internal/pool/pool.go`)
 
 - Generic pool used by **table** and **query** clients for YDB `Session` objects.

--- a/.agents/rules/testing.md
+++ b/.agents/rules/testing.md
@@ -6,6 +6,8 @@
 go test -race ./...
 ```
 
+Within a test file, place test functions first. Put helper functions, fixtures, recording implementations, mocks, and other support code after the tests.
+
 Integration tests in `tests/integration/` are excluded automatically (`//go:build integration`).
 
 > Note: `CONTRIBUTING.md` documents `-tags fast` for unit-only runs, but that build tag does not exist. Default `go test ./...` is correct.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Changed driver connection metrics to expose `conns` by state and count `conn.banned` events with a counter
+
 ## v3.144.3
 * Fixed gRPC connections to cluster nodes removed from Discovery staying open in the connection pool
 * Refactored connection pool lifecycle to reference-counted `Get`/`Put` with balancer-side quarantine

--- a/metrics/driver.go
+++ b/metrics/driver.go
@@ -164,6 +164,7 @@ func driver(config Config) (t trace.Driver) {
 			}
 		}
 	}
+
 	return t
 }
 

--- a/metrics/driver.go
+++ b/metrics/driver.go
@@ -19,8 +19,8 @@ func driver(config Config) (t trace.Driver) {
 	endpoints := config.WithSystem("balancer").GaugeVec("endpoints", "az")
 	balancersDiscoveries := config.WithSystem("balancer").CounterVec("discoveries", "status", "cause")
 	balancerUpdates := config.WithSystem("balancer").CounterVec("updates", "cause")
-	conns := config.GaugeVec("conns", "endpoint", "node_id")
-	banned := config.WithSystem("conn").GaugeVec("banned", "endpoint", "node_id", "cause")
+	conns := config.GaugeVec("conns", "endpoint", "node_id", "state")
+	banned := config.WithSystem("conn").CounterVec("banned", "endpoint", "node_id", "cause")
 	requestStatuses := config.WithSystem("conn").CounterVec("request_statuses", "status", "endpoint", "node_id")
 	requestMethods := config.WithSystem("conn").CounterVec("request_methods", "method", "endpoint", "node_id")
 	tli := config.CounterVec("transaction_locks_invalidated")
@@ -30,6 +30,18 @@ func driver(config Config) (t trace.Driver) {
 	}
 	knownEndpoints := make(map[endpointKey]struct{})
 	endpointsMu := sync.RWMutex{}
+	t.OnConnStateChange = func(info trace.DriverConnStateChangeStartInfo) func(trace.DriverConnStateChangeDoneInfo) {
+		if config.Details()&trace.DriverConnEvents == 0 {
+			return nil
+		}
+
+		endpoint := info.Endpoint
+		updateConnStateGauge(conns, endpoint, info.State, -1)
+
+		return func(info trace.DriverConnStateChangeDoneInfo) {
+			updateConnStateGauge(conns, endpoint, info.State, 1)
+		}
+	}
 
 	t.OnConnInvoke = func(info trace.DriverConnInvokeStartInfo) func(trace.DriverConnInvokeDoneInfo) {
 		var (
@@ -93,7 +105,7 @@ func driver(config Config) (t trace.Driver) {
 			"endpoint": safeEndpointAddress(info.Endpoint),
 			"node_id":  idToString(safeEndpointNodeID(info.Endpoint)),
 			"cause":    errorBrief(info.Cause),
-		}).Add(1)
+		}).Inc()
 
 		return nil
 	}
@@ -152,35 +164,17 @@ func driver(config Config) (t trace.Driver) {
 			}
 		}
 	}
-	t.OnConnDial = func(info trace.DriverConnDialStartInfo) func(trace.DriverConnDialDoneInfo) {
-		endpoint := safeEndpointAddress(info.Endpoint)
-		nodeID := safeEndpointNodeID(info.Endpoint)
-
-		return func(info trace.DriverConnDialDoneInfo) {
-			if config.Details()&trace.DriverConnEvents == 0 {
-				return
-			}
-
-			if info.Error == nil {
-				conns.With(map[string]string{
-					"endpoint": endpoint,
-					"node_id":  idToString(nodeID),
-				}).Add(1)
-			}
-		}
-	}
-	t.OnConnClose = func(info trace.DriverConnCloseStartInfo) func(trace.DriverConnCloseDoneInfo) {
-		if config.Details()&trace.DriverConnEvents == 0 {
-			return nil
-		}
-
-		conns.With(map[string]string{
-			"endpoint": safeEndpointAddress(info.Endpoint),
-			"node_id":  idToString(safeEndpointNodeID(info.Endpoint)),
-		}).Add(-1)
-
-		return nil
-	}
-
 	return t
+}
+
+func updateConnStateGauge(gauge GaugeVec, endpoint trace.EndpointInfo, state trace.ConnState, delta float64) {
+	if isNil(state) || !state.IsValid() {
+		return
+	}
+
+	gauge.With(map[string]string{
+		"endpoint": safeEndpointAddress(endpoint),
+		"node_id":  idToString(safeEndpointNodeID(endpoint)),
+		"state":    state.String(),
+	}).Add(delta)
 }

--- a/metrics/driver_test.go
+++ b/metrics/driver_test.go
@@ -1,0 +1,211 @@
+package metrics
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/conn/state"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/endpoint"
+	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
+)
+
+func TestDriverConnectionMetrics(t *testing.T) {
+	registry := newRecordingRegistry()
+	tracer := driver(recordingConfig{registry: registry})
+	ep := endpoint.New("localhost:2135", endpoint.WithID(42))
+	connLabels := func(connState state.State) map[string]string {
+		return map[string]string{
+			"endpoint": "localhost:2135",
+			"node_id":  "42",
+			"state":    connState.String(),
+		}
+	}
+	transition := func(from, to state.State) {
+		done := tracer.OnConnStateChange(trace.DriverConnStateChangeStartInfo{
+			Endpoint: ep,
+			State:    from,
+		})
+		require.NotNil(t, done)
+		done(trace.DriverConnStateChangeDoneInfo{State: to})
+	}
+
+	require.Equal(t, "gauge", registry.kinds["driver.conns"])
+	require.Equal(t, []string{"endpoint", "node_id", "state"}, registry.labelNames["driver.conns"])
+	require.Equal(t, "counter", registry.kinds["driver.conn.banned"])
+
+	transition(state.Created, state.Online)
+	transition(state.Created, state.Online)
+	require.Equal(t, float64(2), registry.value("driver.conns", connLabels(state.Online)))
+
+	transition(state.Online, state.Banned)
+	require.Equal(t, float64(1), registry.value("driver.conns", connLabels(state.Online)))
+	require.Equal(t, float64(1), registry.value("driver.conns", connLabels(state.Banned)))
+
+	transition(state.Banned, state.Offline)
+	transition(state.Online, state.Destroyed)
+	require.Zero(t, registry.value("driver.conns", connLabels(state.Online)))
+	require.Zero(t, registry.value("driver.conns", connLabels(state.Banned)))
+	require.Equal(t, float64(1), registry.value("driver.conns", connLabels(state.Offline)))
+
+	tracer.OnConnBan(trace.DriverConnBanStartInfo{
+		Endpoint: ep,
+		Cause:    context.Canceled,
+	})
+	tracer.OnConnBan(trace.DriverConnBanStartInfo{
+		Endpoint: ep,
+		Cause:    context.Canceled,
+	})
+	require.Equal(t, float64(2), registry.value("driver.conn.banned", map[string]string{
+		"endpoint": "localhost:2135",
+		"node_id":  "42",
+		"cause":    "context/Canceled",
+	}))
+}
+
+type recordingRegistry struct {
+	mu         sync.Mutex
+	kinds      map[string]string
+	labelNames map[string][]string
+	values     map[string]float64
+}
+
+func newRecordingRegistry() *recordingRegistry {
+	return &recordingRegistry{
+		kinds:      make(map[string]string),
+		labelNames: make(map[string][]string),
+		values:     make(map[string]float64),
+	}
+}
+
+func (r *recordingRegistry) register(path, kind string, labelNames []string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.kinds[path] = kind
+	r.labelNames[path] = append([]string(nil), labelNames...)
+}
+
+func (r *recordingRegistry) key(path string, labels map[string]string) string {
+	parts := make([]string, 0, len(r.labelNames[path])+1)
+	parts = append(parts, path)
+	for _, name := range r.labelNames[path] {
+		parts = append(parts, name+"="+labels[name])
+	}
+
+	return strings.Join(parts, ",")
+}
+
+func (r *recordingRegistry) add(path string, labels map[string]string, delta float64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.values[r.key(path, labels)] += delta
+}
+
+func (r *recordingRegistry) set(path string, labels map[string]string, value float64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.values[r.key(path, labels)] = value
+}
+
+func (r *recordingRegistry) value(path string, labels map[string]string) float64 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.values[r.key(path, labels)]
+}
+
+type recordingCounter struct {
+	registry *recordingRegistry
+	path     string
+	labels   map[string]string
+}
+
+func (c recordingCounter) Inc() {
+	c.registry.add(c.path, c.labels, 1)
+}
+
+type recordingCounterVec struct {
+	registry *recordingRegistry
+	path     string
+}
+
+func (v recordingCounterVec) With(labels map[string]string) Counter {
+	return recordingCounter{registry: v.registry, path: v.path, labels: labels}
+}
+
+type recordingGauge struct {
+	registry *recordingRegistry
+	path     string
+	labels   map[string]string
+}
+
+func (g recordingGauge) Add(delta float64) {
+	g.registry.add(g.path, g.labels, delta)
+}
+
+func (g recordingGauge) Set(value float64) {
+	g.registry.set(g.path, g.labels, value)
+}
+
+type recordingGaugeVec struct {
+	registry *recordingRegistry
+	path     string
+}
+
+func (v recordingGaugeVec) With(labels map[string]string) Gauge {
+	return recordingGauge{registry: v.registry, path: v.path, labels: labels}
+}
+
+type recordingConfig struct {
+	registry *recordingRegistry
+	system   string
+}
+
+func (c recordingConfig) Details() trace.Details {
+	return trace.DetailsAll
+}
+
+func (c recordingConfig) WithSystem(system string) Config {
+	if c.system != "" {
+		system = c.system + "." + system
+	}
+	c.system = system
+
+	return c
+}
+
+func (c recordingConfig) path(name string) string {
+	if c.system == "" {
+		return name
+	}
+
+	return c.system + "." + name
+}
+
+func (c recordingConfig) CounterVec(name string, labelNames ...string) CounterVec {
+	path := c.path(name)
+	c.registry.register(path, "counter", labelNames)
+
+	return recordingCounterVec{registry: c.registry, path: path}
+}
+
+func (c recordingConfig) GaugeVec(name string, labelNames ...string) GaugeVec {
+	path := c.path(name)
+	c.registry.register(path, "gauge", labelNames)
+
+	return recordingGaugeVec{registry: c.registry, path: path}
+}
+
+func (recordingConfig) TimerVec(string, ...string) TimerVec {
+	return noopTimerVec{}
+}
+
+func (recordingConfig) HistogramVec(string, []float64, ...string) HistogramVec {
+	return noopHistogramVec{}
+}

--- a/metrics/driver_test.go
+++ b/metrics/driver_test.go
@@ -15,7 +15,10 @@ import (
 
 func TestDriverConnectionMetrics(t *testing.T) {
 	registry := newRecordingRegistry()
-	tracer := driver(recordingConfig{registry: registry})
+	tracer := driver(recordingConfig{
+		registry: registry,
+		details:  trace.DriverConnEvents,
+	})
 	ep := endpoint.New("localhost:2135", endpoint.WithID(42))
 	connLabels := func(connState state.State) map[string]string {
 		return map[string]string{
@@ -64,6 +67,16 @@ func TestDriverConnectionMetrics(t *testing.T) {
 		"node_id":  "42",
 		"cause":    "context/Canceled",
 	}))
+}
+
+func TestDriverConnectionMetricsDisabled(t *testing.T) {
+	tracer := driver(recordingConfig{
+		registry: newRecordingRegistry(),
+		details:  trace.DriverBalancerEvents,
+	})
+
+	require.Nil(t, tracer.OnConnStateChange(trace.DriverConnStateChangeStartInfo{}))
+	require.Nil(t, tracer.OnConnBan(trace.DriverConnBanStartInfo{}))
 }
 
 type recordingRegistry struct {
@@ -165,10 +178,11 @@ func (v recordingGaugeVec) With(labels map[string]string) Gauge {
 type recordingConfig struct {
 	registry *recordingRegistry
 	system   string
+	details  trace.Details
 }
 
 func (c recordingConfig) Details() trace.Details {
-	return trace.DetailsAll
+	return c.details
 }
 
 func (c recordingConfig) WithSystem(system string) Config {


### PR DESCRIPTION
## Summary

- Added the `state` label to the driver `conns` gauge.
- Switched connection accounting from dial/close events to `OnConnStateChange`.
- Changed the existing `conn.banned` metric from a gauge to a counter.
- Added unit coverage for connection state transitions and ban events.
- Documented the connection state lifecycle and metrics semantics.

## Motivation

The previous `conns` accounting incremented the gauge after every successful dial and decremented it on wrapper close. This could drift after redials or when a connection wrapper was closed without a successful dial.

Connection state transitions provide a more accurate lifecycle:

- entering `Online`, `Offline`, or `Banned` adds a connection;
- moving between valid states preserves `sum(conns)`;
- moving to `Destroyed` removes the connection.

The `conn.banned` metric represents ban events rather than current state, so it is now exported as a counter. Current banned connection cardinality is available through `conns{state="banned"}`.

Dashboards using `sum(conns)` retain the same query and intended total.