### PR TITLE
fix(slo): align local compose project and profiles

### DIFF
--- a/tests/slo/SLO.md
+++ b/tests/slo/SLO.md
@@ -31,9 +31,13 @@ cd tests/slo
 SRC_PATH=native/query WORKLOAD_DURATION=600 docker compose \
   --profile telemetry \
   --profile chaos \
+  --profile extra-nodes \
   --profile workload-current \
   up --build
 ```
+
+The default local run enables telemetry, chaos injection, all five database nodes, and the current workload.
+The `workload-baseline` profile is only needed when comparing two SDK versions.
 
 | Variable            | Description                                    |
 |---------------------|------------------------------------------------|
@@ -105,6 +109,7 @@ rate(sdk_retry_attempts_total[1m])
 docker compose \
   --profile telemetry \
   --profile chaos \
+  --profile extra-nodes \
   --profile workload-current \
   down
 ```

--- a/tests/slo/compose.yaml
+++ b/tests/slo/compose.yaml
@@ -1,2 +1,4 @@
+name: ydb
+
 include:
   - path: https://github.com/ydb-platform/ydb-slo-action.git#v2:deploy/compose.yml


### PR DESCRIPTION
## Summary

- set the local Docker Compose project name to `ydb`
- enable the `extra-nodes` profile in the default local SLO commands
- document which profiles are enabled by default and when `workload-baseline` is needed

## Motivation

The upstream chaos-monkey creates blackhole containers in the hardcoded
`ydb_slo` network. Without an explicit project name, Docker Compose used the
local directory name and created `slo_slo`, causing fault injection to fail
with:

    network ydb_slo not found

The documented local run also omitted the `extra-nodes` profile, so it started
only two database nodes instead of the five-node setup expected by the rolling
restart scenarios.

## Validation

Resolved the Compose configuration with all default profiles and verified:

- project name: `ydb`
- network name: `ydb_slo`
- database nodes: `database-1` through `database-5`
- chaos, telemetry, and current workload services are enabled

No changelog entry is required because this only changes local SLO tooling and
documentation.