### PR TITLE
Restore connection TTL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed `WithConnectionTTL` being a no-op and restored parking of idle gRPC connections without preventing removal of nodes missing from Discovery
+
 ## v3.145.0
 * Added `topicoptions.WithListenerBufferSizeBytes` option for `TopicListener` to configure the read-ahead buffer size (default 1 MiB, same as topic reader).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+* Fixed a TopicListener read buffer credit leak when a batch raced with partition worker shutdown
 * Fixed `WithConnectionTTL` being a no-op and restored parking of idle gRPC connections without preventing removal of nodes missing from Discovery
 
 ## v3.145.0

--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,7 @@ type Config struct {
 
 	trace              *trace.Driver
 	dialTimeout        time.Duration
+	connectionTTL      time.Duration
 	balancerConfig     *balancerConfig.Config
 	secure             bool
 	endpoint           string
@@ -73,11 +74,11 @@ func (c *Config) Meta() *meta.Meta {
 	return c.meta
 }
 
-// Deprecated: connection parking was removed; ConnectionTTL always returns 0.
-// Will be removed after Dec 2026
-// Read about versioning policy: https://github.com/ydb-platform/ydb-go-sdk/blob/master/VERSIONING.md#deprecated
+// ConnectionTTL defines the idle interval after which a gRPC connection is parked.
+//
+// If ConnectionTTL is zero, connections are not parked.
 func (c *Config) ConnectionTTL() time.Duration {
-	return 0
+	return c.connectionTTL
 }
 
 // Secure is a flag for secure connection
@@ -221,11 +222,11 @@ func WithUserAgent(userAgent string) Option {
 	}
 }
 
-// Deprecated: connection parking was removed; this option is now a no-op.
-// Will be removed after Dec 2026
-// Read about versioning policy: https://github.com/ydb-platform/ydb-go-sdk/blob/master/VERSIONING.md#deprecated
+// WithConnectionTTL configures the idle interval after which gRPC connections are parked.
 func WithConnectionTTL(ttl time.Duration) Option {
-	return func(*Config) {}
+	return func(c *Config) {
+		c.connectionTTL = ttl
+	}
 }
 
 func WithCredentials(credentials credentials.Credentials) Option {

--- a/internal/balancer/balancer_discovery_close_test.go
+++ b/internal/balancer/balancer_discovery_close_test.go
@@ -198,12 +198,14 @@ func discoveryOperationOK(msg proto.Message) *Ydb_Operations.Operation {
 type connLifeEvents struct {
 	mu     sync.Mutex
 	dialed map[uint32]int
+	parked map[uint32]int
 	closed map[uint32]int
 }
 
 func newConnLifeEvents() *connLifeEvents {
 	return &connLifeEvents{
 		dialed: make(map[uint32]int),
+		parked: make(map[uint32]int),
 		closed: make(map[uint32]int),
 	}
 }
@@ -231,6 +233,18 @@ func (e *connLifeEvents) driverTrace() *trace.Driver {
 				e.mu.Unlock()
 			}
 		},
+		OnConnPark: func(info trace.DriverConnParkStartInfo) func(trace.DriverConnParkDoneInfo) {
+			nodeID := info.Endpoint.NodeID()
+
+			return func(done trace.DriverConnParkDoneInfo) {
+				if done.Error != nil {
+					return
+				}
+				e.mu.Lock()
+				e.parked[nodeID]++
+				e.mu.Unlock()
+			}
+		},
 	}
 }
 
@@ -246,6 +260,13 @@ func (e *connLifeEvents) closedCount(nodeID uint32) int {
 	defer e.mu.Unlock()
 
 	return e.closed[nodeID]
+}
+
+func (e *connLifeEvents) parkedCount(nodeID uint32) int {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	return e.parked[nodeID]
 }
 
 func dialWhoAmI(tb testing.TB, b *Balancer, nodeID uint32) {
@@ -369,4 +390,76 @@ func TestBalancerDiscoveryDropClosesGRPC(t *testing.T) {
 	}, time.Second, 10*time.Millisecond, "balancer close must close remaining active connections")
 
 	require.Equal(t, 1, events.closedCount(node2))
