### PR TITLE
fix(pool): prevent idle item starvation

### DIFF
--- a/.agents/context/systemPatterns.md
+++ b/.agents/context/systemPatterns.md
@@ -103,18 +103,13 @@ Query additionally has **implicit** session pool for server-side session managem
 ### Session-pool reuse and expiration
 
 - Session expiration is lazy: idle TTL, usage TTL, and usage-limit checks run while an item is acquired from the pool. There is no background idle-session reaper in `internal/pool`.
-- Commit `0d2a081093671731fea36ffbbb62853b99a3133f` (`perf: internal.Pool with semaphore (#2163)`) shipped in v3.138.0 and changed idle-item reuse to a slice-backed LIFO path. This improved hot-item reuse, but a naive LIFO path can permanently hide older idle sessions underneath a frequently reused item.
-- The resulting failure mode is visible during rolling restarts: the client continues creating sessions while old server sessions await cleanup, even when `WithSessionPoolIdleThreshold` is configured. Repeated connection bans or `OVERLOADED` responses may accompany the incident, but they do not explain sessions that never reach the pool's idle-expiration check.
-- Preserve the LIFO fast path for valid items, but give the oldest item an expiration opportunity. On the first acquisition attempt, check the oldest item for idle TTL, usage TTL, or usage-limit expiry; close it if expired, otherwise acquire through normal LIFO/node-hint selection. Do not run the liveness predicate merely to inspect the oldest item; the selected item still goes through the normal full close check.
-- The slice container supports O(1) oldest removal with a logical `head` and amortized compaction. All length, limit, clear, LIFO, and node-specific operations must account for `head`.
-- Regression-test shape: create several sessions with a fake clock, refresh only the newest LIFO session, advance beyond idle TTL for the older sessions, and verify repeated operations close the old sessions while continuing to use the hot one. This test failed before the fix because the old sessions were never selected.
+- LIFO reuse must not starve older sessions from expiration checks. Inspect the oldest item for configured expiry before the normal LIFO or node-hint selection, without running its liveness predicate merely for inspection.
+- The idle container supports efficient removal from both ends while preserving its length, limit, clear, LIFO, and node-specific semantics.
 
 ### Session metrics: client state vs server state
 
-- `ydb.table.sessions{node_id}` is a client lifecycle gauge from `metrics/table.go`: it increments after successful session creation and decrements when deletion starts. It does **not** confirm that `DeleteSession` succeeded on the server.
-- `ydb.table.pool.index`, `idle`, `in_use`, `createInProgress`, `concurrency`, and `wait` are pool-state snapshots derived from `TablePoolStateChange`. `pool.index` is the pool's current `Size`, so it can legitimately differ from `ydb.table.sessions`.
-- Driver `request_methods{method,node_id,...}` and `request_statuses{status,node_id,...}` expose gRPC attempt traffic and outcomes, but method and status are separate counter families; they cannot reliably reconstruct an operation-by-status matrix without additional instrumentation.
-- For a server-session leak investigation, use YDB's `table_session_active_count` as the authoritative active-session count and correlate it with SDK pool gauges and CreateSession/DeleteSession request counters.
+- SDK session and pool metrics describe client lifecycle and pool state; they do not prove that a session was deleted on the server.
+- Diagnose server-session leaks with server-side active-session metrics, correlated with SDK pool state and session RPC activity.
 
 ## Balancer and discovery (`internal/balancer/`)
 

