### PR TITLE
Log nested YQL issue details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed YQL issue logs to preserve the event message and include nested issue details
+
 ## v3.146.0
 * Added `ydb.WithDefaultIdempotent(bool)` driver option
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-* Fixed YQL issue logs to preserve the event message and include nested issue details
+* Fixed YQL issue logs to preserve the event message and include bounded nested issue details
 
 ## v3.146.0
 * Added `ydb.WithDefaultIdempotent(bool)` driver option

--- a/log/driver.go
+++ b/log/driver.go
@@ -218,8 +218,7 @@ func internalDriver(l Logger, d trace.Detailer) trace.Driver {
 					l.Log(WithLevel(ctx, WARN), "YQL issue",
 						kv.String("method", method),
 						kv.String("endpoint", endpoint),
-						kv.String("message", safeIssueMessage(issue)),
-						kv.Int("code", int(safeIssueCode(issue))),
+						kv.Any("issue", makeIssueLog(issue)),
 					)
 				}
 			}

--- a/log/driver_test.go
+++ b/log/driver_test.go
@@ -55,6 +55,25 @@ func TestDriverLogsYQLIssueWithChildren(t *testing.T) {
 	require.Len(t, records[0].fields, 3)
 }
 
+func TestMakeIssueLogLimit(t *testing.T) {
+	children := make([]*Ydb_Issue.IssueMessage, maxIssueLogEntries)
+	for i := range children {
+		children[i] = &Ydb_Issue.IssueMessage{Message: "child"}
+	}
+
+	actual := makeIssueLog(&Ydb_Issue.IssueMessage{
+		Message: "root",
+		Issues:  children,
+	})
+
+	require.Len(t, actual.Issues, maxIssueLogEntries)
+	require.Equal(t, "child", actual.Issues[maxIssueLogEntries-2].Message)
+	require.Equal(t, issueLog{
+		Message:   moreIssuesMessage,
+		Truncated: true,
+	}, actual.Issues[maxIssueLogEntries-1])
+}
+
 type logRecord struct {
 	message string
 	fields  []Field

--- a/log/driver_test.go
+++ b/log/driver_test.go
@@ -1,0 +1,92 @@
+package log
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Issue"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
+)
+
+func TestDriverLogsYQLIssueWithChildren(t *testing.T) {
+	logger := new(recordingLogger)
+	driverTrace := Driver(logger, trace.DriverConnEvents)
+	onDone := driverTrace.OnConnInvoke(trace.DriverConnInvokeStartInfo{
+		Method: "/Ydb.Table.V1.TableService/ExecuteDataQuery",
+	})
+
+	onDone(trace.DriverConnInvokeDoneInfo{
+		Issues: []trace.Issue{
+			&Ydb_Issue.IssueMessage{
+				Message:   "Type annotation",
+				IssueCode: 1030,
+				Severity:  2,
+				Issues: []*Ydb_Issue.IssueMessage{
+					{
+						Message:   "Failed to convert type",
+						IssueCode: 2030,
+						Severity:  1,
+					},
+				},
+			},
+		},
+	})
+
+	records := logger.recordsWithMessage("YQL issue")
+	require.Len(t, records, 1)
+	require.Equal(t, "/Ydb.Table.V1.TableService/ExecuteDataQuery", fieldValue(records[0].fields, "method"))
+	require.Equal(t, "", fieldValue(records[0].fields, "endpoint"))
+
+	issueJSON, err := json.Marshal(fieldValue(records[0].fields, "issue"))
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"message": "Type annotation",
+		"code": 1030,
+		"severity": 2,
+		"issues": [{
+			"message": "Failed to convert type",
+			"code": 2030,
+			"severity": 1
+		}]
+	}`, string(issueJSON))
+	require.Len(t, records[0].fields, 3)
+}
+
+type logRecord struct {
+	message string
+	fields  []Field
+}
+
+type recordingLogger struct {
+	records []logRecord
+}
+
+func (l *recordingLogger) Log(_ context.Context, message string, fields ...Field) {
+	l.records = append(l.records, logRecord{
+		message: message,
+		fields:  append([]Field(nil), fields...),
+	})
+}
+
+func (l *recordingLogger) recordsWithMessage(message string) (records []logRecord) {
+	for _, record := range l.records {
+		if record.message == message {
+			records = append(records, record)
+		}
+	}
+
+	return records
+}
+
+func fieldValue(fields []Field, key string) any {
+	for _, field := range fields {
+		if field.Key() == key {
+			return field.AnyValue()
+		}
+	}
+
+	return nil
+}

--- a/log/driver_test.go
+++ b/log/driver_test.go
@@ -61,17 +61,24 @@ func TestMakeIssueLogLimit(t *testing.T) {
 		children[i] = &Ydb_Issue.IssueMessage{Message: "child"}
 	}
 
-	actual := makeIssueLog(&Ydb_Issue.IssueMessage{
+	atLimit := makeIssueLog(&Ydb_Issue.IssueMessage{
+		Message: "root",
+		Issues:  children[:maxIssueLogEntries-1],
+	})
+	require.Len(t, atLimit.Issues, maxIssueLogEntries-1)
+	require.Equal(t, "child", atLimit.Issues[maxIssueLogEntries-2].Message)
+
+	overLimit := makeIssueLog(&Ydb_Issue.IssueMessage{
 		Message: "root",
 		Issues:  children,
 	})
 
-	require.Len(t, actual.Issues, maxIssueLogEntries)
-	require.Equal(t, "child", actual.Issues[maxIssueLogEntries-2].Message)
+	require.Len(t, overLimit.Issues, maxIssueLogEntries-1)
+	require.Equal(t, "child", overLimit.Issues[maxIssueLogEntries-3].Message)
 	require.Equal(t, issueLog{
 		Message:   moreIssuesMessage,
 		Truncated: true,
-	}, actual.Issues[maxIssueLogEntries-1])
+	}, overLimit.Issues[maxIssueLogEntries-2])
 }
 
 type logRecord struct {

--- a/log/safe.go
+++ b/log/safe.go
@@ -1,6 +1,8 @@
 package log
 
 import (
+	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Issue"
+
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xiface"
 	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
 )
@@ -146,6 +148,30 @@ func safeIssueCode(i trace.Issue) uint32 {
 	}
 
 	return i.GetIssueCode()
+}
+
+type issueLog struct {
+	Message  string     `json:"message"`
+	Code     uint32     `json:"code"`
+	Severity uint32     `json:"severity"`
+	Issues   []issueLog `json:"issues,omitempty"`
+}
+
+func makeIssueLog(i trace.Issue) (result issueLog) {
+	result.Message = safeIssueMessage(i)
+	result.Code = safeIssueCode(i)
+	if !isNil(i) {
+		result.Severity = i.GetSeverity()
+	}
+	if issue, ok := i.(interface {
+		GetIssues() []*Ydb_Issue.IssueMessage
+	}); ok {
+		for _, child := range issue.GetIssues() {
+			result.Issues = append(result.Issues, makeIssueLog(child))
+		}
+	}
+
+	return result
 }
 
 func safeConnState(s trace.ConnState) string {

--- a/log/safe.go
+++ b/log/safe.go
@@ -156,14 +156,29 @@ type issueWithChildren interface {
 	GetIssues() []*Ydb_Issue.IssueMessage
 }
 
+const (
+	// maxIssueLogEntries limits real issues per top-level tree; the truncation marker is additional.
+	maxIssueLogEntries = 20
+	moreIssuesMessage  = "more issues omitted"
+)
+
 type issueLog struct {
-	Message  string     `json:"message"`
-	Code     uint32     `json:"code"`
-	Severity uint32     `json:"severity"`
-	Issues   []issueLog `json:"issues,omitempty"`
+	Message   string     `json:"message"`
+	Code      uint32     `json:"code"`
+	Severity  uint32     `json:"severity"`
+	Issues    []issueLog `json:"issues,omitempty"`
+	Truncated bool       `json:"truncated,omitempty"`
 }
 
-func makeIssueLog(i trace.Issue) (result issueLog) {
+func makeIssueLog(i trace.Issue) issueLog {
+	remaining := maxIssueLogEntries
+	result, _ := makeIssueLogWithLimit(i, &remaining)
+
+	return result
+}
+
+func makeIssueLogWithLimit(i trace.Issue, remaining *int) (result issueLog, truncated bool) {
+	*remaining = *remaining - 1
 	result.Message = safeIssueMessage(i)
 	result.Code = safeIssueCode(i)
 	if !isNil(i) {
@@ -171,11 +186,26 @@ func makeIssueLog(i trace.Issue) (result issueLog) {
 	}
 	if issue, ok := i.(issueWithChildren); ok {
 		for _, child := range issue.GetIssues() {
-			result.Issues = append(result.Issues, makeIssueLog(child))
+			if isNil(child) {
+				continue
+			}
+			if *remaining == 0 {
+				result.Issues = append(result.Issues, issueLog{
+					Message:   moreIssuesMessage,
+					Truncated: true,
+				})
+
+				return result, true
+			}
+			childLog, childTruncated := makeIssueLogWithLimit(child, remaining)
+			result.Issues = append(result.Issues, childLog)
+			if childTruncated {
+				return result, true
+			}
 		}
 	}
 
-	return result
+	return result, false
 }
 
 func safeConnState(s trace.ConnState) string {

--- a/log/safe.go
+++ b/log/safe.go
@@ -157,7 +157,7 @@ type issueWithChildren interface {
 }
 
 const (
-	// maxIssueLogEntries limits real issues per top-level tree; the truncation marker is additional.
+	// maxIssueLogEntries limits all entries per top-level tree, including the truncation marker.
 	maxIssueLogEntries = 20
 	moreIssuesMessage  = "more issues omitted"
 )
@@ -172,9 +172,32 @@ type issueLog struct {
 
 func makeIssueLog(i trace.Issue) issueLog {
 	remaining := maxIssueLogEntries
+	countRemaining := maxIssueLogEntries
+	if issueLogExceedsLimit(i, &countRemaining) {
+		remaining--
+	}
 	result, _ := makeIssueLogWithLimit(i, &remaining)
 
 	return result
+}
+
+func issueLogExceedsLimit(i trace.Issue, remaining *int) bool {
+	if isNil(i) {
+		return false
+	}
+	if *remaining == 0 {
+		return true
+	}
+	*remaining = *remaining - 1
+	if issue, ok := i.(issueWithChildren); ok {
+		for _, child := range issue.GetIssues() {
+			if issueLogExceedsLimit(child, remaining) {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func makeIssueLogWithLimit(i trace.Issue, remaining *int) (result issueLog, truncated bool) {

--- a/log/safe.go
+++ b/log/safe.go
@@ -150,6 +150,12 @@ func safeIssueCode(i trace.Issue) uint32 {
 	return i.GetIssueCode()
 }
 
+// issueWithChildren matches YDB protobuf issues carried by driver traces.
+// Other trace.Issue implementations are logged as leaf issues.
+type issueWithChildren interface {
+	GetIssues() []*Ydb_Issue.IssueMessage
+}
+
 type issueLog struct {
 	Message  string     `json:"message"`
 	Code     uint32     `json:"code"`
@@ -163,9 +169,7 @@ func makeIssueLog(i trace.Issue) (result issueLog) {
 	if !isNil(i) {
 		result.Severity = i.GetSeverity()
 	}
-	if issue, ok := i.(interface {
-		GetIssues() []*Ydb_Issue.IssueMessage
-	}); ok {
+	if issue, ok := i.(issueWithChildren); ok {
 		for _, child := range issue.GetIssues() {
 			result.Issues = append(result.Issues, makeIssueLog(child))
 		}


### PR DESCRIPTION
## What changed

- log each YQL issue as a structured `issue` field
- preserve nested issue messages, codes, and severities
- avoid the top-level `message` field collision with logging adapters
- add a focused regression test and changelog entry

## Why

`DriverConnInvokeDoneInfo.Issues` contains a tree, but the logger only emitted the root message and code. For generic roots such as `Type annotation`, this discarded the actionable nested diagnostics. The top-level `message` field could also override the event message in some `slog` adapters.

The logger now emits a normalized structure instead of exposing the generated protobuf type or flattening the tree into a presentation-specific string.

## Validation

- `golangci-lint run ./...`
- `go test -race ./...`

Fixes #2259