+}
+
+func TestBalancerConnectionTTLParksTransportsAfterNetworkLoss(t *testing.T) {
+	const (
+		nodeCount = 16
+		ttl       = 50 * time.Millisecond
+	)
+
+	nodeIDs := make([]uint32, nodeCount)
+	for i := range nodeIDs {
+		nodeIDs[i] = uint32(i + 1)
+	}
+
+	ctx := t.Context()
+	srv := startDynamicDiscoveryServer(t, nodeIDs)
+	events := newConnLifeEvents()
+
+	cfg := config.New(
+		config.WithEndpoint(srv.endpoint()),
+		config.WithDatabase("/local"),
+		config.WithConnectionTTL(ttl),
+		config.WithDialTimeout(ttl),
+		config.WithGrpcOptions(grpc.WithTransportCredentials(insecure.NewCredentials())),
+		config.WithTrace(*events.driverTrace()),
+		config.WithBalancer(&balancerConfig.Config{}),
+	)
+
+	pool := conn.NewPool(ctx, cfg)
+	defer func() {
+		require.NoError(t, pool.RemoveRef(ctx))
+	}()
+
+	b, err := New(ctx, cfg, pool, discoveryConfig.WithInterval(0))
+	require.NoError(t, err)
+
+	dialWhoAmI(t, b, nodeIDs[0])
+	srv.Close()
+
+	for _, nodeID := range nodeIDs[1:] {
+		callCtx, cancel := context.WithTimeout(endpoint.WithNodeID(ctx, nodeID), ttl)
+		reply := &Ydb_Discovery.WhoAmIResponse{}
+		err = b.Invoke(
+			callCtx,
+			Ydb_Discovery_V1.DiscoveryService_WhoAmI_FullMethodName,
+			&Ydb_Discovery.WhoAmIRequest{},
+			reply,
+		)
+		cancel()
+		require.Error(t, err)
+	}
+
+	for _, nodeID := range nodeIDs {
+		require.Equal(t, 1, events.dialedCount(nodeID))
+	}
+
+	require.Eventually(t, func() bool {
+		for _, nodeID := range nodeIDs {
+			cc := connByNodeID(b, nodeID)
+			if cc == nil || cc.State() != state.Offline || events.parkedCount(nodeID) != 1 {
+				return false
+			}
+		}
+
+		return true
+	}, 5*time.Second, 10*time.Millisecond)
+
+	require.ElementsMatch(t, nodeIDs, activeNodeIDs(b), "parking must keep Discovery wrappers in the balancer")
+	require.NoError(t, b.Close(ctx))
+
+	for _, nodeID := range nodeIDs {
+		require.Equal(t, 1, events.closedCount(nodeID))
+	}
 }

--- a/internal/balancer/balancer_discovery_close_test.go
+++ b/internal/balancer/balancer_discovery_close_test.go
@@ -392,6 +392,66 @@ func TestBalancerDiscoveryDropClosesGRPC(t *testing.T) {
 	require.Equal(t, 1, events.closedCount(node2))
 }
 