--- a/.agents/context/systemPatterns.md
+++ b/.agents/context/systemPatterns.md
@@ -100,6 +100,22 @@ Table and query each maintain their own session pool instance inside `internal/t
 
 Query additionally has **implicit** session pool for server-side session management (see `internal/query/client.go`).
 
+### Session-pool reuse and expiration
+
+- Session expiration is lazy: idle TTL, usage TTL, and usage-limit checks run while an item is acquired from the pool. There is no background idle-session reaper in `internal/pool`.
+- Commit `0d2a081093671731fea36ffbbb62853b99a3133f` (`perf: internal.Pool with semaphore (#2163)`) shipped in v3.138.0 and changed idle-item reuse to a slice-backed LIFO path. This improved hot-item reuse, but a naive LIFO path can permanently hide older idle sessions underneath a frequently reused item.
+- The resulting failure mode is visible during rolling restarts: the client continues creating sessions while old server sessions await cleanup, even when `WithSessionPoolIdleThreshold` is configured. Repeated connection bans or `OVERLOADED` responses may accompany the incident, but they do not explain sessions that never reach the pool's idle-expiration check.
+- Preserve the LIFO fast path for valid items, but give the oldest item an expiration opportunity. On the first acquisition attempt, check the oldest item for idle TTL, usage TTL, or usage-limit expiry; close it if expired, otherwise acquire through normal LIFO/node-hint selection. Do not run the liveness predicate merely to inspect the oldest item; the selected item still goes through the normal full close check.
+- The slice container supports O(1) oldest removal with a logical `head` and amortized compaction. All length, limit, clear, LIFO, and node-specific operations must account for `head`.
+- Regression-test shape: create several sessions with a fake clock, refresh only the newest LIFO session, advance beyond idle TTL for the older sessions, and verify repeated operations close the old sessions while continuing to use the hot one. This test failed before the fix because the old sessions were never selected.
+
+### Session metrics: client state vs server state
+
+- `ydb.table.sessions{node_id}` is a client lifecycle gauge from `metrics/table.go`: it increments after successful session creation and decrements when deletion starts. It does **not** confirm that `DeleteSession` succeeded on the server.
+- `ydb.table.pool.index`, `idle`, `in_use`, `createInProgress`, `concurrency`, and `wait` are pool-state snapshots derived from `TablePoolStateChange`. `pool.index` is the pool's current `Size`, so it can legitimately differ from `ydb.table.sessions`.
+- Driver `request_methods{method,node_id,...}` and `request_statuses{status,node_id,...}` expose gRPC attempt traffic and outcomes, but method and status are separate counter families; they cannot reliably reconstruct an operation-by-status matrix without additional instrumentation.
+- For a server-session leak investigation, use YDB's `table_session_active_count` as the authoritative active-session count and correlate it with SDK pool gauges and CreateSession/DeleteSession request counters.
+
 ## Balancer and discovery (`internal/balancer/`)
 
 ```

--- a/.agents/context/techContext.md
+++ b/.agents/context/techContext.md
@@ -59,6 +59,41 @@ Stress a single flaky integration test: add `-count=N -run 'TestName$'` to the `
 | `slo.yml` | push/PR + manual | SLO benchmarks (active in go-sdk) |
 | `publish.yml` | manual | version bump + release |
 
+## Rolling-restart session-pool A/B
+
+For session-lifecycle regressions, use the native Table workload with a five-node stack and isolate the rolling-restart scenario. The default chaos profile runs multiple/random scenarios and is unsuitable for comparing two SDK revisions unless the selected fault sequence is identical.
+
+Baseline and candidate must use the same:
+
+- `SRC_PATH=native/table` workload;
+- `WithSessionPoolIdleThreshold(5 * time.Second)` option;
+- five database nodes (`--profile extra-nodes`);
+- workload duration, load, server images, rolling order, and observation offsets;
+- clean Compose volumes between runs.
+
+Use a temporary Compose override for `chaos-monkey` that runs only `/opt/ydb.tech/chaos/scenarios/05-rolling-restart.sh`. Keep the override out of the production diff. On Apple Silicon, build both workload images for `linux/amd64`, matching the upstream Compose service.
+
+Measure the server metric, not only SDK gauges:
+
+```promql
+sum(table_session_active_count)
+max_over_time(sum(table_session_active_count)[5m:2s])
+sum by (instance) (table_session_active_count)
+```
+
+Record the peak, values at fixed offsets (for example 25 and 90 seconds after rolling completes), per-node distribution, workload exit code, and the value after `Driver.Close`.
+
+Validated 2026-07-17 with otherwise identical rolling-only runs:
+
+| Measurement | clean v3.137.0 | oldest-expired/LIFO fix |
+|-------------|---------------:|------------------------:|
+| Peak server sessions | 1029 | 1000 |
+| About 25 seconds after rolling | 634 | 46 |
+| About 90 seconds after rolling | 630 | 25 |
+| First post-workload observation | 2 | 0 after the next scrape |
+
+Both workloads exited successfully. Treat the exact counts as environment-specific evidence; the durable signal is that the candidate returns to the small active working set instead of retaining hundreds of sessions.
+
 ## PR labels that skip CI gates
 
 `no lint`, `no tests`, `no integration tests`, `no changelog`, `no examples`, `broken changes`

--- a/.agents/context/techContext.md
+++ b/.agents/context/techContext.md
@@ -59,41 +59,6 @@ Stress a single flaky integration test: add `-count=N -run 'TestName$'` to the `
 | `slo.yml` | push/PR + manual | SLO benchmarks (active in go-sdk) |
 | `publish.yml` | manual | version bump + release |
 
-## Rolling-restart session-pool A/B
-
-For session-lifecycle regressions, use the native Table workload with a five-node stack and isolate the rolling-restart scenario. The default chaos profile runs multiple/random scenarios and is unsuitable for comparing two SDK revisions unless the selected fault sequence is identical.
-
-Baseline and candidate must use the same:
-
-- `SRC_PATH=native/table` workload;
-- `WithSessionPoolIdleThreshold(5 * time.Second)` option;
-- five database nodes (`--profile extra-nodes`);
-- workload duration, load, server images, rolling order, and observation offsets;
-- clean Compose volumes between runs.
-
-Use a temporary Compose override for `chaos-monkey` that runs only `/opt/ydb.tech/chaos/scenarios/05-rolling-restart.sh`. Keep the override out of the production diff. On Apple Silicon, build both workload images for `linux/amd64`, matching the upstream Compose service.
-
-Measure the server metric, not only SDK gauges:
-
-```promql
-sum(table_session_active_count)
-max_over_time(sum(table_session_active_count)[5m:2s])
-sum by (instance) (table_session_active_count)
-```
-
-Record the peak, values at fixed offsets (for example 25 and 90 seconds after rolling completes), per-node distribution, workload exit code, and the value after `Driver.Close`.
-
-Validated 2026-07-17 with otherwise identical rolling-only runs:
-
-| Measurement | clean v3.137.0 | oldest-expired/LIFO fix |
-|-------------|---------------:|------------------------:|
-| Peak server sessions | 1029 | 1000 |
-| About 25 seconds after rolling | 634 | 46 |
-| About 90 seconds after rolling | 630 | 25 |
-| First post-workload observation | 2 | 0 after the next scrape |
-
-Both workloads exited successfully. Treat the exact counts as environment-specific evidence; the durable signal is that the candidate returns to the small active working set instead of retaining hundreds of sessions.
-
 ## PR labels that skip CI gates
 
 `no lint`, `no tests`, `no integration tests`, `no changelog`, `no examples`, `broken changes`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed expired idle sessions being starved behind frequently reused sessions in Table and Query session pools
+
 ## v3.144.4
 * Changed driver connection metrics to expose `conns` by state and count `conn.banned` events with a counter
 

--- a/internal/pool/container.go
+++ b/internal/pool/container.go
@@ -5,13 +5,14 @@ import "sync"
 type sliceContainer[PT ItemConstraint[T], T any] struct {
 	mu   sync.Mutex
 	data []*itemInfo[PT, T]
+	head int
 }
 
 func (items *sliceContainer[PT, T]) PutWithCheckLimit(info *itemInfo[PT, T], limit int) error {
 	items.mu.Lock()
 	defer items.mu.Unlock()
 
-	if len(items.data) >= limit {
+	if items.len() >= limit {
 		return errPoolIsOverflow
 	}
 
@@ -24,16 +25,17 @@ func (items *sliceContainer[PT, T]) Clear() (data []*itemInfo[PT, T]) {
 
 	defer func() {
 		items.data = nil
+		items.head = 0
 	}()
 
-	return items.data
+	return items.data[items.head:]
 }
 
 func (items *sliceContainer[PT, T]) Len() int {
 	items.mu.Lock()
 	defer items.mu.Unlock()
 
-	return len(items.data)
+	return items.len()
 }
 
 func (items *sliceContainer[PT, T]) Put(info *itemInfo[PT, T]) error {
@@ -44,16 +46,43 @@ func (items *sliceContainer[PT, T]) Put(info *itemInfo[PT, T]) error {
 }
 
 func (items *sliceContainer[PT, T]) put(info *itemInfo[PT, T]) error {
+	items.compact()
 	items.data = append(items.data, info)
 
 	return nil
+}
+
+func (items *sliceContainer[PT, T]) len() int {
+	return len(items.data) - items.head
+}
+
+func (items *sliceContainer[PT, T]) compact() {
+	if items.head == 0 || items.head*2 < len(items.data) {
+		return
+	}
+
+	n := copy(items.data, items.data[items.head:])
+	clear(items.data[n:])
+	items.data = items.data[:n]
+	items.head = 0
+}
+
+func (items *sliceContainer[PT, T]) resetIfEmpty() {
+	if items.head == len(items.data) {
+		items.data = nil
+		items.head = 0
+	}
 }
 
 func (items *sliceContainer[PT, T]) Pop() (info *itemInfo[PT, T], _ error) {
 	items.mu.Lock()
 	defer items.mu.Unlock()
 
-	if len(items.data) == 0 {
+	return items.pop()
+}
+
+func (items *sliceContainer[PT, T]) pop() (info *itemInfo[PT, T], _ error) {
+	if items.len() == 0 {
 		return nil, errNothingIdleItems
 	}
 
@@ -61,19 +90,66 @@ func (items *sliceContainer[PT, T]) Pop() (info *itemInfo[PT, T], _ error) {
 	info = items.data[last]
 	items.data[last] = nil
 	items.data = items.data[:last]
+	items.resetIfEmpty()
 
 	return info, nil
+}
+
+func (items *sliceContainer[PT, T]) PopOrOldestIf(
+	predicate func(*itemInfo[PT, T]) bool,
+) (*itemInfo[PT, T], error) {
+	items.mu.Lock()
+	defer items.mu.Unlock()
+
+	if info, ok := items.popOldestIf(predicate); ok {
+		return info, nil
+	}
+
+	return items.pop()
+}
+
+func (items *sliceContainer[PT, T]) popOldestIf(
+	predicate func(*itemInfo[PT, T]) bool,
+) (*itemInfo[PT, T], bool) {
+	if items.len() == 0 || !predicate(items.data[items.head]) {
+		return nil, false
+	}
+
+	info := items.data[items.head]
+	items.data[items.head] = nil
+	items.head++
+	items.resetIfEmpty()
+
+	return info, true
 }
 
 func (items *sliceContainer[PT, T]) PopByNodeID(nodeID uint32) (*itemInfo[PT, T], error) {
 	items.mu.Lock()
 	defer items.mu.Unlock()
 
-	if len(items.data) == 0 {
+	return items.popByNodeID(nodeID)
+}
+
+func (items *sliceContainer[PT, T]) PopByNodeIDOrOldestIf(
+	nodeID uint32,
+	predicate func(*itemInfo[PT, T]) bool,
+) (*itemInfo[PT, T], error) {
+	items.mu.Lock()
+	defer items.mu.Unlock()
+
+	if info, ok := items.popOldestIf(predicate); ok {
+		return info, nil
+	}
+
+	return items.popByNodeID(nodeID)
+}
+
+func (items *sliceContainer[PT, T]) popByNodeID(nodeID uint32) (*itemInfo[PT, T], error) {
+	if items.len() == 0 {
 		return nil, errNothingIdleItems
 	}
 
-	for i := len(items.data) - 1; i >= 0; i-- {
+	for i := len(items.data) - 1; i >= items.head; i-- {
 		if items.data[i].item.NodeID() != nodeID {
 			continue
 		}
@@ -83,6 +159,7 @@ func (items *sliceContainer[PT, T]) PopByNodeID(nodeID uint32) (*itemInfo[PT, T]
 		copy(items.data[i:], items.data[i+1:])
 		items.data[last] = nil
 		items.data = items.data[:last]
+		items.resetIfEmpty()
 
 		return info, nil
 	}

--- a/internal/pool/container_test.go
+++ b/internal/pool/container_test.go
@@ -41,6 +41,53 @@ type (
 
 const containerLen = 500
 
+func TestSliceContainerPopOldestIfPreservesLIFO(t *testing.T) {
+	items := &sliceContainer[*testItem, testItem]{}
+	newInfo := func(id uint32) *itemInfo[*testItem, testItem] {
+		return &itemInfo[*testItem, testItem]{
+			item: &testItem{
+				v: int32(id),
+				onNodeID: func() uint32 {
+					return id
+				},
+			},
+		}
+	}
+
+	for id := uint32(1); id <= 3; id++ {
+		require.NoError(t, items.Put(newInfo(id)))
+	}
+
+	info, err := items.PopOrOldestIf(func(info *itemInfo[*testItem, testItem]) bool {
+		return info.item.v == 0
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 3, info.item.v)
+	require.NoError(t, items.Put(info))
+	require.Equal(t, 3, items.Len())
+
+	info, err = items.PopOrOldestIf(func(info *itemInfo[*testItem, testItem]) bool {
+		return info.item.v == 1
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, info.item.v)
+	require.Equal(t, 2, items.Len())
+
+	info, err = items.Pop()
+	require.NoError(t, err)
+	require.EqualValues(t, 3, info.item.v)
+
+	require.NoError(t, items.Put(newInfo(4)))
+	info, err = items.PopByNodeID(2)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, info.item.v)
+
+	info, err = items.Pop()
+	require.NoError(t, err)
+	require.EqualValues(t, 4, info.item.v)
+	require.Zero(t, items.Len())
+}
+
 // BenchmarkContainers/xsync.Set-12         	 1174489	      1011 ns/op	      86 B/op	       1 allocs/op
 // BenchmarkContainers/slice-12             	 1000000	      1511 ns/op	       0 B/op	       0 allocs/op
 // BenchmarkContainers/map-12               	  674767	      1757 ns/op	       1 B/op	       0 allocs/op

--- a/internal/pool/container_test.go
+++ b/internal/pool/container_test.go
@@ -88,6 +88,35 @@ func TestSliceContainerPopOldestIfPreservesLIFO(t *testing.T) {
 	require.Zero(t, items.Len())
 }
 
+func TestSliceContainerPopByNodeIDOrOldestIfReturnsOldestFirst(t *testing.T) {
+	items := &sliceContainer[*testItem, testItem]{}
+	newInfo := func(id uint32) *itemInfo[*testItem, testItem] {
+		return &itemInfo[*testItem, testItem]{
+			item: &testItem{
+				v: int32(id),
+				onNodeID: func() uint32 {
+					return id
+				},
+			},
+		}
+	}
+
+	for id := uint32(1); id <= 2; id++ {
+		require.NoError(t, items.Put(newInfo(id)))
+	}
+
+	info, err := items.PopByNodeIDOrOldestIf(2, func(info *itemInfo[*testItem, testItem]) bool {
+		return info.item.v == 1
+	})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, info.item.v)
+
+	info, err = items.PopByNodeID(2)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, info.item.v)
+	require.Zero(t, items.Len())
+}
+
 // BenchmarkContainers/xsync.Set-12         	 1174489	      1011 ns/op	      86 B/op	       1 allocs/op
 // BenchmarkContainers/slice-12             	 1000000	      1511 ns/op	       0 B/op	       0 allocs/op
 // BenchmarkContainers/map-12               	  674767	      1757 ns/op	       1 B/op	       0 allocs/op

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -630,6 +630,8 @@ func needCloseItem[PT ItemConstraint[T], T any](c *Config[PT, T], info *itemInfo
 }
 
 func needCloseOldestItem[PT ItemConstraint[T], T any](c *Config[PT, T], info *itemInfo[PT, T]) bool {
+	// Do not call IsAlive while only inspecting the oldest item. The item selected
+	// from the container goes through the full needCloseItem check afterwards.
 	return needCloseItemByMaxUsage(c, info) ||
 		needCloseItemByTTL(c, info) ||
 		needCloseItemByIdleTTL(c, info)

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -629,6 +629,12 @@ func needCloseItem[PT ItemConstraint[T], T any](c *Config[PT, T], info *itemInfo
 	return false
 }
 
+func needCloseOldestItem[PT ItemConstraint[T], T any](c *Config[PT, T], info *itemInfo[PT, T]) bool {
+	return needCloseItemByMaxUsage(c, info) ||
+		needCloseItemByTTL(c, info) ||
+		needCloseItemByIdleTTL(c, info)
+}
+
 func getNodeHintInfo[PT ItemConstraint[T], T any](
 	item PT,
 	preferredNodeID uint32,
@@ -648,7 +654,7 @@ func getNodeHintInfo[PT ItemConstraint[T], T any](
 	return res
 }
 
-func (p *Pool[PT, T]) popItem(nodeID uint32, useNodeID bool, batchChanges *dynamicStats) (
+func (p *Pool[PT, T]) popItem(nodeID uint32, useNodeID, checkOldest bool, batchChanges *dynamicStats) (
 	info *itemInfo[PT, T], _ error,
 ) {
 	defer func() {
@@ -656,6 +662,17 @@ func (p *Pool[PT, T]) popItem(nodeID uint32, useNodeID bool, batchChanges *dynam
 			batchChanges.Idle--
 		}
 	}()
+
+	if checkOldest {
+		predicate := func(info *itemInfo[PT, T]) bool {
+			return needCloseOldestItem(p.config, info)
+		}
+		if useNodeID {
+			return p.idle.PopByNodeIDOrOldestIf(nodeID, predicate)
+		}
+
+		return p.idle.PopOrOldestIf(predicate)
+	}
 
 	if useNodeID {
 		return p.idle.PopByNodeID(nodeID)
@@ -690,10 +707,10 @@ func (p *Pool[PT, T]) getItem(ctx context.Context, batchChanges *dynamicStats) (
 		}
 	}
 
-	for range 2 {
+	for i := range 2 {
 		attempts++
 
-		info, err := p.popItem(nodeID, hasPreferredNodeID, batchChanges)
+		info, err := p.popItem(nodeID, hasPreferredNodeID, i == 0, batchChanges)
 		if err != nil {
 			break
 		}
@@ -711,7 +728,7 @@ func (p *Pool[PT, T]) getItem(ctx context.Context, batchChanges *dynamicStats) (
 		size := st.Size + batchChanges.Size
 		if st.Concurrency == p.config.limit || size >= p.config.limit {
 			// Free a slot before createItem: full concurrent load or pool already at limit.
-			info, err := p.popItem(0, false, batchChanges)
+			info, err := p.popItem(0, false, false, batchChanges)
 			if err != nil {
 				return nil, errNothingIdleItems
 			}

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -191,6 +191,64 @@ func requirePoolStats(t testing.TB, p *Pool[*testItem, testItem], want Stats, ms
 	require.Equal(t, want, p.Stats(), msg...)
 }
 
+func TestPoolIdleTTLDoesNotStarveBehindHotItem(t *testing.T) {
+	const (
+		limit         = 3
+		idleThreshold = 4 * time.Second
+	)
+
+	var (
+		created   atomic.Int32
+		closed    atomic.Int32
+		fakeClock = clockwork.NewFakeClock()
+	)
+	p := mustNewPool[*testItem, testItem](t,
+		WithLimit[*testItem, testItem](limit),
+		WithClock[*testItem, testItem](fakeClock),
+		WithIdleTimeToLive[*testItem, testItem](idleThreshold),
+		WithCreateItemFunc(func(context.Context) (*testItem, error) {
+			return &testItem{
+				v: created.Add(1),
+				onClose: func() error {
+					closed.Add(1)
+
+					return nil
+				},
+			}, nil
+		}),
+	)
+	defer mustClose(t, p)
+
+	infos := make([]*itemInfo[*testItem, testItem], limit)
+	for i := range limit {
+		infos[i] = mustGetItem(t, p)
+	}
+	for _, info := range infos {
+		mustPutItem(t, p, info)
+	}
+
+	fakeClock.Advance(idleThreshold / 2)
+	hot := mustGetItem(t, p)
+	require.EqualValues(t, limit, hot.item.v)
+	mustPutItem(t, p, hot)
+
+	fakeClock.Advance(idleThreshold/2 + time.Nanosecond)
+	for range limit - 1 {
+		err := p.With(t.Context(), func(_ context.Context, item *testItem) error {
+			require.EqualValues(t, limit, item.v)
+
+			return nil
+		})
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, int32(limit-1), closed.Load())
+	requirePoolStats(t, p, poolStats(limit, func(s *Stats) {
+		s.Size = 1
+		s.Idle = 1
+	}))
+}
+
 func TestPool(t *testing.T) { //nolint:gocyclo
 	t.Run("New", func(t *testing.T) {
 		t.Run("Default", func(t *testing.T) {

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -249,6 +249,60 @@ func TestPoolIdleTTLDoesNotStarveBehindHotItem(t *testing.T) {
 	}))
 }
 
+func TestPoolIdleTTLWithPreferredNode(t *testing.T) {
+	const (
+		preferredNodeID = 42
+		idleThreshold   = 4 * time.Second
+	)
+
+	var (
+		closed    atomic.Int32
+		fakeClock = clockwork.NewFakeClock()
+	)
+	p := mustNewPool[*testItem, testItem](t,
+		WithLimit[*testItem, testItem](2),
+		WithClock[*testItem, testItem](fakeClock),
+		WithIdleTimeToLive[*testItem, testItem](idleThreshold),
+		WithCreateItemFunc(func(ctx context.Context) (*testItem, error) {
+			nodeID, _ := endpoint.ContextNodeID(ctx)
+
+			return &testItem{
+				onClose: func() error {
+					closed.Add(1)
+
+					return nil
+				},
+				onNodeID: func() uint32 {
+					return nodeID
+				},
+			}, nil
+		}),
+	)
+	defer mustClose(t, p)
+
+	oldest := mustGetItem(t, p)
+	mustPutItem(t, p, oldest)
+
+	fakeClock.Advance(idleThreshold / 2)
+	ctx := endpoint.WithNodeID(t.Context(), preferredNodeID)
+	preferred, err := getItemWithFlush(ctx, p)
+	require.NoError(t, err)
+	require.EqualValues(t, preferredNodeID, preferred.item.NodeID())
+	mustPutItem(t, p, preferred)
+
+	fakeClock.Advance(idleThreshold/2 + time.Nanosecond)
+	preferred, err = getItemWithFlush(ctx, p)
+	require.NoError(t, err)
+	require.EqualValues(t, preferredNodeID, preferred.item.NodeID())
+	require.Equal(t, int32(1), closed.Load())
+	mustPutItem(t, p, preferred)
+
+	requirePoolStats(t, p, poolStats(2, func(s *Stats) {
+		s.Size = 1
+		s.Idle = 1
+	}))
+}
+
 func TestPool(t *testing.T) { //nolint:gocyclo
 	t.Run("New", func(t *testing.T) {
 		t.Run("Default", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Prevent expired idle items from starving behind frequently reused items in the pool.

The slice-based pool introduced LIFO reuse in v3.138.0. Under sustained load, the newest hot sessions remained at the top of the pool while older idle sessions were never selected and therefore never checked against the idle TTL. During rolling restarts this caused the number of server-side sessions to grow.

The pool now:

- checks the oldest item for expiration before using the normal LIFO path;
- closes it when its idle TTL, usage TTL, or usage limit has expired;
- preserves LIFO reuse when the oldest item is still valid;
- removes oldest items in O(1), with amortized slice compaction.

A regression test covers expired idle items hidden behind a repeatedly reused hot item.

## Rolling restart SLO

Test configuration:

- native Table Client workload;
- five-node local YDB installation;
- rolling-only restart scenario;
- `WithSessionPoolIdleThreshold(5 * time.Second)`;
- identical workload and server configuration for both versions.

| Measurement | v3.137.0 | This PR |
|---|---:|---:|
| Peak server sessions | 1029 | 1000 |
| Sessions ~25s after rolling restart | 634 | 46 |
| Sessions ~90s after rolling restart | 630 | 25 |
| Sessions after driver close | 2 on the first scrape | 0 |

Both workloads completed successfully with exit code 0.