### PR TITLE
Fix gRPC stream cancellation classification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed server-side gRPC stream errors being incorrectly classified as client-side context cancellation
+
 ## v3.146.1
 * Fixed YQL issue logs to preserve the event message and include bounded nested issue details
 

--- a/internal/conn/conn.go
+++ b/internal/conn/conn.go
@@ -469,7 +469,7 @@ func (c *conn) NewStream(
 
 	ctx, sentMark := markContext(meta.WithTraceID(ctx, traceID))
 
-	ctx, cancel := c.childStreams.WithCancel(ctx)
+	grpcCtx, cancel := c.childStreams.WithCancel(ctx)
 	defer func() {
 		if finalErr != nil {
 			cancel()
@@ -477,15 +477,15 @@ func (c *conn) NewStream(
 	}()
 
 	s := &grpcClientStream{
-		parentConn:   c,
-		streamCtx:    ctx,
-		streamCancel: cancel,
-		wrapping:     useWrapping,
-		traceID:      traceID,
-		sentMark:     sentMark,
+		parentConn: c,
+		requestCtx: ctx,
+		grpcCancel: cancel,
+		wrapping:   useWrapping,
+		traceID:    traceID,
+		sentMark:   sentMark,
 	}
 
-	s.stream, err = cc.NewStream(ctx, desc, method, append(opts, grpc.OnFinish(s.finish))...)
+	s.stream, err = cc.NewStream(grpcCtx, desc, method, append(opts, grpc.OnFinish(s.finish))...)
 	if err != nil {
 		if xerrors.IsContextError(err) {
 			return nil, xerrors.WithStackTrace(err)

--- a/internal/conn/grpc_client_stream.go
+++ b/internal/conn/grpc_client_stream.go
@@ -17,13 +17,13 @@ import (
 )
 
 type grpcClientStream struct {
-	parentConn   *conn
-	stream       grpc.ClientStream
-	streamCtx    context.Context //nolint:containedctx
-	streamCancel context.CancelFunc
-	wrapping     bool
-	traceID      string
-	sentMark     *modificationMark
+	parentConn *conn
+	stream     grpc.ClientStream
+	requestCtx context.Context //nolint:containedctx
+	grpcCancel context.CancelFunc
+	wrapping   bool
+	traceID    string
+	sentMark   *modificationMark
 }
 
 func (s *grpcClientStream) Header() (metadata.MD, error) {
@@ -49,7 +49,7 @@ func (s *grpcClientStream) CloseSend() (err error) {
 	defer stopUsage()
 
 	var (
-		ctx    = s.streamCtx
+		ctx    = s.requestCtx
 		onDone = gtrace.DriverOnConnStreamCloseSend(s.parentConn.config.Trace(), &ctx,
 			stack.FunctionID("github.com/ydb-platform/ydb-go-sdk/v3/internal/conn.(*grpcClientStream).CloseSend"),
 		)
@@ -65,7 +65,7 @@ func (s *grpcClientStream) CloseSend() (err error) {
 		}
 
 		return xerrors.WithStackTrace(xerrors.Join(
-			s.streamCtx.Err(),
+			s.requestCtx.Err(),
 			xerrors.Transport(err,
 				xerrors.WithAddress(s.parentConn.Address()),
 				xerrors.WithNodeID(s.parentConn.NodeID()),
@@ -82,7 +82,7 @@ func (s *grpcClientStream) SendMsg(m any) (err error) {
 	defer stopUsage()
 
 	var (
-		ctx    = s.streamCtx
+		ctx    = s.requestCtx
 		onDone = gtrace.DriverOnConnStreamSendMsg(s.parentConn.config.Trace(), &ctx,
 			stack.FunctionID("github.com/ydb-platform/ydb-go-sdk/v3/internal/conn.(*grpcClientStream).SendMsg"),
 		)
@@ -100,7 +100,7 @@ func (s *grpcClientStream) SendMsg(m any) (err error) {
 		if s.sentMark.canRetry() {
 			return xerrors.WithStackTrace(xerrors.Retryable(
 				xerrors.Join(
-					s.streamCtx.Err(),
+					s.requestCtx.Err(),
 					xerrors.Transport(err, xerrors.WithTraceID(s.traceID)),
 				),
 				xerrors.WithName("SendMsg"),
@@ -108,7 +108,7 @@ func (s *grpcClientStream) SendMsg(m any) (err error) {
 		}
 
 		return xerrors.WithStackTrace(xerrors.Join(
-			s.streamCtx.Err(),
+			s.requestCtx.Err(),
 			xerrors.Transport(err,
 				xerrors.WithAddress(s.parentConn.Address()),
 				xerrors.WithNodeID(s.parentConn.NodeID()),
@@ -121,10 +121,10 @@ func (s *grpcClientStream) SendMsg(m any) (err error) {
 }
 
 func (s *grpcClientStream) finish(err error) {
-	gtrace.DriverOnConnStreamFinish(s.parentConn.config.Trace(), s.streamCtx,
+	gtrace.DriverOnConnStreamFinish(s.parentConn.config.Trace(), s.requestCtx,
 		stack.FunctionID("github.com/ydb-platform/ydb-go-sdk/v3/internal/conn.(*grpcClientStream).finish"), err,
 	)
-	s.streamCancel()
+	s.grpcCancel()
 }
 
 func (s *grpcClientStream) RecvMsg(m any) (err error) {
@@ -132,7 +132,7 @@ func (s *grpcClientStream) RecvMsg(m any) (err error) {
 	defer stopUsage()
 
 	var (
-		ctx    = s.streamCtx
+		ctx    = s.requestCtx
 		onDone = gtrace.DriverOnConnStreamRecvMsg(s.parentConn.config.Trace(), &ctx,
 			stack.FunctionID("github.com/ydb-platform/ydb-go-sdk/v3/internal/conn.(*grpcClientStream).RecvMsg"),
 		)
@@ -140,7 +140,7 @@ func (s *grpcClientStream) RecvMsg(m any) (err error) {
 	defer func() {
 		onDone(err)
 		if err != nil {
-			meta.CallTrailerCallback(s.streamCtx, s.stream.Trailer())
+			meta.CallTrailerCallback(s.requestCtx, s.stream.Trailer())
 		}
 	}()
 
@@ -157,7 +157,7 @@ func (s *grpcClientStream) RecvMsg(m any) (err error) {
 		if s.sentMark.canRetry() {
 			return xerrors.WithStackTrace(xerrors.Retryable(
 				xerrors.Join(
-					s.streamCtx.Err(),
+					s.requestCtx.Err(),
 					xerrors.Transport(err, xerrors.WithTraceID(s.traceID)),
 				),
 				xerrors.WithName("RecvMsg"),
@@ -165,7 +165,7 @@ func (s *grpcClientStream) RecvMsg(m any) (err error) {
 		}
 
 		return xerrors.WithStackTrace(xerrors.Join(
-			s.streamCtx.Err(),
+			s.requestCtx.Err(),
 			xerrors.Transport(err,
 				xerrors.WithAddress(s.parentConn.Address()),
 				xerrors.WithNodeID(s.parentConn.NodeID()),

--- a/internal/conn/grpc_client_stream_test.go
+++ b/internal/conn/grpc_client_stream_test.go
@@ -136,7 +136,7 @@ func TestGrpcClientStream_CloseSend(t *testing.T) {
 		s := &grpcClientStream{
 			parentConn: parentConn,
 			stream:     mockStream,
-			streamCtx:  t.Context(),
+			requestCtx: t.Context(),
 			wrapping:   true,
 			traceID:    "test-trace-id",
 		}
@@ -160,7 +160,7 @@ func TestGrpcClientStream_CloseSend(t *testing.T) {
 		s := &grpcClientStream{
 			parentConn: parentConn,
 			stream:     mockStream,
-			streamCtx:  t.Context(),
+			requestCtx: t.Context(),
 			wrapping:   true,
 			traceID:    "test-trace-id",
 		}
@@ -192,7 +192,7 @@ func TestGrpcClientStream_CloseSend(t *testing.T) {
 		s := &grpcClientStream{
 			parentConn: parentConn,
 			stream:     mockStream,
-			streamCtx:  cancelledCtx,
+			requestCtx: cancelledCtx,
 			wrapping:   true,
 			traceID:    "test-trace-id",
 		}
@@ -220,7 +220,7 @@ func TestGrpcClientStream_CloseSend(t *testing.T) {
 		s := &grpcClientStream{
 			parentConn: parentConn,
 			stream:     mockStream,
-			streamCtx:  t.Context(),
+			requestCtx: t.Context(),
 			wrapping:   true,
 			traceID:    "test-trace-id",
 		}
@@ -246,7 +246,7 @@ func TestGrpcClientStream_CloseSend(t *testing.T) {
 		s := &grpcClientStream{
 			parentConn: parentConn,
 			stream:     mockStream,
-			streamCtx:  t.Context(),
+			requestCtx: t.Context(),
 			wrapping:   false,
 		}
 
@@ -273,7 +273,7 @@ func TestGrpcClientStream_SendMsg(t *testing.T) {
 		s := &grpcClientStream{
 			parentConn: parentConn,
 			stream:     mockStream,
-			streamCtx:  t.Context(),
+			requestCtx: t.Context(),
 			wrapping:   true,
 			sentMark:   &modificationMark{},
 		}
@@ -298,7 +298,7 @@ func TestGrpcClientStream_SendMsg(t *testing.T) {
 		s := &grpcClientStream{
 			parentConn: parentConn,
 			stream:     mockStream,
-			streamCtx:  t.Context(),
+			requestCtx: t.Context(),
 			wrapping:   true,
 			sentMark:   &modificationMark{},
 		}
@@ -331,7 +331,7 @@ func TestGrpcClientStream_SendMsg(t *testing.T) {
 		s := &grpcClientStream{
 			parentConn: parentConn,
 			stream:     mockStream,
-			streamCtx:  cancelledCtx,
+			requestCtx: cancelledCtx,
 			wrapping:   true,
 			traceID:    "test-trace-id",
 			sentMark:   &modificationMark{},
@@ -361,7 +361,7 @@ func TestGrpcClientStream_SendMsg(t *testing.T) {
 		s := &grpcClientStream{
 			parentConn: parentConn,
 			stream:     mockStream,
-			streamCtx:  t.Context(),
+			requestCtx: t.Context(),
 			wrapping:   true,
 			traceID:    "test-trace-id",
 			sentMark:   &modificationMark{},
@@ -392,7 +392,7 @@ func TestGrpcClientStream_SendMsg(t *testing.T) {
 		s := &grpcClientStream{
 			parentConn: parentConn,
 			stream:     mockStream,
-			streamCtx:  t.Context(),
+			requestCtx: t.Context(),
 			wrapping:   true,
 			traceID:    "test-trace-id",
 			sentMark:   mark,
@@ -421,7 +421,7 @@ func TestGrpcClientStream_SendMsg(t *testing.T) {
 		s := &grpcClientStream{
 			parentConn: parentConn,
 			stream:     mockStream,
-			streamCtx:  t.Context(),
+			requestCtx: t.Context(),
 			wrapping:   false,
 			sentMark:   &modificationMark{},
 		}
@@ -454,7 +454,7 @@ func TestGrpcClientStream_RecvMsg(t *testing.T) {
 		s := &grpcClientStream{
 			parentConn: parentConn,
 			stream:     mockStream,
-			streamCtx:  t.Context(),
+			requestCtx: t.Context(),
 			wrapping:   true,
 			sentMark:   &modificationMark{},
 		}
@@ -480,7 +480,7 @@ func TestGrpcClientStream_RecvMsg(t *testing.T) {
 		s := &grpcClientStream{
 			parentConn: parentConn,
 			stream:     mockStream,
-			streamCtx:  t.Context(),
+			requestCtx: t.Context(),
 			wrapping:   true,
 			sentMark:   &modificationMark{},
 		}
@@ -507,7 +507,7 @@ func TestGrpcClientStream_RecvMsg(t *testing.T) {
 			s := &grpcClientStream{
 				parentConn: parentConn,
 				stream:     mockStream,
-				streamCtx:  t.Context(),
+				requestCtx: t.Context(),
 				wrapping:   true,
 				sentMark:   &modificationMark{},
 			}
@@ -536,7 +536,7 @@ func TestGrpcClientStream_RecvMsg(t *testing.T) {
 			s := &grpcClientStream{
 				parentConn: parentConn,
 				stream:     mockStream,
-				streamCtx:  ctx,
+				requestCtx: ctx,
 				wrapping:   true,
 				sentMark:   &modificationMark{},
 			}
@@ -572,7 +572,7 @@ func TestGrpcClientStream_RecvMsg(t *testing.T) {
 		s := &grpcClientStream{
 			parentConn: parentConn,
 			stream:     mockStream,
-			streamCtx:  cancelledCtx,
+			requestCtx: cancelledCtx,
 			wrapping:   true,
 			traceID:    "test-trace-id",
 			sentMark:   &modificationMark{},
@@ -605,7 +605,7 @@ func TestGrpcClientStream_RecvMsg(t *testing.T) {
 			s := &grpcClientStream{
 				parentConn: parentConn,
 				stream:     mockStream,
-				streamCtx:  t.Context(),
+				requestCtx: t.Context(),
 				wrapping:   true,
 				traceID:    "test-trace-id",
 				sentMark:   &modificationMark{},
@@ -637,10 +637,10 @@ func TestGrpcClientStream_RecvMsg(t *testing.T) {
 						config:   &mockConfig{},
 						endpoint: endpoint.New("test-endpoint:2135"),
 					},
-					stream:    mockStream,
-					streamCtx: ctx,
-					wrapping:  true,
-					sentMark:  mark,
+					stream:     mockStream,
+					requestCtx: ctx,
+					wrapping:   true,
+					sentMark:   mark,
 				}
 
 				err := s.RecvMsg(msg)
@@ -668,10 +668,10 @@ func TestGrpcClientStream_RecvMsg(t *testing.T) {
 						config:   &mockConfig{},
 						endpoint: endpoint.New("test-endpoint:2135"),
 					},
-					stream:    mockStream,
-					streamCtx: ctx,
-					wrapping:  true,
-					sentMark:  &modificationMark{},
+					stream:     mockStream,
+					requestCtx: ctx,
+					wrapping:   true,
+					sentMark:   &modificationMark{},
 				}
 
 				err := s.RecvMsg(msg)
@@ -706,7 +706,7 @@ func TestGrpcClientStream_RecvMsg(t *testing.T) {
 		s := &grpcClientStream{
 			parentConn: parentConn,
 			stream:     mockStream,
-			streamCtx:  t.Context(),
+			requestCtx: t.Context(),
 			wrapping:   true,
 			traceID:    "test-trace-id",
 			sentMark:   mark,
@@ -736,7 +736,7 @@ func TestGrpcClientStream_RecvMsg(t *testing.T) {
 		s := &grpcClientStream{
 			parentConn: parentConn,
 			stream:     mockStream,
-			streamCtx:  t.Context(),
+			requestCtx: t.Context(),
 			wrapping:   false,
 			sentMark:   &modificationMark{},
 		}
@@ -768,7 +768,7 @@ func TestGrpcClientStream_RecvMsg(t *testing.T) {
 		s := &grpcClientStream{
 			parentConn: parentConn,
 			stream:     mockStream,
-			streamCtx:  t.Context(),
+			requestCtx: t.Context(),
 			wrapping:   true,
 			sentMark:   &modificationMark{},
 		}
@@ -799,7 +799,7 @@ func TestGrpcClientStream_RecvMsg(t *testing.T) {
 		s := &grpcClientStream{
 			parentConn: parentConn,
 			stream:     mockStream,
-			streamCtx:  t.Context(),
+			requestCtx: t.Context(),
 			wrapping:   false,
 			sentMark:   &modificationMark{},
 		}
@@ -829,10 +829,10 @@ func TestGrpcClientStream_Finish(t *testing.T) {
 		}
 
 		s := &grpcClientStream{
-			parentConn:   parentConn,
-			stream:       mockStream,
-			streamCtx:    ctx,
-			streamCancel: wrappedCancel,
+			parentConn: parentConn,
+			stream:     mockStream,
+			requestCtx: ctx,
+			grpcCancel: wrappedCancel,
 		}
 
 		s.finish(nil)
@@ -853,10 +853,10 @@ func TestGrpcClientStream_Finish(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())
 
 		s := &grpcClientStream{
-			parentConn:   parentConn,
-			stream:       mockStream,
-			streamCtx:    ctx,
-			streamCancel: cancel,
+			parentConn: parentConn,
+			stream:     mockStream,
+			requestCtx: ctx,
+			grpcCancel: cancel,
 		}
 
 		testErr := fmt.Errorf("test error")

--- a/internal/mock/server.go
+++ b/internal/mock/server.go
@@ -49,6 +49,13 @@ func WithExecuteQueryPartDelay(delay time.Duration) ServerOption {
 	}
 }
 
+// WithExecuteQuery runs f before QueryService.ExecuteQuery sends its response.
+func WithExecuteQuery(f func(context.Context) error) ServerOption {
+	return func(m *server) {
+		m.executeQuery = f
+	}
+}
+
 // server is a local gRPC mock (Discovery + Table + Query).
 type server struct {
 	listener   net.Listener
@@ -77,6 +84,7 @@ type server struct {
 	// executeQueryPartDelay is inserted before each ExecuteQuery response part
 	// send to simulate network latency between stream parts in benchmarks.
 	executeQueryPartDelay time.Duration
+	executeQuery          func(context.Context) error
 
 	// bulkUpsertFailFirst is the number of initial BulkUpsert calls that return
 	// bulkUpsertFailStatus before succeeding.
@@ -351,6 +359,12 @@ func (m *querySrv) ExecuteQuery(
 	stream Ydb_Query_V1.QueryService_ExecuteQueryServer,
 ) error {
 	m.mock.executeQueryCalls.Add(1)
+
+	if m.mock.executeQuery != nil {
+		if err := m.mock.executeQuery(stream.Context()); err != nil {
+			return err
+		}
+	}
 
 	if isCommitQuery(req) && m.mock.executeQueryBehavior != executeQueryBehaviorDefault {
 		return m.executeCommitQuery(req, stream)

--- a/internal/query/test/server_cancel_test.go
+++ b/internal/query/test/server_cancel_test.go
@@ -1,0 +1,66 @@
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	grpcCodes "google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/mock"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
+)
+
+func TestQueryClientServerCanceledIsNotContextError(t *testing.T) {
+	mockSrv := mock.Server(t, mock.WithExecuteQuery(func(context.Context) error {
+		return status.Error(grpcCodes.Canceled, "server canceled")
+	}))
+
+	ctx := t.Context()
+	db, err := ydb.Open(ctx, mockSrv.ConnString(), ydb.WithAnonymousCredentials())
+	require.NoError(t, err)
+	defer func() { _ = db.Close(ctx) }()
+
+	_, err = db.Query().Query(ctx, "SELECT 1")
+
+	require.Error(t, err)
+	require.NoError(t, ctx.Err())
+	require.True(t, xerrors.IsTransportError(err, grpcCodes.Canceled))
+	require.False(t, xerrors.IsContextError(err))
+}
+
+func TestQueryClientCanceledContextIsContextError(t *testing.T) {
+	control := make(chan struct{})
+	mockSrv := mock.Server(t, mock.WithExecuteQuery(func(context.Context) error {
+		control <- struct{}{}
+		<-control
+
+		return nil
+	}))
+
+	ctx := t.Context()
+	db, err := ydb.Open(ctx, mockSrv.ConnString(), ydb.WithAnonymousCredentials())
+	require.NoError(t, err)
+	defer func() { _ = db.Close(ctx) }()
+
+	queryCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go func() {
+		select {
+		case <-control:
+		case <-ctx.Done():
+			return
+		}
+		cancel()
+		select {
+		case control <- struct{}{}:
+		case <-ctx.Done():
+		}
+	}()
+
+	_, err = db.Query().Query(queryCtx, "SELECT 1")
+	require.ErrorIs(t, err, context.Canceled)
+	require.True(t, xerrors.IsContextError(err))
+}


### PR DESCRIPTION
## Summary

- keep the logical request context separate from the guarded gRPC transport context
- preserve client-side context cancellation while classifying server-side stream failures as transport errors
- add full-stack Query client regression tests for both server-side and client-side cancellation

## Root cause

`grpc.OnFinish` canceled the same context stored in `grpcClientStream`. By the time `RecvMsg` wrapped a server-side stream error, that context contained `context.Canceled`, so the joined error was incorrectly recognized as a client context error.

## Impact

Server-side gRPC stream errors no longer appear as client-side context cancellation. Genuine client cancellation continues to satisfy `xerrors.IsContextError`.

## Validation

- `golangci-lint run ./...`
- `go test -race ./...`
