### PR TITLE
fix(meta): send observability chains only on Discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Send observability adoption chains (`ydb-sdk-tracing`, `ydb-sdk-metrics`) in `x-ydb-sdk-build-info` only on Discovery, so `.sys/query_sessions.ClientSdkBuildInfo` stays free of telemetry markers
+
 ## v3.144.4
 * Changed driver connection metrics to expose `conns` by state and count `conn.banned` events with a counter
 

--- a/internal/balancer/balancer.go
+++ b/internal/balancer/balancer.go
@@ -370,7 +370,7 @@ func makeDiscoveryFunc(
 			)
 		}
 
-		ctx, err = driverConfig.Meta().Context(ctx)
+		ctx, err = driverConfig.Meta().DiscoveryContext(ctx)
 		if err != nil {
 			return endpoints, location, xerrors.WithStackTrace(
 				fmt.Errorf("failed to enrich context with meta, traceID %q: %w", traceID, err),

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -112,7 +112,7 @@ func (c *Client) Discover(ctx context.Context) (endpoints []endpoint.Endpoint, f
 		onDone(location, nodes, finalErr)
 	}()
 
-	ctx, err := c.config.Meta().Context(ctx)
+	ctx, err := c.config.Meta().DiscoveryContext(ctx)
 	if err != nil {
 		return nil, xerrors.WithStackTrace(err)
 	}

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -77,16 +77,21 @@ func WithBuildInfo(frameworkName string, frameworkVersion string) Option {
 // intentionally omitted here so they do not pollute
 // `.sys/query_sessions.ClientSdkBuildInfo`.
 func (info *buildInfo) makeHeader() string {
+	return buildInfoFirstPart + info.frameworkSuffix()
+}
+
+// frameworkSuffix returns ";framework/version..." for custom frameworks only.
+func (info *buildInfo) frameworkSuffix() string {
 	frameworkKeys := xslices.Keys(info.frameworks)
 	frameworkKeys = xslices.Filter(frameworkKeys, func(frameworkName string) bool {
 		return frameworkName != observability.TracingChainName &&
 			frameworkName != observability.MetricsChainName
 	})
 	if len(frameworkKeys) == 0 {
-		return buildInfoFirstPart
+		return ""
 	}
 
-	return buildInfoFirstPart + ";" + strings.Join(
+	return ";" + strings.Join(
 		xslices.Transform(
 			frameworkKeys,
 			func(frameworkName string) string {
@@ -101,11 +106,11 @@ func (info *buildInfo) makeHeader() string {
 // Example: "ydb-sdk-tracing/0.1.0;ydb-sdk-metrics/0.1.0".
 func (info *buildInfo) observabilityChains() string {
 	var chains []string
-	if version, ok := info.frameworks[observability.TracingChainName]; ok {
-		chains = append(chains, observability.TracingChainName+"/"+version)
+	if chainVersion, ok := info.frameworks[observability.TracingChainName]; ok {
+		chains = append(chains, observability.TracingChainName+"/"+chainVersion)
 	}
-	if version, ok := info.frameworks[observability.MetricsChainName]; ok {
-		chains = append(chains, observability.MetricsChainName+"/"+version)
+	if chainVersion, ok := info.frameworks[observability.MetricsChainName]; ok {
+		chains = append(chains, observability.MetricsChainName+"/"+chainVersion)
 	}
 
 	return strings.Join(chains, ";")
@@ -240,10 +245,11 @@ func (m *Meta) Context(ctx context.Context) (_ context.Context, err error) {
 // x-ydb-sdk-build-info. Use it only for Discovery.ListEndpoints.
 func (m *Meta) DiscoveryContext(ctx context.Context) (_ context.Context, err error) {
 	info := m.buildInfo.Load()
-	header := info.buildInfoHeader
+	header := buildInfoFirstPart
 	if chains := info.observabilityChains(); chains != "" {
-		header = buildInfoFirstPart + " " + chains + strings.TrimPrefix(info.buildInfoHeader, buildInfoFirstPart)
+		header += " " + chains
 	}
+	header += info.frameworkSuffix()
 
 	md, err := m.meta(ctx, header)
 	if err != nil {

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -38,9 +38,8 @@ func New(
 	}
 
 	m.buildInfo.Store(&buildInfo{
-		frameworks:               make(map[string]string),
-		buildInfoHeader:          buildInfoFirstPart,
-		discoveryBuildInfoHeader: buildInfoFirstPart,
+		frameworks:      make(map[string]string),
+		buildInfoHeader: buildInfoFirstPart,
 	})
 
 	for _, opt := range opts {
@@ -68,78 +67,48 @@ func WithBuildInfo(frameworkName string, frameworkVersion string) Option {
 		}
 		maps.Copy(next.frameworks, current.frameworks)
 		next.frameworks[frameworkName] = frameworkVersion
-
-		next.buildInfoHeader = next.makeHeader(false)
-		next.discoveryBuildInfoHeader = next.makeHeader(true)
+		next.buildInfoHeader = next.makeHeader()
 		m.buildInfo.Store(next)
 	}
 }
 
-// makeHeader keeps backward-compatible semantics for build-info parsers.
-//
-// Regular requests (includeObservability=false) keep session-facing headers lean:
-// only the base SDK token and custom frameworks. Observability adoption chains are
-// intentionally omitted so they do not pollute `.sys/query_sessions.ClientSdkBuildInfo`.
-//
-// Discovery requests (includeObservability=true) append chain markers:
-// - chain markers are appended after the base token using a space;
-// - tracing and metrics markers are separated with ';' when both are present;
-// - custom frameworks remain in ';framework/version' form.
-func (info *buildInfo) makeHeader(includeObservability bool) string {
-	builder := strings.Builder{}
-	builder.WriteString(buildInfoFirstPart)
-
-	if includeObservability {
-		info.writeObservabilityChains(&builder)
-	}
-
+// makeHeader builds the session-facing x-ydb-sdk-build-info value:
+// base SDK token plus custom frameworks. Observability adoption chains are
+// intentionally omitted here so they do not pollute
+// `.sys/query_sessions.ClientSdkBuildInfo`.
+func (info *buildInfo) makeHeader() string {
 	frameworkKeys := xslices.Keys(info.frameworks)
 	frameworkKeys = xslices.Filter(frameworkKeys, func(frameworkName string) bool {
 		return frameworkName != observability.TracingChainName &&
 			frameworkName != observability.MetricsChainName
 	})
-
 	if len(frameworkKeys) == 0 {
-		return builder.String()
+		return buildInfoFirstPart
 	}
 
-	builder.WriteString(";")
-	builder.WriteString(
-		strings.Join(
-			xslices.Transform(
-				frameworkKeys,
-				func(frameworkName string) string {
-					return frameworkName + "/" + info.frameworks[frameworkName]
-				},
-			), ";",
+	return buildInfoFirstPart + ";" + strings.Join(
+		xslices.Transform(
+			frameworkKeys,
+			func(frameworkName string) string {
+				return frameworkName + "/" + info.frameworks[frameworkName]
+			},
 		),
+		";",
 	)
-
-	return builder.String()
 }
 
-func (info *buildInfo) writeObservabilityChains(builder *strings.Builder) {
-	tracingVersion, hasTracing := info.frameworks[observability.TracingChainName]
-	if hasTracing {
-		builder.WriteString(" ")
-		builder.WriteString(observability.TracingChainName)
-		builder.WriteString("/")
-		builder.WriteString(tracingVersion)
+// observabilityChains returns adoption markers for Discovery only, joined with ';'.
+// Example: "ydb-sdk-tracing/0.1.0;ydb-sdk-metrics/0.1.0".
+func (info *buildInfo) observabilityChains() string {
+	var chains []string
+	if version, ok := info.frameworks[observability.TracingChainName]; ok {
+		chains = append(chains, observability.TracingChainName+"/"+version)
+	}
+	if version, ok := info.frameworks[observability.MetricsChainName]; ok {
+		chains = append(chains, observability.MetricsChainName+"/"+version)
 	}
 
-	metricsVersion, hasMetrics := info.frameworks[observability.MetricsChainName]
-	if !hasMetrics {
-		return
-	}
-
-	if hasTracing {
-		builder.WriteString(";")
-	} else {
-		builder.WriteString(" ")
-	}
-	builder.WriteString(observability.MetricsChainName)
-	builder.WriteString("/")
-	builder.WriteString(metricsVersion)
+	return strings.Join(chains, ";")
 }
 
 func WithRequestTypeOption(requestType string) Option {
@@ -169,9 +138,8 @@ func ForbidOption(feature string) Option {
 
 type (
 	buildInfo struct {
-		frameworks               map[string]string // frameworkName -> version
-		buildInfoHeader          string
-		discoveryBuildInfoHeader string
+		frameworks      map[string]string // frameworkName -> version
+		buildInfoHeader string
 	}
 	Meta struct {
 		pid             string
@@ -268,11 +236,16 @@ func (m *Meta) Context(ctx context.Context) (_ context.Context, err error) {
 	return metadata.NewOutgoingContext(ctx, md), nil
 }
 
-// DiscoveryContext is like Context, but includes observability adoption chains in
-// x-ydb-sdk-build-info. Use it only for Discovery.ListEndpoints so session-facing
-// RPCs (CreateSession and friends) keep a lean ClientSdkBuildInfo.
+// DiscoveryContext is like Context, but appends observability adoption chains to
+// x-ydb-sdk-build-info. Use it only for Discovery.ListEndpoints.
 func (m *Meta) DiscoveryContext(ctx context.Context) (_ context.Context, err error) {
-	md, err := m.meta(ctx, m.buildInfo.Load().discoveryBuildInfoHeader)
+	info := m.buildInfo.Load()
+	header := info.buildInfoHeader
+	if chains := info.observabilityChains(); chains != "" {
+		header = buildInfoFirstPart + " " + chains + strings.TrimPrefix(info.buildInfoHeader, buildInfoFirstPart)
+	}
+
+	md, err := m.meta(ctx, header)
 	if err != nil {
 		return ctx, xerrors.WithStackTrace(err)
 	}

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -77,21 +77,16 @@ func WithBuildInfo(frameworkName string, frameworkVersion string) Option {
 // intentionally omitted here so they do not pollute
 // `.sys/query_sessions.ClientSdkBuildInfo`.
 func (info *buildInfo) makeHeader() string {
-	return buildInfoFirstPart + info.frameworkSuffix()
-}
-
-// frameworkSuffix returns ";framework/version..." for custom frameworks only.
-func (info *buildInfo) frameworkSuffix() string {
 	frameworkKeys := xslices.Keys(info.frameworks)
 	frameworkKeys = xslices.Filter(frameworkKeys, func(frameworkName string) bool {
 		return frameworkName != observability.TracingChainName &&
 			frameworkName != observability.MetricsChainName
 	})
 	if len(frameworkKeys) == 0 {
-		return ""
+		return buildInfoFirstPart
 	}
 
-	return ";" + strings.Join(
+	return buildInfoFirstPart + ";" + strings.Join(
 		xslices.Transform(
 			frameworkKeys,
 			func(frameworkName string) string {
@@ -245,11 +240,10 @@ func (m *Meta) Context(ctx context.Context) (_ context.Context, err error) {
 // x-ydb-sdk-build-info. Use it only for Discovery.ListEndpoints.
 func (m *Meta) DiscoveryContext(ctx context.Context) (_ context.Context, err error) {
 	info := m.buildInfo.Load()
-	header := buildInfoFirstPart
+	header := info.buildInfoHeader
 	if chains := info.observabilityChains(); chains != "" {
 		header += " " + chains
 	}
-	header += info.frameworkSuffix()
 
 	md, err := m.meta(ctx, header)
 	if err != nil {

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -242,7 +242,7 @@ func (m *Meta) DiscoveryContext(ctx context.Context) (_ context.Context, err err
 	info := m.buildInfo.Load()
 	header := info.buildInfoHeader
 	if chains := info.observabilityChains(); chains != "" {
-		header += " " + chains
+		header += ";" + chains
 	}
 
 	md, err := m.meta(ctx, header)

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -90,23 +90,7 @@ func (info *buildInfo) makeHeader(includeObservability bool) string {
 	builder.WriteString(buildInfoFirstPart)
 
 	if includeObservability {
-		if tracingVersion, has := info.frameworks[observability.TracingChainName]; has {
-			builder.WriteString(" ")
-			builder.WriteString(observability.TracingChainName)
-			builder.WriteString("/")
-			builder.WriteString(tracingVersion)
-		}
-
-		if metricsVersion, has := info.frameworks[observability.MetricsChainName]; has {
-			if _, hasTracing := info.frameworks[observability.TracingChainName]; hasTracing {
-				builder.WriteString(";")
-			} else {
-				builder.WriteString(" ")
-			}
-			builder.WriteString(observability.MetricsChainName)
-			builder.WriteString("/")
-			builder.WriteString(metricsVersion)
-		}
+		info.writeObservabilityChains(&builder)
 	}
 
 	frameworkKeys := xslices.Keys(info.frameworks)
@@ -132,6 +116,30 @@ func (info *buildInfo) makeHeader(includeObservability bool) string {
 	)
 
 	return builder.String()
+}
+
+func (info *buildInfo) writeObservabilityChains(builder *strings.Builder) {
+	tracingVersion, hasTracing := info.frameworks[observability.TracingChainName]
+	if hasTracing {
+		builder.WriteString(" ")
+		builder.WriteString(observability.TracingChainName)
+		builder.WriteString("/")
+		builder.WriteString(tracingVersion)
+	}
+
+	metricsVersion, hasMetrics := info.frameworks[observability.MetricsChainName]
+	if !hasMetrics {
+		return
+	}
+
+	if hasTracing {
+		builder.WriteString(";")
+	} else {
+		builder.WriteString(" ")
+	}
+	builder.WriteString(observability.MetricsChainName)
+	builder.WriteString("/")
+	builder.WriteString(metricsVersion)
 }
 
 func WithRequestTypeOption(requestType string) Option {

--- a/internal/meta/meta.go
+++ b/internal/meta/meta.go
@@ -38,8 +38,9 @@ func New(
 	}
 
 	m.buildInfo.Store(&buildInfo{
-		frameworks:      make(map[string]string),
-		buildInfoHeader: buildInfoFirstPart,
+		frameworks:               make(map[string]string),
+		buildInfoHeader:          buildInfoFirstPart,
+		discoveryBuildInfoHeader: buildInfoFirstPart,
 	})
 
 	for _, opt := range opts {
@@ -68,35 +69,44 @@ func WithBuildInfo(frameworkName string, frameworkVersion string) Option {
 		maps.Copy(next.frameworks, current.frameworks)
 		next.frameworks[frameworkName] = frameworkVersion
 
-		next.buildInfoHeader = next.makeHeader()
+		next.buildInfoHeader = next.makeHeader(false)
+		next.discoveryBuildInfoHeader = next.makeHeader(true)
 		m.buildInfo.Store(next)
 	}
 }
 
-// makeHeader keeps backward-compatible semantics for build-info parsers:
+// makeHeader keeps backward-compatible semantics for build-info parsers.
+//
+// Regular requests (includeObservability=false) keep session-facing headers lean:
+// only the base SDK token and custom frameworks. Observability adoption chains are
+// intentionally omitted so they do not pollute `.sys/query_sessions.ClientSdkBuildInfo`.
+//
+// Discovery requests (includeObservability=true) append chain markers:
 // - chain markers are appended after the base token using a space;
 // - tracing and metrics markers are separated with ';' when both are present;
 // - custom frameworks remain in ';framework/version' form.
-func (info *buildInfo) makeHeader() string {
+func (info *buildInfo) makeHeader(includeObservability bool) string {
 	builder := strings.Builder{}
 	builder.WriteString(buildInfoFirstPart)
 
-	if tracingVersion, has := info.frameworks[observability.TracingChainName]; has {
-		builder.WriteString(" ")
-		builder.WriteString(observability.TracingChainName)
-		builder.WriteString("/")
-		builder.WriteString(tracingVersion)
-	}
-
-	if metricsVersion, has := info.frameworks[observability.MetricsChainName]; has {
-		if _, hasTracing := info.frameworks[observability.TracingChainName]; hasTracing {
-			builder.WriteString(";")
-		} else {
+	if includeObservability {
+		if tracingVersion, has := info.frameworks[observability.TracingChainName]; has {
 			builder.WriteString(" ")
+			builder.WriteString(observability.TracingChainName)
+			builder.WriteString("/")
+			builder.WriteString(tracingVersion)
 		}
-		builder.WriteString(observability.MetricsChainName)
-		builder.WriteString("/")
-		builder.WriteString(metricsVersion)
+
+		if metricsVersion, has := info.frameworks[observability.MetricsChainName]; has {
+			if _, hasTracing := info.frameworks[observability.TracingChainName]; hasTracing {
+				builder.WriteString(";")
+			} else {
+				builder.WriteString(" ")
+			}
+			builder.WriteString(observability.MetricsChainName)
+			builder.WriteString("/")
+			builder.WriteString(metricsVersion)
+		}
 	}
 
 	frameworkKeys := xslices.Keys(info.frameworks)
@@ -151,8 +161,9 @@ func ForbidOption(feature string) Option {
 
 type (
 	buildInfo struct {
-		frameworks      map[string]string // frameworkName -> version
-		buildInfoHeader string
+		frameworks               map[string]string // frameworkName -> version
+		buildInfoHeader          string
+		discoveryBuildInfoHeader string
 	}
 	Meta struct {
 		pid             string
@@ -168,7 +179,7 @@ type (
 
 const buildInfoFirstPart = version.FullVersion
 
-func (m *Meta) meta(ctx context.Context) (_ metadata.MD, err error) {
+func (m *Meta) meta(ctx context.Context, buildInfoHeader string) (_ metadata.MD, err error) {
 	md, has := metadata.FromOutgoingContext(ctx)
 	if !has {
 		md = metadata.MD{}
@@ -181,7 +192,7 @@ func (m *Meta) meta(ctx context.Context) (_ metadata.MD, err error) {
 	}
 
 	if len(md.Get(HeaderVersion)) == 0 {
-		md.Set(HeaderVersion, m.buildInfo.Load().buildInfoHeader)
+		md.Set(HeaderVersion, buildInfoHeader)
 	}
 
 	if m.requestsType != "" {
@@ -241,7 +252,19 @@ func ValidateBuildInfo(frameworkName string, frameworkVersion string) error {
 }
 
 func (m *Meta) Context(ctx context.Context) (_ context.Context, err error) {
-	md, err := m.meta(ctx)
+	md, err := m.meta(ctx, m.buildInfo.Load().buildInfoHeader)
+	if err != nil {
+		return ctx, xerrors.WithStackTrace(err)
+	}
+
+	return metadata.NewOutgoingContext(ctx, md), nil
+}
+
+// DiscoveryContext is like Context, but includes observability adoption chains in
+// x-ydb-sdk-build-info. Use it only for Discovery.ListEndpoints so session-facing
+// RPCs (CreateSession and friends) keep a lean ClientSdkBuildInfo.
+func (m *Meta) DiscoveryContext(ctx context.Context) (_ context.Context, err error) {
+	md, err := m.meta(ctx, m.buildInfo.Load().discoveryBuildInfoHeader)
 	if err != nil {
 		return ctx, xerrors.WithStackTrace(err)
 	}

--- a/internal/meta/meta_test.go
+++ b/internal/meta/meta_test.go
@@ -97,7 +97,7 @@ func TestMetaContext(t *testing.T) {
 		require.Equal(t, []string{buildInfoFirstPart + ";database/sql/1.0.0;my-framework/2.0.0"}, md.Get(HeaderVersion))
 	})
 
-	t.Run("ObservabilityChainsEnabled", func(t *testing.T) {
+	t.Run("ObservabilityChainsOnlyOnDiscovery", func(t *testing.T) {
 		m := New(
 			"database",
 			nil,
@@ -110,15 +110,24 @@ func TestMetaContext(t *testing.T) {
 		require.NoError(t, err)
 
 		md, has := metadata.FromOutgoingContext(ctx)
+		require.True(t, has)
+		require.Equal(t, []string{buildInfoFirstPart}, md.Get(HeaderVersion))
+		require.False(t, strings.Contains(md.Get(HeaderVersion)[0], observability.TracingChainName))
+		require.False(t, strings.Contains(md.Get(HeaderVersion)[0], observability.MetricsChainName))
+
+		discoveryCtx, err := m.DiscoveryContext(context.Background())
+		require.NoError(t, err)
+
+		discoveryMD, has := metadata.FromOutgoingContext(discoveryCtx)
 		require.True(t, has)
 		require.Equal(t, []string{
 			buildInfoFirstPart + " " +
 				observability.TracingChainName + "/" + observability.TracingChainVersion + ";" +
 				observability.MetricsChainName + "/" + observability.MetricsChainVersion,
-		}, md.Get(HeaderVersion))
+		}, discoveryMD.Get(HeaderVersion))
 	})
 
-	t.Run("ObservabilityChainsKeepFrameworkFormat", func(t *testing.T) {
+	t.Run("ObservabilityChainsKeepFrameworkFormatOnDiscovery", func(t *testing.T) {
 		m := New(
 			"database",
 			nil,
@@ -132,14 +141,21 @@ func TestMetaContext(t *testing.T) {
 
 		md, has := metadata.FromOutgoingContext(ctx)
 		require.True(t, has)
+		require.Equal(t, []string{buildInfoFirstPart + ";database/sql/1.2.3"}, md.Get(HeaderVersion))
+
+		discoveryCtx, err := m.DiscoveryContext(context.Background())
+		require.NoError(t, err)
+
+		discoveryMD, has := metadata.FromOutgoingContext(discoveryCtx)
+		require.True(t, has)
 		require.Equal(t, []string{
 			buildInfoFirstPart + " " +
 				observability.TracingChainName + "/" + observability.TracingChainVersion +
 				";database/sql/1.2.3",
-		}, md.Get(HeaderVersion))
+		}, discoveryMD.Get(HeaderVersion))
 	})
 
-	t.Run("ObservabilityMetricsKeepFrameworkFormat", func(t *testing.T) {
+	t.Run("ObservabilityMetricsKeepFrameworkFormatOnDiscovery", func(t *testing.T) {
 		m := New(
 			"database",
 			nil,
@@ -153,11 +169,18 @@ func TestMetaContext(t *testing.T) {
 
 		md, has := metadata.FromOutgoingContext(ctx)
 		require.True(t, has)
+		require.Equal(t, []string{buildInfoFirstPart + ";database/sql/1.2.3"}, md.Get(HeaderVersion))
+
+		discoveryCtx, err := m.DiscoveryContext(context.Background())
+		require.NoError(t, err)
+
+		discoveryMD, has := metadata.FromOutgoingContext(discoveryCtx)
+		require.True(t, has)
 		require.Equal(t, []string{
 			buildInfoFirstPart + " " +
 				observability.MetricsChainName + "/" + observability.MetricsChainVersion +
 				";database/sql/1.2.3",
-		}, md.Get(HeaderVersion))
+		}, discoveryMD.Get(HeaderVersion))
 	})
 
 	t.Run("ObservabilityChainsDisabled", func(t *testing.T) {
@@ -175,6 +198,13 @@ func TestMetaContext(t *testing.T) {
 		require.Equal(t, []string{buildInfoFirstPart}, md.Get(HeaderVersion))
 		require.False(t, strings.Contains(md.Get(HeaderVersion)[0], observability.TracingChainName))
 		require.False(t, strings.Contains(md.Get(HeaderVersion)[0], observability.MetricsChainName))
+
+		discoveryCtx, err := m.DiscoveryContext(context.Background())
+		require.NoError(t, err)
+
+		discoveryMD, has := metadata.FromOutgoingContext(discoveryCtx)
+		require.True(t, has)
+		require.Equal(t, []string{buildInfoFirstPart}, discoveryMD.Get(HeaderVersion))
 	})
 
 	t.Run("SDKVersionCannotBeOverwritten", func(t *testing.T) {

--- a/internal/meta/meta_test.go
+++ b/internal/meta/meta_test.go
@@ -149,9 +149,8 @@ func TestMetaContext(t *testing.T) {
 		discoveryMD, has := metadata.FromOutgoingContext(discoveryCtx)
 		require.True(t, has)
 		require.Equal(t, []string{
-			buildInfoFirstPart + " " +
-				observability.TracingChainName + "/" + observability.TracingChainVersion +
-				";database/sql/1.2.3",
+			buildInfoFirstPart + ";database/sql/1.2.3 " +
+				observability.TracingChainName + "/" + observability.TracingChainVersion,
 		}, discoveryMD.Get(HeaderVersion))
 	})
 
@@ -177,9 +176,8 @@ func TestMetaContext(t *testing.T) {
 		discoveryMD, has := metadata.FromOutgoingContext(discoveryCtx)
 		require.True(t, has)
 		require.Equal(t, []string{
-			buildInfoFirstPart + " " +
-				observability.MetricsChainName + "/" + observability.MetricsChainVersion +
-				";database/sql/1.2.3",
+			buildInfoFirstPart + ";database/sql/1.2.3 " +
+				observability.MetricsChainName + "/" + observability.MetricsChainVersion,
 		}, discoveryMD.Get(HeaderVersion))
 	})
 
@@ -206,10 +204,9 @@ func TestMetaContext(t *testing.T) {
 		discoveryMD, has := metadata.FromOutgoingContext(discoveryCtx)
 		require.True(t, has)
 		require.Equal(t, []string{
-			buildInfoFirstPart + " " +
+			buildInfoFirstPart + ";database/sql/1.2.3 " +
 				observability.TracingChainName + "/" + observability.TracingChainVersion + ";" +
-				observability.MetricsChainName + "/" + observability.MetricsChainVersion +
-				";database/sql/1.2.3",
+				observability.MetricsChainName + "/" + observability.MetricsChainVersion,
 		}, discoveryMD.Get(HeaderVersion))
 	})
 

--- a/internal/meta/meta_test.go
+++ b/internal/meta/meta_test.go
@@ -183,6 +183,36 @@ func TestMetaContext(t *testing.T) {
 		}, discoveryMD.Get(HeaderVersion))
 	})
 
+	t.Run("ObservabilityTracingAndMetricsKeepFrameworkFormatOnDiscovery", func(t *testing.T) {
+		m := New(
+			"database",
+			nil,
+			&trace.Driver{},
+			WithBuildInfo(observability.TracingChainName, observability.TracingChainVersion),
+			WithBuildInfo(observability.MetricsChainName, observability.MetricsChainVersion),
+			WithBuildInfo("database/sql", "1.2.3"),
+		)
+
+		ctx, err := m.Context(context.Background())
+		require.NoError(t, err)
+
+		md, has := metadata.FromOutgoingContext(ctx)
+		require.True(t, has)
+		require.Equal(t, []string{buildInfoFirstPart + ";database/sql/1.2.3"}, md.Get(HeaderVersion))
+
+		discoveryCtx, err := m.DiscoveryContext(context.Background())
+		require.NoError(t, err)
+
+		discoveryMD, has := metadata.FromOutgoingContext(discoveryCtx)
+		require.True(t, has)
+		require.Equal(t, []string{
+			buildInfoFirstPart + " " +
+				observability.TracingChainName + "/" + observability.TracingChainVersion + ";" +
+				observability.MetricsChainName + "/" + observability.MetricsChainVersion +
+				";database/sql/1.2.3",
+		}, discoveryMD.Get(HeaderVersion))
+	})
+
 	t.Run("ObservabilityChainsDisabled", func(t *testing.T) {
 		m := New(
 			"database",

--- a/internal/meta/meta_test.go
+++ b/internal/meta/meta_test.go
@@ -121,7 +121,7 @@ func TestMetaContext(t *testing.T) {
 		discoveryMD, has := metadata.FromOutgoingContext(discoveryCtx)
 		require.True(t, has)
 		require.Equal(t, []string{
-			buildInfoFirstPart + " " +
+			buildInfoFirstPart + ";" +
 				observability.TracingChainName + "/" + observability.TracingChainVersion + ";" +
 				observability.MetricsChainName + "/" + observability.MetricsChainVersion,
 		}, discoveryMD.Get(HeaderVersion))
@@ -149,7 +149,7 @@ func TestMetaContext(t *testing.T) {
 		discoveryMD, has := metadata.FromOutgoingContext(discoveryCtx)
 		require.True(t, has)
 		require.Equal(t, []string{
-			buildInfoFirstPart + ";database/sql/1.2.3 " +
+			buildInfoFirstPart + ";database/sql/1.2.3;" +
 				observability.TracingChainName + "/" + observability.TracingChainVersion,
 		}, discoveryMD.Get(HeaderVersion))
 	})
@@ -176,7 +176,7 @@ func TestMetaContext(t *testing.T) {
 		discoveryMD, has := metadata.FromOutgoingContext(discoveryCtx)
 		require.True(t, has)
 		require.Equal(t, []string{
-			buildInfoFirstPart + ";database/sql/1.2.3 " +
+			buildInfoFirstPart + ";database/sql/1.2.3;" +
 				observability.MetricsChainName + "/" + observability.MetricsChainVersion,
 		}, discoveryMD.Get(HeaderVersion))
 	})
@@ -204,7 +204,7 @@ func TestMetaContext(t *testing.T) {
 		discoveryMD, has := metadata.FromOutgoingContext(discoveryCtx)
 		require.True(t, has)
 		require.Equal(t, []string{
-			buildInfoFirstPart + ";database/sql/1.2.3 " +
+			buildInfoFirstPart + ";database/sql/1.2.3;" +
 				observability.TracingChainName + "/" + observability.TracingChainVersion + ";" +
 				observability.MetricsChainName + "/" + observability.MetricsChainVersion,
 		}, discoveryMD.Get(HeaderVersion))

--- a/options_observability_test.go
+++ b/options_observability_test.go
@@ -14,16 +14,18 @@ import (
 
 func TestWithObservabilityBuildInfoChains(t *testing.T) {
 	for _, tt := range []struct {
-		name     string
-		opts     []Option
-		expected string
+		name              string
+		opts              []Option
+		expectedRegular   string
+		expectedDiscovery string
 	}{
 		{
 			name: "tracing only",
 			opts: []Option{
 				With(config.WithBuildInfo(observability.TracingChainName, observability.TracingChainVersion)),
 			},
-			expected: version.FullVersion + " " +
+			expectedRegular: version.FullVersion,
+			expectedDiscovery: version.FullVersion + " " +
 				observability.TracingChainName + "/" + observability.TracingChainVersion,
 		},
 		{
@@ -31,7 +33,8 @@ func TestWithObservabilityBuildInfoChains(t *testing.T) {
 			opts: []Option{
 				With(config.WithBuildInfo(observability.MetricsChainName, observability.MetricsChainVersion)),
 			},
-			expected: version.FullVersion + " " +
+			expectedRegular: version.FullVersion,
+			expectedDiscovery: version.FullVersion + " " +
 				observability.MetricsChainName + "/" + observability.MetricsChainVersion,
 		},
 		{
@@ -40,7 +43,8 @@ func TestWithObservabilityBuildInfoChains(t *testing.T) {
 				With(config.WithBuildInfo(observability.TracingChainName, observability.TracingChainVersion)),
 				With(config.WithBuildInfo(observability.MetricsChainName, observability.MetricsChainVersion)),
 			},
-			expected: version.FullVersion + " " +
+			expectedRegular: version.FullVersion,
+			expectedDiscovery: version.FullVersion + " " +
 				observability.TracingChainName + "/" + observability.TracingChainVersion + ";" +
 				observability.MetricsChainName + "/" + observability.MetricsChainVersion,
 		},
@@ -58,7 +62,14 @@ func TestWithObservabilityBuildInfoChains(t *testing.T) {
 
 			md, has := metadata.FromOutgoingContext(ctx)
 			require.True(t, has)
-			require.Equal(t, []string{tt.expected}, md.Get("x-ydb-sdk-build-info"))
+			require.Equal(t, []string{tt.expectedRegular}, md.Get("x-ydb-sdk-build-info"))
+
+			discoveryCtx, err := d.config.Meta().DiscoveryContext(context.Background())
+			require.NoError(t, err)
+
+			discoveryMD, has := metadata.FromOutgoingContext(discoveryCtx)
+			require.True(t, has)
+			require.Equal(t, []string{tt.expectedDiscovery}, discoveryMD.Get("x-ydb-sdk-build-info"))
 		})
 	}
 }

--- a/options_observability_test.go
+++ b/options_observability_test.go
@@ -25,7 +25,7 @@ func TestWithObservabilityBuildInfoChains(t *testing.T) {
 				With(config.WithBuildInfo(observability.TracingChainName, observability.TracingChainVersion)),
 			},
 			expectedRegular: version.FullVersion,
-			expectedDiscovery: version.FullVersion + " " +
+			expectedDiscovery: version.FullVersion + ";" +
 				observability.TracingChainName + "/" + observability.TracingChainVersion,
 		},
 		{
@@ -34,7 +34,7 @@ func TestWithObservabilityBuildInfoChains(t *testing.T) {
 				With(config.WithBuildInfo(observability.MetricsChainName, observability.MetricsChainVersion)),
 			},
 			expectedRegular: version.FullVersion,
-			expectedDiscovery: version.FullVersion + " " +
+			expectedDiscovery: version.FullVersion + ";" +
 				observability.MetricsChainName + "/" + observability.MetricsChainVersion,
 		},
 		{
@@ -44,7 +44,7 @@ func TestWithObservabilityBuildInfoChains(t *testing.T) {
 				With(config.WithBuildInfo(observability.MetricsChainName, observability.MetricsChainVersion)),
 			},
 			expectedRegular: version.FullVersion,
-			expectedDiscovery: version.FullVersion + " " +
+			expectedDiscovery: version.FullVersion + ";" +
 				observability.TracingChainName + "/" + observability.TracingChainVersion + ";" +
 				observability.MetricsChainName + "/" + observability.MetricsChainVersion,
 		},

--- a/tests/integration/query_sessions_build_info_test.go
+++ b/tests/integration/query_sessions_build_info_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -88,10 +89,12 @@ func TestDiscoveryBuildInfoContainsObservabilityChains(t *testing.T) {
 				) error {
 					if strings.Contains(method, "ListEndpoints") {
 						md, has := metadata.FromOutgoingContext(ctx)
-						require.True(t, has)
-						values := md.Get(meta.HeaderVersion)
-						require.NotEmpty(t, values)
-						discoveryBuildInfo = values[0]
+						if assert.True(t, has) {
+							values := md.Get(meta.HeaderVersion)
+							if assert.NotEmpty(t, values) {
+								discoveryBuildInfo = values[0]
+							}
+						}
 					}
 
 					return invoker(ctx, method, req, reply, cc, opts...)

--- a/tests/integration/query_sessions_build_info_test.go
+++ b/tests/integration/query_sessions_build_info_test.go
@@ -1,0 +1,108 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3"
+	"github.com/ydb-platform/ydb-go-sdk/v3/config"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/meta"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/observability"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/version"
+	"github.com/ydb-platform/ydb-go-sdk/v3/query"
+	"github.com/ydb-platform/ydb-go-sdk/v3/spans"
+)
+
+func TestQuerySessionsClientSdkBuildInfoWithoutObservabilityChains(t *testing.T) {
+	scope := newScope(t)
+
+	const applicationName = "query-sessions-build-info-without-observability-chains"
+
+	db := scope.Driver(
+		ydb.WithApplicationName(applicationName),
+		ydb.WithSessionPoolSizeLimit(1),
+		spans.WithTraces(MockSpansAdapter{}),
+	)
+
+	const yql = "" +
+		"DECLARE $sessionId AS Utf8;\n" +
+		"DECLARE $applicationName AS Utf8;\n" +
+		"SELECT ClientSdkBuildInfo, ApplicationName\n" +
+		"FROM `.sys/query_sessions`\n" +
+		"WHERE SessionId = $sessionId AND ApplicationName = $applicationName;"
+
+	err := db.Query().Do(scope.Ctx, func(ctx context.Context, s query.Session) error {
+		row, err := s.QueryRow(ctx, yql,
+			query.WithParameters(
+				ydb.ParamsBuilder().
+					Param("$sessionId").Text(s.ID()).
+					Param("$applicationName").Text(applicationName).
+					Build(),
+			),
+		)
+		if err != nil {
+			return err
+		}
+
+		var (
+			clientSdkBuildInfo string
+			gotApplicationName string
+		)
+		if err = row.Scan(&clientSdkBuildInfo, &gotApplicationName); err != nil {
+			return err
+		}
+
+		require.Equal(t, applicationName, gotApplicationName)
+		require.True(t, strings.HasPrefix(clientSdkBuildInfo, version.FullVersion), clientSdkBuildInfo)
+		require.NotContains(t, clientSdkBuildInfo, observability.TracingChainName)
+		require.NotContains(t, clientSdkBuildInfo, observability.MetricsChainName)
+
+		return nil
+	}, query.WithIdempotent())
+	require.NoError(t, err)
+}
+
+func TestDiscoveryBuildInfoContainsObservabilityChains(t *testing.T) {
+	scope := newScope(t)
+
+	var discoveryBuildInfo string
+	db := scope.Driver(
+		spans.WithTraces(MockSpansAdapter{}),
+		ydb.With(
+			config.WithGrpcOptions(
+				grpc.WithUnaryInterceptor(func(
+					ctx context.Context,
+					method string,
+					req, reply any,
+					cc *grpc.ClientConn,
+					invoker grpc.UnaryInvoker,
+					opts ...grpc.CallOption,
+				) error {
+					if strings.Contains(method, "ListEndpoints") {
+						md, has := metadata.FromOutgoingContext(ctx)
+						require.True(t, has)
+						values := md.Get(meta.HeaderVersion)
+						require.NotEmpty(t, values)
+						discoveryBuildInfo = values[0]
+					}
+
+					return invoker(ctx, method, req, reply, cc, opts...)
+				}),
+			),
+		),
+	)
+
+	_, err := db.Discovery().Discover(scope.Ctx)
+	require.NoError(t, err)
+	require.NotEmpty(t, discoveryBuildInfo)
+	require.Contains(t, discoveryBuildInfo, version.FullVersion)
+	require.Contains(t, discoveryBuildInfo, observability.TracingChainName+"/"+observability.TracingChainVersion)
+}


### PR DESCRIPTION
## Summary
- observability adoption chains (`ydb-sdk-tracing`, `ydb-sdk-metrics`) are no longer attached to every RPC via `Meta.Context`
- they are reported only through `Meta.DiscoveryContext`, used by balancer discovery and `Discovery().Discover()`
- session-facing headers (CreateSession → `.sys/query_sessions.ClientSdkBuildInfo`) keep the lean `ydb-go-sdk/<version>[;frameworks...]` form
- added integration coverage: open a query session and assert `ClientSdkBuildInfo` has no observability chains; assert Discovery still carries tracing chain

## Test plan
- [x] `go test ./internal/meta ./internal/discovery ./internal/balancer . ./spans ./metrics`
- [ ] CI integration: `TestQuerySessionsClientSdkBuildInfoWithoutObservabilityChains`
- [ ] CI integration: `TestDiscoveryBuildInfoContainsObservabilityChains`

Made with [Cursor](https://cursor.com)