+func TestBalancerDiscoveryDropDestroysParkedConnection(t *testing.T) {
+	const (
+		node1 uint32 = 1
+		node2 uint32 = 2
+		ttl          = 50 * time.Millisecond
+	)
+
+	ctx := t.Context()
+	srv := startDynamicDiscoveryServer(t, []uint32{node1, node2})
+	events := newConnLifeEvents()
+
+	cfg := config.New(
+		config.WithEndpoint(srv.endpoint()),
+		config.WithDatabase("/local"),
+		config.WithConnectionTTL(ttl),
+		config.WithGrpcOptions(grpc.WithTransportCredentials(insecure.NewCredentials())),
+		config.WithTrace(*events.driverTrace()),
+		config.WithBalancer(&balancerConfig.Config{}),
+	)
+
+	pool := conn.NewPool(ctx, cfg)
+	defer func() {
+		require.NoError(t, pool.RemoveRef(ctx))
+	}()
+
+	b, err := New(ctx, cfg, pool, discoveryConfig.WithInterval(0))
+	require.NoError(t, err)
+
+	dialWhoAmI(t, b, node2)
+	node2Conn := connByNodeID(b, node2)
+	require.NotNil(t, node2Conn)
+
+	require.Eventually(t, func() bool {
+		return node2Conn.State() == state.Offline && events.parkedCount(node2) == 1
+	}, time.Second, 10*time.Millisecond, "connection TTL must park the node transport")
+	require.Equal(t, 0, events.closedCount(node2), "parking must preserve the pooled wrapper")
+
+	// Discovery #2: keep both nodes and establish the quarantine generation.
+	require.NoError(t, b.clusterDiscoveryAttemptWithDial(ctx))
+	require.Same(t, node2Conn, connByNodeID(b, node2))
+	require.Equal(t, state.Offline, node2Conn.State())
+
+	// Discovery #3: node 2 disappears but remains referenced by quarantine.
+	srv.setNodeIDs([]uint32{node1})
+	require.NoError(t, b.clusterDiscoveryAttemptWithDial(ctx))
+	require.Same(t, node2Conn, connInQuarantine(b, node2))
+	require.Equal(t, state.Offline, node2Conn.State())
+	require.Equal(t, 0, events.closedCount(node2))
+
+	// Discovery #4: release quarantine and destroy the already parked wrapper.
+	require.NoError(t, b.clusterDiscoveryAttemptWithDial(ctx))
+	require.Eventually(t, func() bool {
+		return node2Conn.State() == state.Destroyed && events.closedCount(node2) == 1
+	}, time.Second, 10*time.Millisecond, "Discovery removal must destroy a parked connection")
+	require.Equal(t, 1, events.parkedCount(node2))
+	require.Equal(t, 1, events.dialedCount(node2))
+
+	require.NoError(t, b.Close(ctx))
+}
+
 func TestBalancerConnectionTTLParksTransportsAfterNetworkLoss(t *testing.T) {
 	const (
 		nodeCount = 16

--- a/internal/conn/config.go
+++ b/internal/conn/config.go
@@ -10,6 +10,7 @@ import (
 
 type Config interface {
 	DialTimeout() time.Duration
+	ConnectionTTL() time.Duration
 	Trace() *trace.Driver
 	GrpcDialOptions() []grpc.DialOption
 }

--- a/internal/conn/conn.go
+++ b/internal/conn/conn.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/jonboulle/clockwork"
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -66,6 +67,7 @@ type (
 		state                   atomic.Uint32
 		lastClusterAnnouncement atomic.Int64
 		childStreams            *xcontext.CancelsGuard
+		usage                   *usageTracker
 		onClose                 []func(*conn)
 	}
 )
@@ -394,6 +396,9 @@ func (c *conn) Invoke(
 	res any,
 	opts ...grpc.CallOption,
 ) (err error) {
+	stopUsage := c.startUsage()
+	defer stopUsage()
+
 	var (
 		opID   string
 		issues []trace.Issue
@@ -436,6 +441,9 @@ func (c *conn) NewStream(
 	method string,
 	opts ...grpc.CallOption,
 ) (_ grpc.ClientStream, finalErr error) {
+	stopUsage := c.startUsage()
+	defer stopUsage()
+
 	var (
 		onDone = gtrace.DriverOnConnNewStream(
 			c.config.Trace(), &ctx,
@@ -511,6 +519,14 @@ func withOnClose(onClose func(*conn)) option {
 	return func(c *conn) {
 		if onClose != nil {
 			c.onClose = append(c.onClose, onClose)
+		}
+	}
+}
+
+func withUsageTracker(clock clockwork.Clock, enabled bool) option {
+	return func(c *conn) {
+		if enabled {
+			c.usage = newUsageTracker(clock)
 		}
 	}
 }

--- a/internal/conn/conn_park.go
+++ b/internal/conn/conn_park.go
@@ -1,0 +1,58 @@
+package conn
+
+import (
+	"context"
+	"time"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/conn/gtrace"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/conn/state"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/stack"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
+)
+
+func noopStopUsage() {}
+
+func (c *conn) startUsage() func() {
+	if c.usage == nil {
+		return noopStopUsage
+	}
+
+	return c.usage.start()
+}
+
+func (c *conn) parkIfIdle(ctx context.Context, ttl time.Duration) {
+	if c.usage == nil {
+		return
+	}
+
+	c.usage.ifIdle(ttl, func() {
+		s := c.State()
+		if s == state.Online || s == state.Banned {
+			_ = c.park(ctx)
+		}
+	})
+}
+
+func (c *conn) park(ctx context.Context) (err error) {
+	onDone := gtrace.DriverOnConnPark(
+		c.config.Trace(), &ctx,
+		stack.FunctionID("github.com/ydb-platform/ydb-go-sdk/v3/internal/conn.(*conn).park"),
+		c.Endpoint(),
+	)
+	defer func() {
+		onDone(err)
+	}()
+
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	if c.closed || c.grpcConn == nil {
+		return nil
+	}
+
+	if err = c.close(ctx); err != nil {
+		return xerrors.WithStackTrace(err)
+	}
+
+	return nil
+}

--- a/internal/conn/conn_park.go
+++ b/internal/conn/conn_park.go
@@ -34,6 +34,13 @@ func (c *conn) parkIfIdle(ctx context.Context, ttl time.Duration) {
 }
 
 func (c *conn) park(ctx context.Context) (err error) {
+	c.mtx.Lock()
+	defer c.mtx.Unlock()
+
+	if c.closed || c.grpcConn == nil {
+		return nil
+	}
+
 	onDone := gtrace.DriverOnConnPark(
 		c.config.Trace(), &ctx,
 		stack.FunctionID("github.com/ydb-platform/ydb-go-sdk/v3/internal/conn.(*conn).park"),
@@ -42,13 +49,6 @@ func (c *conn) park(ctx context.Context) (err error) {
 	defer func() {
 		onDone(err)
 	}()
-
-	c.mtx.Lock()
-	defer c.mtx.Unlock()
-
-	if c.closed || c.grpcConn == nil {
-		return nil
-	}
 
 	if err = c.close(ctx); err != nil {
 		return xerrors.WithStackTrace(err)

--- a/internal/conn/grpc_client_stream.go
+++ b/internal/conn/grpc_client_stream.go
@@ -45,6 +45,9 @@ func (s *grpcClientStream) Endpoint() endpoint.Endpoint {
 }
 
 func (s *grpcClientStream) CloseSend() (err error) {
+	stopUsage := s.parentConn.startUsage()
+	defer stopUsage()
+
 	var (
 		ctx    = s.streamCtx
 		onDone = gtrace.DriverOnConnStreamCloseSend(s.parentConn.config.Trace(), &ctx,
@@ -75,6 +78,9 @@ func (s *grpcClientStream) CloseSend() (err error) {
 }
 
 func (s *grpcClientStream) SendMsg(m any) (err error) {
+	stopUsage := s.parentConn.startUsage()
+	defer stopUsage()
+
 	var (
 		ctx    = s.streamCtx
 		onDone = gtrace.DriverOnConnStreamSendMsg(s.parentConn.config.Trace(), &ctx,
@@ -122,6 +128,9 @@ func (s *grpcClientStream) finish(err error) {
 }
 
 func (s *grpcClientStream) RecvMsg(m any) (err error) {
+	stopUsage := s.parentConn.startUsage()
+	defer stopUsage()
+
 	var (
 		ctx    = s.streamCtx
 		onDone = gtrace.DriverOnConnStreamRecvMsg(s.parentConn.config.Trace(), &ctx,

--- a/internal/conn/pool.go
+++ b/internal/conn/pool.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/jonboulle/clockwork"
 	"google.golang.org/grpc"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/closer"
@@ -28,6 +29,8 @@ type (
 	Pool struct {
 		config      Config
 		dialOptions []grpc.DialOption
+		clock       clockwork.Clock
+		done        chan struct{}
 
 		mu     sync.Mutex
 		usages int64
@@ -81,7 +84,7 @@ func (p *Pool) get(e endpoint.Endpoint) *connValue {
 	}
 
 	value := &connValue{
-		cc: newConn(e, p),
+		cc: newConn(e, p, withUsageTracker(p.clock, p.config.ConnectionTTL() > 0)),
 	}
 
 	p.conns[key] = value
@@ -208,6 +211,7 @@ func (p *Pool) release() []closer.Closer {
 	}
 
 	p.closed.Store(true)
+	close(p.done)
 
 	toClose := make([]closer.Closer, 0, len(p.conns))
 	for _, value := range p.conns {
@@ -293,7 +297,50 @@ func (p *Pool) onResolveDone(ctx context.Context, target string, resolved []stri
 	}
 }
 
-func NewPool(ctx context.Context, config Config) *Pool {
+func (p *Pool) connsForParking() []*conn {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.conns == nil {
+		return nil
+	}
+
+	conns := make([]*conn, 0, len(p.conns))
+	for _, value := range p.conns {
+		conns = append(conns, value.cc)
+	}
+
+	return conns
+}
+
+func (p *Pool) parkIdleConnections(ctx context.Context, ttl time.Duration) {
+	for _, cc := range p.connsForParking() {
+		cc.parkIfIdle(ctx, ttl)
+	}
+}
+
+func (p *Pool) connParker(ctx context.Context, ttl time.Duration) {
+	interval := ttl / 2 //nolint:mnd
+	if interval <= 0 {
+		interval = ttl
+	}
+
+	ticker := p.clock.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-p.done:
+			return
+		case <-ticker.Chan():
+			p.parkIdleConnections(ctx, ttl)
+		}
+	}
+}
+
+type poolOption func(*Pool)
+
+func NewPool(ctx context.Context, config Config, opts ...poolOption) *Pool {
 	onDone := gtrace.DriverOnPoolNew(config.Trace(), &ctx,
 		stack.FunctionID("github.com/ydb-platform/ydb-go-sdk/v3/internal/conn.NewPool"),
 	)
@@ -303,7 +350,13 @@ func NewPool(ctx context.Context, config Config) *Pool {
 		usages:      1,
 		config:      config,
 		dialOptions: config.GrpcDialOptions(),
+		clock:       clockwork.NewRealClock(),
+		done:        make(chan struct{}),
 		conns:       make(map[endpoint.Key]*connValue),
+	}
+
+	for _, opt := range opts {
+		opt(p)
 	}
 
 	p.dialOptions = append(p.dialOptions,
@@ -311,6 +364,10 @@ func NewPool(ctx context.Context, config Config) *Pool {
 			xresolver.New("", p.onResolveDriverTrace(ctx, config.Trace())),
 		),
 	)
+
+	if ttl := config.ConnectionTTL(); ttl > 0 {
+		go p.connParker(xcontext.ValueOnly(ctx), ttl)
+	}
 
 	return p
 }

--- a/internal/conn/pool.go
+++ b/internal/conn/pool.go
@@ -320,6 +320,7 @@ func (p *Pool) parkIdleConnections(ctx context.Context, ttl time.Duration) {
 }
 
 func (p *Pool) connParker(ctx context.Context, ttl time.Duration) {
+	// Check twice per TTL to park within about 1.5×TTL after last use without excessive polling.
 	interval := ttl / 2 //nolint:mnd
 	if interval <= 0 {
 		interval = ttl

--- a/internal/conn/pool_test.go
+++ b/internal/conn/pool_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
@@ -22,13 +23,18 @@ import (
 
 // mockConfig implements the Config interface for testing
 type mockConfig struct {
-	dialTimeout  time.Duration
-	driverTrace  *trace.Driver
-	grpcDialOpts []grpc.DialOption
+	dialTimeout   time.Duration
+	connectionTTL time.Duration
+	driverTrace   *trace.Driver
+	grpcDialOpts  []grpc.DialOption
 }
 
 func (m *mockConfig) DialTimeout() time.Duration {
 	return m.dialTimeout
+}
+
+func (m *mockConfig) ConnectionTTL() time.Duration {
+	return m.connectionTTL
 }
 
 func (m *mockConfig) Trace() *trace.Driver {
@@ -100,6 +106,13 @@ func testPoolConnUseCount(p *Pool, key endpoint.Key) (int64, bool) {
 	}
 
 	return value.useCount, true
+}
+
+func testConnGRPCConn(c *conn) grpcClientConnInterface {
+	c.mtx.RLock()
+	defer c.mtx.RUnlock()
+
+	return c.grpcConn
 }
 
 func TestPool_Get(t *testing.T) {
@@ -285,6 +298,103 @@ func TestPool_ConfigMethods(t *testing.T) {
 
 		// The pool adds additional options, so we check the length is at least the ones we provided
 		require.GreaterOrEqual(t, len(pool.GrpcDialOptions()), len(opts))
+	})
+}
+
+func TestPool_ConnectionTTL(t *testing.T) {
+	t.Run("ParksIdleTransportWithoutRemovingWrapper", func(t *testing.T) {
+		const ttl = 10 * time.Second
+
+		ctx := t.Context()
+		clock := clockwork.NewFakeClockAt(time.Unix(1, 0))
+		pool := NewPool(ctx, &mockConfig{connectionTTL: ttl}, func(p *Pool) {
+			p.clock = clock
+		})
+		defer func() {
+			require.NoError(t, pool.RemoveRef(ctx))
+		}()
+
+		e := endpoint.New("idle:2135")
+		cc := pool.Get(e).(*conn)
+		cc.mtx.Lock()
+		cc.grpcConn = &mockGrpcConn{}
+		cc.mtx.Unlock()
+		cc.setState(ctx, state.Online)
+
+		waitCtx, cancel := context.WithTimeout(ctx, time.Second)
+		defer cancel()
+		require.NoError(t, clock.BlockUntilContext(waitCtx, 1))
+		clock.Advance(ttl + time.Second)
+		require.Eventually(t, func() bool {
+			return cc.State() == state.Offline
+		}, time.Second, time.Millisecond)
+
+		require.Equal(t, state.Offline, cc.State())
+		require.Nil(t, testConnGRPCConn(cc))
+		require.True(t, testPoolHasConn(pool, e.Key()))
+		useCount, ok := testPoolConnUseCount(pool, e.Key())
+		require.True(t, ok)
+		require.Equal(t, int64(1), useCount)
+	})
+
+	t.Run("DoesNotParkActiveTransport", func(t *testing.T) {
+		const ttl = 10 * time.Second
+
+		ctx := t.Context()
+		clock := clockwork.NewFakeClockAt(time.Unix(1, 0))
+		pool := NewPool(ctx, &mockConfig{connectionTTL: ttl}, func(p *Pool) {
+			p.clock = clock
+		})
+		defer func() {
+			require.NoError(t, pool.RemoveRef(ctx))
+		}()
+
+		cc := pool.Get(endpoint.New("active:2135")).(*conn)
+		transport := &mockGrpcConn{}
+		cc.mtx.Lock()
+		cc.grpcConn = transport
+		cc.mtx.Unlock()
+		cc.setState(ctx, state.Online)
+
+		stopUsage := cc.startUsage()
+		clock.Advance(ttl + time.Second)
+		pool.parkIdleConnections(ctx, ttl)
+		require.Same(t, transport, testConnGRPCConn(cc))
+
+		stopUsage()
+		clock.Advance(ttl + time.Second)
+		pool.parkIdleConnections(ctx, ttl)
+		require.Nil(t, testConnGRPCConn(cc))
+	})
+
+	t.Run("DiscoveryReleaseDestroysParkedWrapper", func(t *testing.T) {
+		const ttl = 10 * time.Second
+
+		ctx := t.Context()
+		clock := clockwork.NewFakeClockAt(time.Unix(1, 0))
+		pool := NewPool(ctx, &mockConfig{connectionTTL: ttl}, func(p *Pool) {
+			p.clock = clock
+		})
+		defer func() {
+			require.NoError(t, pool.RemoveRef(ctx))
+		}()
+
+		e := endpoint.New("removed-from-discovery:2135")
+		cc := pool.Get(e).(*conn)
+		cc.mtx.Lock()
+		cc.grpcConn = &mockGrpcConn{}
+		cc.mtx.Unlock()
+		cc.setState(ctx, state.Online)
+
+		clock.Advance(ttl + time.Second)
+		pool.parkIdleConnections(ctx, ttl)
+		require.Equal(t, state.Offline, cc.State())
+		require.True(t, testPoolHasConn(pool, e.Key()))
+
+		pool.Put(ctx, cc)
+
+		require.Equal(t, state.Destroyed, cc.State())
+		require.False(t, testPoolHasConn(pool, e.Key()))
 	})
 }
 

--- a/internal/conn/pool_test.go
+++ b/internal/conn/pool_test.go
@@ -302,6 +302,23 @@ func TestPool_ConfigMethods(t *testing.T) {
 }
 
 func TestPool_ConnectionTTL(t *testing.T) {
+	t.Run("DoesNotTraceNoOpParking", func(t *testing.T) {
+		var parkEvents atomic.Int64
+		cfg := &mockConfig{
+			driverTrace: &trace.Driver{
+				OnConnPark: func(trace.DriverConnParkStartInfo) func(trace.DriverConnParkDoneInfo) {
+					parkEvents.Add(1)
+
+					return func(trace.DriverConnParkDoneInfo) {}
+				},
+			},
+		}
+		cc := newConn(endpoint.New("not-dialed:2135"), cfg)
+
+		require.NoError(t, cc.park(t.Context()))
+		require.Zero(t, parkEvents.Load())
+	})
+
 	t.Run("ParksIdleTransportWithoutRemovingWrapper", func(t *testing.T) {
 		const ttl = 10 * time.Second
 

--- a/internal/conn/usage_tracker.go
+++ b/internal/conn/usage_tracker.go
@@ -1,0 +1,56 @@
+package conn
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+)
+
+type usageTracker struct {
+	mu     sync.Mutex
+	clock  clockwork.Clock
+	active int
+	last   time.Time
+}
+
+func newUsageTracker(clock clockwork.Clock) *usageTracker {
+	return &usageTracker{
+		clock: clock,
+		last:  clock.Now(),
+	}
+}
+
+func (u *usageTracker) start() func() {
+	u.mu.Lock()
+	u.active++
+	u.mu.Unlock()
+
+	var stopped atomic.Bool
+
+	return func() {
+		if stopped.Swap(true) {
+			return
+		}
+
+		u.mu.Lock()
+		defer u.mu.Unlock()
+
+		u.active--
+		if u.active == 0 {
+			u.last = u.clock.Now()
+		}
+	}
+}
+
+func (u *usageTracker) ifIdle(ttl time.Duration, f func()) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+
+	if u.active > 0 || u.clock.Now().Sub(u.last) <= ttl {
+		return
+	}
+
+	f()
+}

--- a/internal/topic/topiclistenerinternal/partition_worker.go
+++ b/internal/topic/topiclistenerinternal/partition_worker.go
@@ -126,7 +126,9 @@ func (w *PartitionWorker) Start(ctx context.Context) {
 
 // AddUnifiedMessage adds a unified message to the processing queue
 func (w *PartitionWorker) AddUnifiedMessage(msg unifiedMessage) {
-	w.messageQueue.SendWithMerge(msg, w.tryMergeMessages)
+	if !w.messageQueue.SendWithMerge(msg, w.tryMergeMessages) {
+		w.freeBatchCredit(msg)
+	}
 }
 
 // AddRawServerMessage sends a raw server message
@@ -166,10 +168,9 @@ func (w *PartitionWorker) receiveMessagesLoop(ctx context.Context) {
 		}
 	}()
 
-	// On stop (Close, handler error, panic) batches may still sit in the queue buffer
-	// without reaching processBatchMessage. Drain them here instead of Close(): only
-	// this goroutine knows processing is finished and must not use blocking Receive.
-	defer w.freeBufferedBatchCredits()
+	// Close before the final drain so a concurrent sender either queues before the
+	// drain or observes the closed queue and releases its own buffer credit.
+	defer w.closeQueueAndFreeBufferedBatchCredits()
 
 	for {
 		// Use context-aware Receive method
@@ -354,10 +355,19 @@ func (w *PartitionWorker) processBatchMessage(ctx context.Context, msg *batchMes
 // partition queue. In-flight batch is freed by processBatchMessage defer, not here.
 func (w *PartitionWorker) freeBufferedBatchCredits() {
 	for _, msg := range w.messageQueue.DrainBuffered() {
-		// StartPartition / StopPartition do not consume read-ahead data bytes.
-		if msg.BatchMessage != nil {
-			w.readBufferReleaser.ReadBufferRelease(batchReadBufferSize(msg.BatchMessage.Batch))
-		}
+		w.freeBatchCredit(msg)
+	}
+}
+
+func (w *PartitionWorker) closeQueueAndFreeBufferedBatchCredits() {
+	w.messageQueue.Close()
+	w.freeBufferedBatchCredits()
+}
+
+func (w *PartitionWorker) freeBatchCredit(msg unifiedMessage) {
+	// StartPartition / StopPartition do not consume read-ahead data bytes.
+	if msg.BatchMessage != nil {
+		w.readBufferReleaser.ReadBufferRelease(batchReadBufferSize(msg.BatchMessage.Batch))
 	}
 }
 

--- a/internal/topic/topiclistenerinternal/partition_worker_test.go
+++ b/internal/topic/topiclistenerinternal/partition_worker_test.go
@@ -672,6 +672,65 @@ func TestPartitionWorkerInterface_UserHandlerErrorFreesQueuedBatches(t *testing.
 	messageSender := newSyncMessageSender()
 	mockHandler := NewMockEventHandler(ctrl)
 
+	handlerStarted := make(empty.Chan)
+	returnHandlerError := make(empty.Chan)
+	errorReceived := make(empty.Chan, 1)
+	onStopped := func(sessionID rawtopicreader.PartitionSessionID, err error) {
+		select {
+		case errorReceived <- empty.Struct{}:
+		default:
+		}
+	}
+
+	mockHandler.EXPECT().
+		OnReadMessages(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(context.Context, *PublicReadMessages) error {
+			close(handlerStarted)
+			<-returnHandlerError
+
+			return errors.New("user handler error")
+		})
+
+	worker := NewPartitionWorker(
+		123,
+		session,
+		messageSender,
+		mockHandler,
+		onStopped,
+		&trace.Topic{},
+		"test-listener",
+	)
+
+	worker.Start(ctx)
+
+	metadata1 := rawtopiccommon.ServerMessageMetadata{Status: rawydb.StatusSuccess}
+	metadata2 := rawtopiccommon.ServerMessageMetadata{
+		Status: rawydb.StatusSuccess,
+		Issues: rawydb.Issues{{Message: "different metadata to prevent queue merge"}},
+	}
+
+	const firstBatchSize = 17
+	const queuedBatchSize = 23
+	worker.AddMessagesBatch(metadata1, createTestBatchWithBufferBytes(t, firstBatchSize))
+	xtest.WaitChannelClosed(t, handlerStarted)
+	worker.AddMessagesBatch(metadata2, createTestBatchWithBufferBytes(t, queuedBatchSize))
+	close(returnHandlerError)
+
+	xtest.WaitChannelClosed(t, errorReceived)
+
+	require.NoError(t, worker.Close(ctx, nil))
+	require.ElementsMatch(t, []int{firstBatchSize, queuedBatchSize}, messageSender.GetFreedBuffer())
+}
+
+func TestPartitionWorkerInterface_BatchAfterHandlerErrorFreesBuffer(t *testing.T) {
+	ctx := xtest.Context(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	session := createTestPartitionSession()
+	messageSender := newSyncMessageSender()
+	mockHandler := NewMockEventHandler(ctrl)
+
 	errorReceived := make(empty.Chan, 1)
 	onStopped := func(sessionID rawtopicreader.PartitionSessionID, err error) {
 		select {
@@ -696,19 +755,22 @@ func TestPartitionWorkerInterface_UserHandlerErrorFreesQueuedBatches(t *testing.
 
 	worker.Start(ctx)
 
-	metadata1 := rawtopiccommon.ServerMessageMetadata{Status: rawydb.StatusSuccess}
-	metadata2 := rawtopiccommon.ServerMessageMetadata{
-		Status: rawydb.StatusSuccess,
-		Issues: rawydb.Issues{{Message: "different metadata to prevent queue merge"}},
-	}
-
-	worker.AddMessagesBatch(metadata1, createTestBatch())
-	worker.AddMessagesBatch(metadata2, createTestBatch())
+	const firstBatchSize = 17
+	worker.AddMessagesBatch(
+		rawtopiccommon.ServerMessageMetadata{Status: rawydb.StatusSuccess},
+		createTestBatchWithBufferBytes(t, firstBatchSize),
+	)
 
 	xtest.WaitChannelClosed(t, errorReceived)
+	require.NoError(t, worker.bgWorker.Close(ctx, nil))
 
-	require.NoError(t, worker.Close(ctx, nil))
-	require.Len(t, messageSender.GetFreedBuffer(), 2)
+	const lateBatchSize = 23
+	worker.AddMessagesBatch(
+		rawtopiccommon.ServerMessageMetadata{Status: rawydb.StatusSuccess},
+		createTestBatchWithBufferBytes(t, lateBatchSize),
+	)
+
+	require.ElementsMatch(t, []int{firstBatchSize, lateBatchSize}, messageSender.GetFreedBuffer())
 }
 
 func TestPartitionWorkerInterface_BadBatchMetadataFreesBuffer(t *testing.T) {

--- a/internal/topic/topiclistenerinternal/partition_worker_test.go
+++ b/internal/topic/topiclistenerinternal/partition_worker_test.go
@@ -773,6 +773,28 @@ func TestPartitionWorkerInterface_BatchAfterHandlerErrorFreesBuffer(t *testing.T
 	require.ElementsMatch(t, []int{firstBatchSize, lateBatchSize}, messageSender.GetFreedBuffer())
 }
 
+func TestPartitionWorkerInterface_RawMessageAfterCloseDoesNotReleaseBuffer(t *testing.T) {
+	ctx := xtest.Context(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	messageSender := newSyncMessageSender()
+	worker := NewPartitionWorker(
+		123,
+		createTestPartitionSession(),
+		messageSender,
+		NewMockEventHandler(ctrl),
+		func(rawtopicreader.PartitionSessionID, error) {},
+		&trace.Topic{},
+		"test-listener",
+	)
+
+	require.NoError(t, worker.Close(ctx, nil))
+	worker.AddRawServerMessage(&rawtopicreader.StartPartitionSessionRequest{})
+
+	require.Empty(t, messageSender.GetFreedBuffer())
+}
+
 func TestPartitionWorkerInterface_BadBatchMetadataFreesBuffer(t *testing.T) {
 	ctx := xtest.Context(t)
 	ctrl := gomock.NewController(t)

--- a/internal/topic/topiclistenerinternal/stream_listener.go
+++ b/internal/topic/topiclistenerinternal/stream_listener.go
@@ -357,6 +357,10 @@ func (l *streamListener) receiveMessagesLoop(ctx context.Context) {
 
 		logCtx := ctx
 		if err != nil {
+			if l.closing.Load() || ctx.Err() != nil {
+				return
+			}
+
 			gtrace.TopicOnListenerReceiveMessage(l.tracer, &logCtx, l.listenerID, l.sessionID, "", 0, err)
 			gtrace.TopicOnListenerError(l.tracer, &logCtx, l.listenerID, l.sessionID, err)
 			l.goClose(ctx, xerrors.WithStackTrace(xerrors.Wrap(

--- a/internal/topic/topiclistenerinternal/stream_listener_new_test.go
+++ b/internal/topic/topiclistenerinternal/stream_listener_new_test.go
@@ -103,3 +103,32 @@ func TestNewStreamListener_SeedsInitialReadRequest(t *testing.T) {
 		return grpcStream.readRequestBytes.Load() == bufferSize
 	}, time.Second, 10*time.Millisecond)
 }
+
+func TestStreamListenerReceiveMessagesLoopIgnoresRecvErrorWhileClosing(t *testing.T) {
+	recvCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	unexpectedClose := make(chan error, 1)
+	listener := &streamListener{
+		stream: rawtopicreader.StreamReader{
+			Stream: &testInitGrpcStream{
+				initSent:    true,
+				recvContext: recvCtx,
+			},
+			Tracer: &trace.Topic{},
+		},
+		streamClose: func(reason error) {
+			unexpectedClose <- reason
+		},
+		tracer: &trace.Topic{},
+	}
+	listener.closing.Store(true)
+
+	listener.receiveMessagesLoop(context.Background())
+
+	select {
+	case reason := <-unexpectedClose:
+		t.Fatalf("receive loop initiated duplicate close during shutdown: %v", reason)
+	default:
+	}
+}

--- a/internal/xsync/unbounded_chan.go
+++ b/internal/xsync/unbounded_chan.go
@@ -54,8 +54,9 @@ func (c *UnboundedChan[T]) Send(msg T) {
 // SendWithMerge adds a message to the channel with optional merging.
 // If mergeFunc returns true, the new message will be merged with the last message.
 // The merge operation is atomic and preserves message order.
-func (c *UnboundedChan[T]) SendWithMerge(msg T, mergeFunc func(last, new T) (T, bool)) {
-	var notify bool
+// It returns false when the channel is already closed and the message was rejected.
+func (c *UnboundedChan[T]) SendWithMerge(msg T, mergeFunc func(last, new T) (T, bool)) bool {
+	var accepted bool
 	c.mutex.WithLock(func() {
 		if c.closed {
 			return
@@ -64,19 +65,21 @@ func (c *UnboundedChan[T]) SendWithMerge(msg T, mergeFunc func(last, new T) (T, 
 		if len(c.buffer) > 0 {
 			if merged, shouldMerge := mergeFunc(c.buffer[len(c.buffer)-1], msg); shouldMerge {
 				c.buffer[len(c.buffer)-1] = merged
-				notify = true
+				accepted = true
 
 				return
 			}
 		}
 
 		c.buffer = append(c.buffer, msg)
-		notify = true
+		accepted = true
 	})
 
-	if notify {
+	if accepted {
 		c.notify()
 	}
+
+	return accepted
 }
 
 // Receive retrieves a message from the channel with context support.

--- a/internal/xsync/unbounded_chan_test.go
+++ b/internal/xsync/unbounded_chan_test.go
@@ -122,7 +122,8 @@ func TestUnboundedChanSendAfterClose(t *testing.T) {
 
 	// Must not panic when sending after close (e.g. race with partition worker shutdown).
 	ch.Send(1)
-	ch.SendWithMerge(2, func(last, new int) (int, bool) { return last + new, true })
+	accepted := ch.SendWithMerge(2, func(last, new int) (int, bool) { return last + new, true })
+	require.False(t, accepted)
 }
 
 func TestUnboundedChanSendCloseConcurrent(t *testing.T) {

--- a/options.go
+++ b/options.go
@@ -214,11 +214,11 @@ func WithConnectionString(connectionString string) Option {
 	}
 }
 
-// Deprecated: connection parking was removed; this option is now a no-op.
-// Will be removed after Dec 2026.
-// Read about versioning policy: https://github.com/ydb-platform/ydb-go-sdk/blob/master/VERSIONING.md#deprecated
+// WithConnectionTTL configures the idle interval after which gRPC connections are parked.
 func WithConnectionTTL(ttl time.Duration) Option {
-	return func(context.Context, *Driver) error {
+	return func(_ context.Context, d *Driver) error {
+		d.options = append(d.options, config.WithConnectionTTL(ttl))
+
 		return nil
 	}
 }

--- a/with_test.go
+++ b/with_test.go
@@ -21,6 +21,14 @@ import (
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/conn"
 )
 
+func TestWithConnectionTTL(t *testing.T) {
+	const ttl = 30 * time.Second
+
+	db, err := driverFromOptions(t.Context(), WithConnectionTTL(ttl))
+	require.NoError(t, err)
+	require.Equal(t, ttl, db.config.ConnectionTTL())
+}
+
 func TestWithCertificatesCached(t *testing.T) {
 	ca := &x509.Certificate{
 		SerialNumber: big.NewInt(2019),


### PR DESCRIPTION
## Summary

- Restore `WithConnectionTTL` configuration and idle gRPC connection parking.
- Track active unary and streaming operations to prevent parking connections while they are in use.
- Preserve connection wrappers and pool reference counts when parking transports.
- Keep Discovery cleanup independent, allowing nodes missing from Discovery to be removed even if their transports were already parked.

## Motivation

`WithConnectionTTL` became a no-op when background connection parking was removed.

In large installations with thousands of nodes, retained gRPC connections may continuously attempt to reconnect to every node during a network outage. Restoring idle connection parking limits these background reconnection attempts.

## Implementation

Connection TTL now closes only the underlying idle gRPC transport and moves the connection to the `Offline` state. The pooled wrapper and its reference count remain intact.

When an endpoint disappears from Discovery, the existing `Get`/`Put` lifecycle still removes the wrapper from the pool and moves it to `Destroyed`, including when its transport was previously parked.



+ fix(topic): avoid duplicate listener close during shutdown 