### PR TITLE
Add default idempotent retry option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Added `ydb.WithDefaultIdempotent(bool)` driver option
+
 ## v3.145.1
 * Fixed a TopicListener read buffer credit leak when a batch raced with partition worker shutdown
 * Fixed `WithConnectionTTL` being a no-op and restored parking of idle gRPC connections without preventing removal of nodes missing from Discovery

--- a/dsn.go
+++ b/dsn.go
@@ -110,6 +110,15 @@ func parseConnectionString(dataSourceName string) (opts []Option, _ error) {
 			}
 		}
 	}
+	if defaultIdempotent := info.Params.Get("go_default_idempotent"); defaultIdempotent != "" {
+		idempotent, err := strconv.ParseBool(defaultIdempotent)
+		if err != nil {
+			return nil, xerrors.WithStackTrace(fmt.Errorf(
+				"invalid go_default_idempotent: %s", defaultIdempotent,
+			))
+		}
+		opts = append(opts, withConnectorOptions(xsql.WithDefaultIdempotent(idempotent)))
+	}
 	if info.Params.Has("go_query_bind") {
 		var binders []xsql.Option
 		queryTransformers := strings.SplitSeq(info.Params.Get("go_query_bind"), ",")

--- a/dsn_test.go
+++ b/dsn_test.go
@@ -179,6 +179,30 @@ func TestParse(t *testing.T) {
 			err: nil,
 		},
 		{
+			dsn: "grpc://localhost:2135/local?go_default_idempotent=true",
+			opts: []config.Option{
+				config.WithSecure(false),
+				config.WithEndpoint("localhost:2135"),
+				config.WithDatabase("/local"),
+			},
+			connectorOpts: []xsql.Option{
+				xsql.WithDefaultIdempotent(true),
+			},
+			err: nil,
+		},
+		{
+			dsn: "grpc://localhost:2135/local?go_default_idempotent=false",
+			opts: []config.Option{
+				config.WithSecure(false),
+				config.WithEndpoint("localhost:2135"),
+				config.WithDatabase("/local"),
+			},
+			connectorOpts: []xsql.Option{
+				xsql.WithDefaultIdempotent(false),
+			},
+			err: nil,
+		},
+		{
 			dsn: "grpc://localhost:2135/local?query_mode=scripting&go_query_bind=positional,declare,wide_time_types", //nolint:lll
 			opts: []config.Option{
 				config.WithSecure(false),
@@ -239,6 +263,12 @@ func TestParseInvalidPrefetchQueryResultParts(t *testing.T) {
 	_, err := parseConnectionString("grpc://localhost:2135/local?prefetch_query_result_parts=bad")
 	require.Error(t, err)
 	require.ErrorContains(t, err, "invalid prefetch_query_result_parts: bad")
+}
+
+func TestParseInvalidDefaultIdempotent(t *testing.T) {
+	_, err := parseConnectionString("grpc://localhost:2135/local?go_default_idempotent=bad")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "invalid go_default_idempotent: bad")
 }
 
 func TestExtractTablePathPrefixFromBinderName(t *testing.T) {

--- a/internal/query/client.go
+++ b/internal/query/client.go
@@ -348,6 +348,20 @@ func do(
 	return nil
 }
 
+func (c *Client) withDefaultRetryOptions(opts ...retry.Option) []retry.Option {
+	return append(
+		[]retry.Option{retry.WithIdempotent(c.config.DefaultIdempotent())},
+		opts...,
+	)
+}
+
+func (c *Client) withDefaultExecuteOptions(opts ...options.Execute) []options.Execute {
+	return append(
+		[]options.Execute{options.WithIdempotent(c.config.DefaultIdempotent())},
+		opts...,
+	)
+}
+
 func (c *Client) Do(ctx context.Context, op query.Operation, opts ...options.DoOption) (finalErr error) {
 	ctx, leave, err := c.enter(ctx)
 	if err != nil {
@@ -367,24 +381,27 @@ func (c *Client) Do(ctx context.Context, op query.Operation, opts ...options.DoO
 		onDone(attempts, finalErr)
 	}()
 
+	retryOpts := c.withDefaultRetryOptions(
+		// Driver-level trace.Retry (e.g. spans.WithTraces) so retry
+		// callers see ydb.RunWithRetry / ydb.Try spans for Do().
+		retry.WithTrace(c.config.TraceRetry()),
+		retry.WithTrace(&trace.Retry{
+			OnRetry: func(info trace.RetryLoopStartInfo) func(trace.RetryLoopDoneInfo) {
+				return func(info trace.RetryLoopDoneInfo) {
+					attempts = info.Attempts
+				}
+			},
+		}),
+	)
+	retryOpts = append(retryOpts, settings.RetryOpts()...)
+
 	err = do(ctx, c.explicitSessionPool,
 		func(ctx context.Context, s *Session) error {
 			return withSessionTrace(s, settings.CallTrace(), func() error {
 				return op(ctx, s)
 			})
 		},
-		append([]retry.Option{
-			// Driver-level trace.Retry (e.g. spans.WithTraces) so retry
-			// callers see ydb.RunWithRetry / ydb.Try spans for Do().
-			retry.WithTrace(c.config.TraceRetry()),
-			retry.WithTrace(&trace.Retry{
-				OnRetry: func(info trace.RetryLoopStartInfo) func(trace.RetryLoopDoneInfo) {
-					return func(info trace.RetryLoopDoneInfo) {
-						attempts = info.Attempts
-					}
-				},
-			}),
-		}, settings.RetryOpts()...)...,
+		retryOpts...,
 	)
 
 	return err
@@ -485,7 +502,7 @@ func (c *Client) QueryRow(ctx context.Context, q string, opts ...options.Execute
 	}
 	defer leave()
 
-	settings := options.ExecuteSettings(opts...)
+	settings := options.ExecuteSettings(c.withDefaultExecuteOptions(opts...)...)
 
 	onDone := gtrace.QueryOnQueryRow(c.config.Trace(), &ctx,
 		stack.FunctionID("github.com/ydb-platform/ydb-go-sdk/v3/internal/query.(*Client).QueryRow"),
@@ -544,6 +561,7 @@ func (c *Client) Exec(ctx context.Context, q string, opts ...options.Execute) (f
 	}
 	defer leave()
 
+	opts = c.withDefaultExecuteOptions(opts...)
 	settings := options.ExecuteSettings(opts...)
 	onDone := gtrace.QueryOnExec(c.config.Trace(), &ctx,
 		stack.FunctionID("github.com/ydb-platform/ydb-go-sdk/v3/internal/query.(*Client).Exec"),
@@ -602,6 +620,7 @@ func (c *Client) Query(ctx context.Context, q string, opts ...options.Execute) (
 	}
 	defer leave()
 
+	opts = c.withDefaultExecuteOptions(opts...)
 	settings := options.ExecuteSettings(opts...)
 	onDone := gtrace.QueryOnQuery(c.config.Trace(), &ctx,
 		stack.FunctionID("github.com/ydb-platform/ydb-go-sdk/v3/internal/query.(*Client).Query"),
@@ -660,7 +679,7 @@ func (c *Client) QueryResultSet(
 	defer leave()
 
 	var (
-		settings  = options.ExecuteSettings(opts...)
+		settings  = options.ExecuteSettings(c.withDefaultExecuteOptions(opts...)...)
 		rowsCount int
 	)
 
@@ -717,24 +736,24 @@ func (c *Client) DoTx(ctx context.Context, op query.TxOperation, opts ...options
 		ctx = tx.WithLazyTx(ctx, *lazyTx)
 	}
 
+	retryOpts := c.withDefaultRetryOptions(
+		// Driver-level trace.Retry (e.g. spans.WithTraces) so retry
+		// callers see ydb.RunWithRetry / ydb.Try spans for DoTx().
+		retry.WithTrace(c.config.TraceRetry()),
+		retry.WithTrace(&trace.Retry{
+			OnRetry: func(info trace.RetryLoopStartInfo) func(trace.RetryLoopDoneInfo) {
+				return func(info trace.RetryLoopDoneInfo) {
+					attempts = info.Attempts
+				}
+			},
+		}),
+	)
+	retryOpts = append(retryOpts, settings.RetryOpts()...)
+
 	err = doTx(ctx, c.explicitSessionPool, op,
 		settings.TxSettings(),
 		settings.CallTrace(),
-		append(
-			[]retry.Option{
-				// Driver-level trace.Retry (e.g. spans.WithTraces) so retry
-				// callers see ydb.RunWithRetry / ydb.Try spans for DoTx().
-				retry.WithTrace(c.config.TraceRetry()),
-				retry.WithTrace(&trace.Retry{
-					OnRetry: func(info trace.RetryLoopStartInfo) func(trace.RetryLoopDoneInfo) {
-						return func(info trace.RetryLoopDoneInfo) {
-							attempts = info.Attempts
-						}
-					},
-				}),
-			},
-			settings.RetryOpts()...,
-		)...,
+		retryOpts...,
 	)
 	if err != nil {
 		return xerrors.WithStackTrace(err)

--- a/internal/query/client.go
+++ b/internal/query/client.go
@@ -349,15 +349,23 @@ func do(
 }
 
 func (c *Client) withDefaultRetryOptions(opts ...retry.Option) []retry.Option {
+	if !c.config.DefaultIdempotent() {
+		return opts
+	}
+
 	return append(
-		[]retry.Option{retry.WithIdempotent(c.config.DefaultIdempotent())},
+		[]retry.Option{retry.WithIdempotent(true)},
 		opts...,
 	)
 }
 
 func (c *Client) withDefaultExecuteOptions(opts ...options.Execute) []options.Execute {
+	if !c.config.DefaultIdempotent() {
+		return opts
+	}
+
 	return append(
-		[]options.Execute{options.WithIdempotent(c.config.DefaultIdempotent())},
+		[]options.Execute{options.WithIdempotent(true)},
 		opts...,
 	)
 }

--- a/internal/query/config/config.go
+++ b/internal/query/config/config.go
@@ -28,7 +28,8 @@ type Config struct {
 
 	allowImplicitSessions bool
 
-	lazyTx bool
+	lazyTx            bool
+	defaultIdempotent bool
 
 	trace *trace.Query
 }
@@ -98,6 +99,10 @@ func (c *Config) SessionIdleTimeToLive() time.Duration {
 
 func (c *Config) LazyTx() bool {
 	return c.lazyTx
+}
+
+func (c *Config) DefaultIdempotent() bool {
+	return c.defaultIdempotent
 }
 
 // PoolWarmUpSize is the number of sessions to pre-create in the explicit session pool at client initialization.

--- a/internal/query/config/config_test.go
+++ b/internal/query/config/config_test.go
@@ -22,6 +22,7 @@ func TestNew(t *testing.T) {
 		require.Equal(t, time.Duration(0), cfg.PoolSessionUsageTTL())
 		require.Equal(t, time.Duration(0), cfg.SessionIdleTimeToLive())
 		require.False(t, cfg.LazyTx())
+		require.False(t, cfg.DefaultIdempotent())
 		require.Equal(t, 0, cfg.PoolWarmUpSize())
 	})
 
@@ -88,6 +89,11 @@ func TestNew(t *testing.T) {
 	t.Run("WithLazyTx", func(t *testing.T) {
 		cfg := New(WithLazyTx(true))
 		require.True(t, cfg.LazyTx())
+	})
+
+	t.Run("WithDefaultIdempotent", func(t *testing.T) {
+		cfg := New(WithDefaultIdempotent(true))
+		require.True(t, cfg.DefaultIdempotent())
 	})
 
 	t.Run("WithTrace", func(t *testing.T) {

--- a/internal/query/config/options.go
+++ b/internal/query/config/options.go
@@ -93,6 +93,12 @@ func WithLazyTx(lazyTx bool) Option {
 	}
 }
 
+func WithDefaultIdempotent(idempotent bool) Option {
+	return func(c *Config) {
+		c.defaultIdempotent = idempotent
+	}
+}
+
 func WithDisableSessionBalancer() Option {
 	return func(c *Config) {
 		c.SetDisableSessionBalancer()

--- a/internal/query/default_idempotent_test.go
+++ b/internal/query/default_idempotent_test.go
@@ -19,6 +19,15 @@ func TestDefaultIdempotentOptions(t *testing.T) {
 		config: config.New(config.WithDefaultIdempotent(true)),
 	}
 
+	t.Run("disabled default does not add options", func(t *testing.T) {
+		client := &Client{
+			config: config.New(),
+		}
+
+		require.Empty(t, client.withDefaultRetryOptions())
+		require.Empty(t, client.withDefaultExecuteOptions())
+	})
+
 	t.Run("Do uses client default", func(t *testing.T) {
 		attempts, err := runIdempotentRetry(client.withDefaultRetryOptions()...)
 		require.NoError(t, err)

--- a/internal/query/default_idempotent_test.go
+++ b/internal/query/default_idempotent_test.go
@@ -1,0 +1,90 @@
+package query
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/backoff"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/query/config"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/query/options"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
+	publicQuery "github.com/ydb-platform/ydb-go-sdk/v3/query"
+	"github.com/ydb-platform/ydb-go-sdk/v3/retry"
+)
+
+func TestDefaultIdempotentOptions(t *testing.T) {
+	client := &Client{
+		config: config.New(config.WithDefaultIdempotent(true)),
+	}
+
+	t.Run("Do uses client default", func(t *testing.T) {
+		attempts, err := runIdempotentRetry(client.withDefaultRetryOptions()...)
+		require.NoError(t, err)
+		require.Equal(t, 2, attempts)
+	})
+
+	t.Run("Do per-call false overrides client default", func(t *testing.T) {
+		settings := options.ParseDoOpts(nil, publicQuery.WithIdempotent(false))
+
+		attempts, err := runIdempotentRetry(
+			client.withDefaultRetryOptions(settings.RetryOpts()...)...,
+		)
+		require.Error(t, err)
+		require.Equal(t, 1, attempts)
+	})
+
+	t.Run("Execute uses client default", func(t *testing.T) {
+		settings := options.ExecuteSettings(client.withDefaultExecuteOptions()...)
+
+		attempts, err := runIdempotentRetry(settings.RetryOpts()...)
+		require.NoError(t, err)
+		require.Equal(t, 2, attempts)
+	})
+
+	t.Run("Execute per-call false overrides client default", func(t *testing.T) {
+		settings := options.ExecuteSettings(client.withDefaultExecuteOptions(
+			publicQuery.WithIdempotent(false),
+		)...)
+
+		attempts, err := runIdempotentRetry(settings.RetryOpts()...)
+		require.Error(t, err)
+		require.Equal(t, 1, attempts)
+	})
+}
+
+func runIdempotentRetry(opts ...retry.Option) (attempts int, err error) {
+	err = retry.Retry(context.Background(), func(context.Context) error {
+		attempts++
+		if attempts == 1 {
+			return idempotentRetryableError{}
+		}
+
+		return nil
+	}, opts...)
+
+	return attempts, err
+}
+
+type idempotentRetryableError struct{}
+
+func (idempotentRetryableError) Error() string {
+	return "idempotent retryable error"
+}
+
+func (idempotentRetryableError) Code() int32 {
+	return -1
+}
+
+func (idempotentRetryableError) Name() string {
+	return "idempotent retryable error"
+}
+
+func (idempotentRetryableError) Type() xerrors.Type {
+	return xerrors.TypeConditionallyRetryable
+}
+
+func (idempotentRetryableError) BackoffType() backoff.Type {
+	return backoff.TypeInstant
+}

--- a/internal/query/options/retry.go
+++ b/internal/query/options/retry.go
@@ -130,8 +130,17 @@ func WithLazyTx(lazyTx bool) lazyTxOption {
 	return lazyTxOption{lazyTx: lazyTx}
 }
 
-func WithIdempotent() RetryOptionsOption {
-	return []retry.Option{retry.WithIdempotent(true)}
+func WithIdempotent(bb ...bool) RetryOptionsOption {
+	idempotent := true
+	switch len(bb) {
+	case 0:
+	case 1:
+		idempotent = bb[0]
+	default:
+		panic("only one bool arg allowed")
+	}
+
+	return []retry.Option{retry.WithIdempotent(idempotent)}
 }
 
 func WithLabel(lbl string) LabelOption {

--- a/internal/query/options/retry_test.go
+++ b/internal/query/options/retry_test.go
@@ -1,0 +1,15 @@
+package options
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithIdempotent(t *testing.T) {
+	require.Len(t, WithIdempotent(), 1)
+	require.Len(t, WithIdempotent(false), 1)
+	require.Panics(t, func() {
+		WithIdempotent(true, false)
+	})
+}

--- a/internal/table/client.go
+++ b/internal/table/client.go
@@ -234,10 +234,13 @@ func (c *Client) CreateSession(ctx context.Context, opts ...table.Option) (_ tab
 		onDone(safe.SessionInfo(s), attempts, err)
 	}()
 
+	config := c.retryOptions(append(
+		[]table.Option{table.WithIdempotent(true)},
+		opts...,
+	)...)
 	s, err = retry.RetryWithResult(ctx, createSession,
 		append(
 			[]retry.Option{
-				retry.WithIdempotent(true),
 				retry.WithTrace(&trace.Retry{
 					OnRetry: func(info trace.RetryLoopStartInfo) func(trace.RetryLoopDoneInfo) {
 						return func(info trace.RetryLoopDoneInfo) {
@@ -245,7 +248,7 @@ func (c *Client) CreateSession(ctx context.Context, opts ...table.Option) (_ tab
 						}
 					},
 				}),
-			}, c.retryOptions(opts...).RetryOptions...,
+			}, config.RetryOptions...,
 		)...,
 	)
 	if err != nil {
@@ -379,10 +382,12 @@ func (c *Client) BulkUpsert(
 		return xerrors.WithStackTrace(errClosedClient)
 	}
 
-	attempts, config := 0, c.retryOptions(opts...)
+	attempts, config := 0, c.retryOptions(append(
+		[]table.Option{table.WithIdempotent(true)},
+		opts...,
+	)...)
 	config.RetryOptions = append(
 		[]retry.Option{
-			retry.WithIdempotent(true),
 			retry.WithTrace(&trace.Retry{
 				OnRetry: func(info trace.RetryLoopStartInfo) func(trace.RetryLoopDoneInfo) {
 					return func(info trace.RetryLoopDoneInfo) {
@@ -555,10 +560,12 @@ func (c *Client) ReadRows(
 
 	client := Ydb_Table_V1.NewTableServiceClient(c.cc)
 
-	attempts, config := 0, c.retryOptions(retryOptions...)
+	attempts, config := 0, c.retryOptions(append(
+		[]table.Option{table.WithIdempotent(true)},
+		retryOptions...,
+	)...)
 	config.RetryOptions = append(
 		[]retry.Option{
-			retry.WithIdempotent(true),
 			retry.WithTrace(&trace.Retry{
 				OnRetry: func(info trace.RetryLoopStartInfo) func(trace.RetryLoopDoneInfo) {
 					return func(info trace.RetryLoopDoneInfo) {

--- a/internal/table/config/config.go
+++ b/internal/table/config/config.go
@@ -155,6 +155,12 @@ func WithDisableSessionBalancer() Option {
 	}
 }
 
+func WithDefaultIdempotent(idempotent bool) Option {
+	return func(c *Config) {
+		c.defaultIdempotent = idempotent
+	}
+}
+
 // WithClock replaces default clock
 func WithClock(clock clockwork.Clock) Option {
 	return func(c *Config) {
@@ -178,6 +184,7 @@ type Config struct {
 	ignoreTruncated                  bool
 	useQuerySession                  bool
 	executeDataQueryOverQueryService bool
+	defaultIdempotent                bool
 
 	maxRequestMessageSize int
 
@@ -234,6 +241,10 @@ func (c *Config) UseQuerySession() bool {
 // ExecuteDataQueryOverQueryService specifies behavior on execute handle
 func (c *Config) ExecuteDataQueryOverQueryService() bool {
 	return c.executeDataQueryOverQueryService
+}
+
+func (c *Config) DefaultIdempotent() bool {
+	return c.defaultIdempotent
 }
 
 // IdleThreshold is a maximum duration between any activity within session.

--- a/internal/table/config/config_test.go
+++ b/internal/table/config/config_test.go
@@ -252,6 +252,7 @@ func TestConfigGetters(t *testing.T) {
 			WithIgnoreTruncated(),
 			WithMaxRequestMessageSize(2048),
 			ExecuteDataQueryOverQueryService(true),
+			WithDefaultIdempotent(true),
 		)
 
 		require.Equal(t, 100, c.SizeLimit())
@@ -263,6 +264,7 @@ func TestConfigGetters(t *testing.T) {
 		require.Equal(t, 2048, c.MaxRequestMessageSize())
 		require.True(t, c.ExecuteDataQueryOverQueryService())
 		require.True(t, c.UseQuerySession())
+		require.True(t, c.DefaultIdempotent())
 		require.NotNil(t, c.Trace())
 		require.NotNil(t, c.Clock())
 	})

--- a/internal/table/retry.go
+++ b/internal/table/retry.go
@@ -82,8 +82,10 @@ func (c *Client) retryOptions(opts ...table.Option) *table.Options {
 		RetryOptions: []retry.Option{
 			retry.WithTrace(c.config.TraceRetry()),
 			retry.WithBudget(c.config.RetryBudget()),
-			retry.WithIdempotent(c.config.DefaultIdempotent()),
 		},
+	}
+	if c.config.DefaultIdempotent() {
+		options.RetryOptions = append(options.RetryOptions, retry.WithIdempotent(true))
 	}
 	for _, opt := range opts {
 		if opt != nil {

--- a/internal/table/retry.go
+++ b/internal/table/retry.go
@@ -82,6 +82,7 @@ func (c *Client) retryOptions(opts ...table.Option) *table.Options {
 		RetryOptions: []retry.Option{
 			retry.WithTrace(c.config.TraceRetry()),
 			retry.WithBudget(c.config.RetryBudget()),
+			retry.WithIdempotent(c.config.DefaultIdempotent()),
 		},
 	}
 	for _, opt := range opts {

--- a/internal/table/retry_test.go
+++ b/internal/table/retry_test.go
@@ -217,6 +217,14 @@ func TestRetryOptionsDefaultIdempotent(t *testing.T) {
 		config: config.New(config.WithDefaultIdempotent(true)),
 	}
 
+	t.Run("disabled client default", func(t *testing.T) {
+		settings := (&Client{config: config.New()}).retryOptions()
+
+		attempts, err := runTableIdempotentRetry(settings.RetryOptions...)
+		require.Error(t, err)
+		require.Equal(t, 1, attempts)
+	})
+
 	t.Run("uses client default", func(t *testing.T) {
 		settings := client.retryOptions()
 

--- a/internal/table/retry_test.go
+++ b/internal/table/retry_test.go
@@ -12,6 +12,7 @@ import (
 	grpcCodes "google.golang.org/grpc/codes"
 	grpcStatus "google.golang.org/grpc/status"
 
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/backoff"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/pool"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/table/config"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xcontext"
@@ -209,6 +210,28 @@ func TestDoImmediateReturn(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRetryOptionsDefaultIdempotent(t *testing.T) {
+	client := &Client{
+		config: config.New(config.WithDefaultIdempotent(true)),
+	}
+
+	t.Run("uses client default", func(t *testing.T) {
+		settings := client.retryOptions()
+
+		attempts, err := runTableIdempotentRetry(settings.RetryOptions...)
+		require.NoError(t, err)
+		require.Equal(t, 2, attempts)
+	})
+
+	t.Run("per-call false overrides client default", func(t *testing.T) {
+		settings := client.retryOptions(table.WithIdempotent(false))
+
+		attempts, err := runTableIdempotentRetry(settings.RetryOptions...)
+		require.Error(t, err)
+		require.Equal(t, 1, attempts)
+	})
 }
 
 // We are testing all suspentions of custom operation func against to all deadline
@@ -485,4 +508,39 @@ func (s *singleSession) With(ctx context.Context,
 	return retry.Retry(ctx, func(ctx context.Context) error {
 		return f(ctx, s.s)
 	}, opts...)
+}
+
+func runTableIdempotentRetry(opts ...retry.Option) (attempts int, err error) {
+	err = retry.Retry(context.Background(), func(context.Context) error {
+		attempts++
+		if attempts == 1 {
+			return tableIdempotentRetryableError{}
+		}
+
+		return nil
+	}, opts...)
+
+	return attempts, err
+}
+
+type tableIdempotentRetryableError struct{}
+
+func (tableIdempotentRetryableError) Error() string {
+	return "idempotent retryable error"
+}
+
+func (tableIdempotentRetryableError) Code() int32 {
+	return -1
+}
+
+func (tableIdempotentRetryableError) Name() string {
+	return "idempotent retryable error"
+}
+
+func (tableIdempotentRetryableError) Type() xerrors.Type {
+	return xerrors.TypeConditionallyRetryable
+}
+
+func (tableIdempotentRetryableError) BackoffType() backoff.Type {
+	return backoff.TypeInstant
 }

--- a/internal/xsql/connector.go
+++ b/internal/xsql/connector.go
@@ -53,6 +53,7 @@ type (
 		traceRetry           *trace.Retry
 		composePanicCallback func(e any)
 		retryBudget          budget.Budget
+		defaultIdempotent    bool
 		pathNormalizer       bind.TablePathPrefix
 		bindings             bind.Bindings
 	}
@@ -82,6 +83,10 @@ func (c *Connector) Parent() ydbDriver {
 
 func (c *Connector) RetryBudget() budget.Budget {
 	return c.retryBudget
+}
+
+func (c *Connector) DefaultIdempotent() bool {
+	return c.defaultIdempotent
 }
 
 func (c *Connector) Bindings() bind.Bindings {

--- a/internal/xsql/connector_test.go
+++ b/internal/xsql/connector_test.go
@@ -58,6 +58,13 @@ func TestConnector_Getters(t *testing.T) {
 		require.Nil(t, connector.RetryBudget())
 	})
 
+	t.Run("DefaultIdempotentGetter", func(t *testing.T) {
+		connector := &Connector{
+			defaultIdempotent: true,
+		}
+		require.True(t, connector.DefaultIdempotent())
+	})
+
 	t.Run("BindingsGetter", func(t *testing.T) {
 		connector := &Connector{
 			bindings: nil,

--- a/internal/xsql/options.go
+++ b/internal/xsql/options.go
@@ -38,9 +38,13 @@ type (
 	retryBudgetOption           struct {
 		budget budget.Budget
 	}
+
 	BindOption struct {
 		bind.Bind
 	}
+
+	defaultIdempotentOption bool
+
 	queryProcessorOption Engine
 )
 
@@ -65,6 +69,12 @@ func (opt BindOption) Apply(c *Connector) error {
 
 func (opt retryBudgetOption) Apply(c *Connector) error {
 	c.retryBudget = opt.budget
+
+	return nil
+}
+
+func (opt defaultIdempotentOption) Apply(c *Connector) error {
+	c.defaultIdempotent = bool(opt)
 
 	return nil
 }
@@ -150,6 +160,10 @@ func WithRetryBudget(budget budget.Budget) Option {
 	return retryBudgetOption{
 		budget: budget,
 	}
+}
+
+func WithDefaultIdempotent(idempotent bool) Option {
+	return defaultIdempotentOption(idempotent)
 }
 
 func WithTablePathPrefix(tablePathPrefix string) QueryBindOption {

--- a/internal/xsql/options_test.go
+++ b/internal/xsql/options_test.go
@@ -199,6 +199,16 @@ func TestWithRetryBudget(t *testing.T) {
 	require.Equal(t, b, connector.retryBudget)
 }
 
+func TestWithDefaultIdempotent(t *testing.T) {
+	opt := WithDefaultIdempotent(true)
+	require.NotNil(t, opt)
+
+	connector := &Connector{}
+	err := opt.Apply(connector)
+	require.NoError(t, err)
+	require.True(t, connector.defaultIdempotent)
+}
+
 func TestWithTablePathPrefix(t *testing.T) {
 	opt := WithTablePathPrefix("/test/path")
 	require.NotNil(t, opt)

--- a/options.go
+++ b/options.go
@@ -426,6 +426,19 @@ func WithRetryBudget(b budget.Budget) Option {
 	}
 }
 
+// WithDefaultIdempotent sets the default idempotency flag for retrying operations
+// in the native Table and Query clients and in database/sql retry helpers.
+// Per-call idempotency options override this default.
+func WithDefaultIdempotent(idempotent bool) Option {
+	return func(ctx context.Context, d *Driver) error {
+		d.tableOptions = append(d.tableOptions, tableConfig.WithDefaultIdempotent(idempotent))
+		d.queryOptions = append(d.queryOptions, queryConfig.WithDefaultIdempotent(idempotent))
+		d.databaseSQLOptions = append(d.databaseSQLOptions, xsql.WithDefaultIdempotent(idempotent))
+
+		return nil
+	}
+}
+
 // WithTraceDriver appends trace.Driver into driver traces
 func WithTraceDriver(t trace.Driver) Option { //nolint:gocritic
 	return func(ctx context.Context, d *Driver) error {

--- a/options_default_idempotent_test.go
+++ b/options_default_idempotent_test.go
@@ -1,0 +1,41 @@
+package ydb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	queryConfig "github.com/ydb-platform/ydb-go-sdk/v3/internal/query/config"
+	tableConfig "github.com/ydb-platform/ydb-go-sdk/v3/internal/table/config"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xsql"
+)
+
+func TestWithDefaultIdempotent(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		driver, err := driverFromOptions(t.Context())
+		require.NoError(t, err)
+
+		require.False(t, queryConfig.New(driver.queryOptions...).DefaultIdempotent())
+		require.False(t, tableConfig.New(driver.tableOptions...).DefaultIdempotent())
+
+		connector := &xsql.Connector{}
+		for _, opt := range driver.databaseSQLOptions {
+			require.NoError(t, opt.Apply(connector))
+		}
+		require.False(t, connector.DefaultIdempotent())
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		driver, err := driverFromOptions(t.Context(), WithDefaultIdempotent(true))
+		require.NoError(t, err)
+
+		require.True(t, queryConfig.New(driver.queryOptions...).DefaultIdempotent())
+		require.True(t, tableConfig.New(driver.tableOptions...).DefaultIdempotent())
+
+		connector := &xsql.Connector{}
+		for _, opt := range driver.databaseSQLOptions {
+			require.NoError(t, opt.Apply(connector))
+		}
+		require.True(t, connector.DefaultIdempotent())
+	})
+}

--- a/query/client.go
+++ b/query/client.go
@@ -148,8 +148,11 @@ type (
 	DoTxOption = options.DoTxOption
 )
 
-func WithIdempotent() options.RetryOptionsOption {
-	return options.WithIdempotent()
+// WithIdempotent overrides the default idempotency flag for a single operation.
+// With no argument, it marks the operation as idempotent.
+// No more than one bool argument is allowed.
+func WithIdempotent(bb ...bool) options.RetryOptionsOption {
+	return options.WithIdempotent(bb...)
 }
 
 func WithTrace(t *trace.Query) options.TraceOption {

--- a/retry/sql.go
+++ b/retry/sql.go
@@ -78,6 +78,11 @@ func DoWithResult[T any](ctx context.Context, db *sql.DB,
 		copy(options.retryOptions[1:], options.retryOptions)
 		options.retryOptions[0] = WithTrace(tracer.TraceRetry())
 	}
+	if provider, has := db.Driver().(interface {
+		DefaultIdempotent() bool
+	}); has {
+		options.retryOptions = append(options.retryOptions, WithIdempotent(provider.DefaultIdempotent()))
+	}
 	for _, opt := range opts {
 		if opt != nil {
 			opt.ApplyDoOption(&options)
@@ -219,6 +224,11 @@ func DoTxWithResult[T any](ctx context.Context, db *sql.DB,
 		copy(options.retryOptions[2:], options.retryOptions)
 		options.retryOptions[0] = WithTrace(d.TraceRetry())
 		options.retryOptions[1] = WithBudget(d.RetryBudget())
+	}
+	if provider, has := db.Driver().(interface {
+		DefaultIdempotent() bool
+	}); has {
+		options.retryOptions = append(options.retryOptions, WithIdempotent(provider.DefaultIdempotent()))
 	}
 	for _, opt := range opts {
 		if opt != nil {

--- a/retry/sql.go
+++ b/retry/sql.go
@@ -262,8 +262,8 @@ func DoTxWithResult[T any](ctx context.Context, db *sql.DB,
 func appendDefaultIdempotentOption(db *sql.DB, options []Option) []Option {
 	if provider, has := db.Driver().(interface {
 		DefaultIdempotent() bool
-	}); has {
-		return append(options, WithIdempotent(provider.DefaultIdempotent()))
+	}); has && provider.DefaultIdempotent() {
+		return append(options, WithIdempotent(true))
 	}
 
 	return options

--- a/retry/sql.go
+++ b/retry/sql.go
@@ -78,11 +78,7 @@ func DoWithResult[T any](ctx context.Context, db *sql.DB,
 		copy(options.retryOptions[1:], options.retryOptions)
 		options.retryOptions[0] = WithTrace(tracer.TraceRetry())
 	}
-	if provider, has := db.Driver().(interface {
-		DefaultIdempotent() bool
-	}); has {
-		options.retryOptions = append(options.retryOptions, WithIdempotent(provider.DefaultIdempotent()))
-	}
+	options.retryOptions = appendDefaultIdempotentOption(db, options.retryOptions)
 	for _, opt := range opts {
 		if opt != nil {
 			opt.ApplyDoOption(&options)
@@ -225,11 +221,7 @@ func DoTxWithResult[T any](ctx context.Context, db *sql.DB,
 		options.retryOptions[0] = WithTrace(d.TraceRetry())
 		options.retryOptions[1] = WithBudget(d.RetryBudget())
 	}
-	if provider, has := db.Driver().(interface {
-		DefaultIdempotent() bool
-	}); has {
-		options.retryOptions = append(options.retryOptions, WithIdempotent(provider.DefaultIdempotent()))
-	}
+	options.retryOptions = appendDefaultIdempotentOption(db, options.retryOptions)
 	for _, opt := range opts {
 		if opt != nil {
 			opt.ApplyDoTxOption(&options)
@@ -265,6 +257,16 @@ func DoTxWithResult[T any](ctx context.Context, db *sql.DB,
 	}
 
 	return v, nil
+}
+
+func appendDefaultIdempotentOption(db *sql.DB, options []Option) []Option {
+	if provider, has := db.Driver().(interface {
+		DefaultIdempotent() bool
+	}); has {
+		return append(options, WithIdempotent(provider.DefaultIdempotent()))
+	}
+
+	return options
 }
 
 func transformCommitError(ctx context.Context, err error) error {

--- a/retry/sql_test.go
+++ b/retry/sql_test.go
@@ -18,11 +18,12 @@ import (
 )
 
 type mockConnector struct {
-	t         testing.TB
-	conns     uint32
-	queryErr  error
-	execErr   error
-	commitErr error
+	t                 testing.TB
+	conns             uint32
+	queryErr          error
+	execErr           error
+	commitErr         error
+	defaultIdempotent bool
 }
 
 var _ driver.Connector = &mockConnector{}
@@ -48,6 +49,32 @@ func (m *mockConnector) Driver() driver.Driver {
 	m.t.Log(stack.Record(0))
 
 	return m
+}
+
+func (m *mockConnector) DefaultIdempotent() bool {
+	return m.defaultIdempotent
+}
+
+type idempotentRetryableError struct{}
+
+func (idempotentRetryableError) Error() string {
+	return "idempotent retryable error"
+}
+
+func (idempotentRetryableError) Code() int32 {
+	return -1
+}
+
+func (idempotentRetryableError) Name() string {
+	return "idempotent retryable error"
+}
+
+func (idempotentRetryableError) Type() xerrors.Type {
+	return xerrors.TypeConditionallyRetryable
+}
+
+func (idempotentRetryableError) BackoffType() backoff.Type {
+	return backoff.TypeInstant
 }
 
 type mockConn struct {
@@ -234,6 +261,102 @@ func TestDoTx(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDefaultIdempotent(t *testing.T) {
+	retryErr := idempotentRetryableError{}
+
+	t.Run("Do retries with connector default", func(t *testing.T) {
+		db := sql.OpenDB(&mockConnector{
+			t:                 t,
+			defaultIdempotent: true,
+		})
+		defer func() {
+			require.NoError(t, db.Close())
+		}()
+
+		attempts := 0
+		err := Do(context.Background(), db, func(context.Context, *sql.Conn) error {
+			attempts++
+			if attempts == 1 {
+				return retryErr
+			}
+
+			return nil
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, 2, attempts)
+	})
+
+	t.Run("Do per-call false overrides connector default", func(t *testing.T) {
+		db := sql.OpenDB(&mockConnector{
+			t:                 t,
+			defaultIdempotent: true,
+		})
+		defer func() {
+			require.NoError(t, db.Close())
+		}()
+
+		attempts := 0
+		err := Do(context.Background(), db, func(context.Context, *sql.Conn) error {
+			attempts++
+			if attempts == 1 {
+				return retryErr
+			}
+
+			return nil
+		}, WithDoRetryOptions(WithIdempotent(false)))
+
+		require.Error(t, err)
+		require.Equal(t, 1, attempts)
+	})
+
+	t.Run("DoTx retries with connector default", func(t *testing.T) {
+		db := sql.OpenDB(&mockConnector{
+			t:                 t,
+			defaultIdempotent: true,
+		})
+		defer func() {
+			require.NoError(t, db.Close())
+		}()
+
+		attempts := 0
+		err := DoTx(context.Background(), db, func(context.Context, *sql.Tx) error {
+			attempts++
+			if attempts == 1 {
+				return retryErr
+			}
+
+			return nil
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, 2, attempts)
+	})
+
+	t.Run("DoTx per-call false overrides connector default", func(t *testing.T) {
+		db := sql.OpenDB(&mockConnector{
+			t:                 t,
+			defaultIdempotent: true,
+		})
+		defer func() {
+			require.NoError(t, db.Close())
+		}()
+
+		attempts := 0
+		err := DoTx(context.Background(), db, func(context.Context, *sql.Tx) error {
+			attempts++
+			if attempts == 1 {
+				return retryErr
+			}
+
+			return nil
+		}, WithDoTxRetryOptions(WithIdempotent(false)))
+
+		require.Error(t, err)
+		require.Equal(t, 1, attempts)
+	})
 }
 
 func TestCleanUpResourcesOnPanicInRetryOperation(t *testing.T) {


### PR DESCRIPTION
## Summary

- add the `ydb.WithDefaultIdempotent(bool)` driver option
- apply the default to `database/sql` retry wrappers, the native Query API, and the Table API
- keep per-call `WithIdempotent(...)` options as overrides
- cover the disabled-by-default behavior and retry/override semantics with tests

## Why

Applications using idempotent operations through retry wrappers currently need to pass the same flag on every call. The driver-level option makes that behavior configurable once while retaining per-call control.

## Validation

- `go test -race ./...`
- `go test -race ./internal/table ./internal/table/test ./table`
- `git diff --check`
