### PR TITLE
Respect caller context while creating pooled sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed session pool waits for in-progress session creation to return on caller context cancellation while preserving the created session for reuse
+
 ## v3.146.1
 * Fixed YQL issue logs to preserve the event message and include bounded nested issue details
 

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -49,6 +49,11 @@ type (
 		lastUsage  time.Time
 		useCounter uint64
 	}
+	createItemResult[PT ItemConstraint[T], T any] struct {
+		item         PT
+		batchChanges dynamicStats
+		err          error
+	}
 	Pool[PT ItemConstraint[T], T any] struct {
 		config *Config[PT, T]
 
@@ -324,6 +329,55 @@ func (p *Pool[PT, T]) createItem(ctx context.Context, batchChanges *dynamicStats
 	return item, nil
 }
 
+func (p *Pool[PT, T]) startCreateItem(ctx context.Context) <-chan createItemResult[PT, T] {
+	result := make(chan createItemResult[PT, T], 1)
+
+	go func() {
+		var batchChanges dynamicStats
+		item, err := p.createItem(ctx, &batchChanges)
+		result <- createItemResult[PT, T]{
+			item:         item,
+			batchChanges: batchChanges,
+			err:          err,
+		}
+	}()
+
+	return result
+}
+
+func (p *Pool[PT, T]) newItemInfo(item PT) *itemInfo[PT, T] {
+	now := p.config.clock.Now()
+
+	return &itemInfo[PT, T]{
+		item:      item,
+		created:   now,
+		lastUsage: now,
+	}
+}
+
+// finishCreateItem completes a creation whose caller stopped waiting.
+// It owns the semaphore slot until the item is stored or discarded.
+func (p *Pool[PT, T]) finishCreateItem(ctx context.Context, res createItemResult[PT, T]) {
+	defer func() {
+		p.sema <- struct{}{}
+	}()
+
+	defer p.applyBatchStats(&res.batchChanges)
+
+	if res.err != nil {
+		return
+	}
+
+	_ = p.putIdleItem(ctx, p.newItemInfo(res.item), &res.batchChanges)
+}
+
+func (p *Pool[PT, T]) waitCreateItemInBackground(
+	ctx context.Context,
+	result <-chan createItemResult[PT, T],
+) {
+	p.finishCreateItem(ctx, <-result)
+}
+
 // closeItem closes the item with timeout handling
 // closeItem called only under p.sema lock
 func (p *Pool[PT, T]) closeItem(ctx context.Context, item PT, batchChanges *dynamicStats) {
@@ -387,6 +441,8 @@ func (p *Pool[PT, T]) try(ctx context.Context,
 		}
 	}
 
+	releaseSlot := true
+
 	select {
 	case <-ctx.Done():
 		return xerrors.WithStackTrace(ctx.Err())
@@ -401,11 +457,16 @@ func (p *Pool[PT, T]) try(ctx context.Context,
 		// pick this case while Close() has already closed p.done but tokens remain.
 		// try() may then run until user callback returns; Close() waits for sema drain.
 		defer func() {
-			p.sema <- struct{}{}
+			if releaseSlot {
+				p.sema <- struct{}{}
+			}
 		}()
 	}
 
-	info, err := p.getItem(ctx, batchChanges)
+	info, slotTransferred, err := p.getItem(ctx, batchChanges)
+	if slotTransferred {
+		releaseSlot = false
+	}
 	if err != nil {
 		if isRetriable(err) {
 			return xerrors.WithStackTrace(xerrors.Retryable(err))
@@ -423,6 +484,7 @@ func (p *Pool[PT, T]) try(ctx context.Context,
 	}
 
 	batchChanges.InUse++
+	itemUsed := false
 
 	defer func() {
 		batchChanges.InUse--
@@ -433,9 +495,20 @@ func (p *Pool[PT, T]) try(ctx context.Context,
 			return
 		}
 
-		_ = p.putItem(ctx, info, batchChanges)
+		if itemUsed {
+			_ = p.putItem(ctx, info, batchChanges)
+
+			return
+		}
+
+		_ = p.putIdleItem(ctx, info, batchChanges)
 	}()
 
+	if err := ctx.Err(); err != nil {
+		return xerrors.WithStackTrace(err)
+	}
+
+	itemUsed = true
 	err = f(ctx, info.item)
 	if err != nil {
 		return xerrors.WithStackTrace(err)
@@ -683,10 +756,14 @@ func (p *Pool[PT, T]) popItem(nodeID uint32, useNodeID, checkOldest bool, batchC
 	return p.idle.Pop()
 }
 
-// getItem called only under p.sema lock
+// getItem is called only under the p.sema lock.
+// slotTransferred reports that background item creation owns the current semaphore slot.
 //
 //nolint:funlen
-func (p *Pool[PT, T]) getItem(ctx context.Context, batchChanges *dynamicStats) (info *itemInfo[PT, T], finalErr error) {
+func (p *Pool[PT, T]) getItem(
+	ctx context.Context,
+	batchChanges *dynamicStats,
+) (info *itemInfo[PT, T], slotTransferred bool, finalErr error) {
 	nodeID, hasPreferredNodeID := endpoint.ContextNodeID(ctx)
 
 	var attempts int
@@ -721,7 +798,7 @@ func (p *Pool[PT, T]) getItem(ctx context.Context, batchChanges *dynamicStats) (
 		case needCloseItem(p.config, info):
 			p.closeItem(ctx, info.item, batchChanges)
 		default:
-			return info, nil
+			return info, false, nil
 		}
 	}
 
@@ -732,7 +809,7 @@ func (p *Pool[PT, T]) getItem(ctx context.Context, batchChanges *dynamicStats) (
 			// Free a slot before createItem: full concurrent load or pool already at limit.
 			info, err := p.popItem(0, false, false, batchChanges)
 			if err != nil {
-				return nil, errNothingIdleItems
+				return nil, false, errNothingIdleItems
 			}
 
 			p.closeItem(ctx, info.item, batchChanges)
@@ -742,27 +819,49 @@ func (p *Pool[PT, T]) getItem(ctx context.Context, batchChanges *dynamicStats) (
 	attempts++
 
 	// create item after two fails
-	item, err := p.createItem(ctx, batchChanges)
-	if err != nil {
+	select {
+	case <-ctx.Done():
+		return nil, false, xerrors.WithStackTrace(ctx.Err())
+	case <-p.done:
+		return nil, false, xerrors.WithStackTrace(errClosedPool)
+	default:
+	}
+
+	result := p.startCreateItem(ctx)
+
+	var res createItemResult[PT, T]
+	select {
+	case <-ctx.Done():
+		go p.waitCreateItemInBackground(xcontext.ValueOnly(ctx), result)
+
+		return nil, true, xerrors.WithStackTrace(ctx.Err())
+	case <-p.done:
+		go p.waitCreateItemInBackground(xcontext.ValueOnly(ctx), result)
+
+		return nil, true, xerrors.WithStackTrace(errClosedPool)
+	case res = <-result:
+		if err := ctx.Err(); err != nil {
+			go p.finishCreateItem(xcontext.ValueOnly(ctx), res)
+
+			return nil, true, xerrors.WithStackTrace(err)
+		}
+	}
+	batchChanges.add(res.batchChanges)
+
+	if res.err != nil {
+		err := res.err
 		if isRetriable(err) {
-			return nil, xerrors.Retryable(err)
+			return nil, false, xerrors.Retryable(err)
 		}
 
-		return nil, err
+		return nil, false, err
 	}
 
-	if item == nil {
-		return nil, errNilItem
+	if res.item == nil {
+		return nil, false, errNilItem
 	}
 
-	now := p.config.clock.Now()
-
-	return &itemInfo[PT, T]{
-		item:       item,
-		created:    now,
-		lastUsage:  now,
-		useCounter: 0,
-	}, nil
+	return p.newItemInfo(res.item), false, nil
 }
 
 // putItem called only under p.sema lock
@@ -788,6 +887,23 @@ func (p *Pool[PT, T]) putItem(ctx context.Context, info *itemInfo[PT, T], batchC
 		info.useCounter++
 		info.lastUsage = p.config.clock.Now()
 
+		return p.putIdleItem(ctx, info, batchChanges)
+	}
+}
+
+// putIdleItem stores an item without counting it as used.
+// It is called only under the p.sema lock.
+func (p *Pool[PT, T]) putIdleItem(
+	ctx context.Context,
+	info *itemInfo[PT, T],
+	batchChanges *dynamicStats,
+) error {
+	select {
+	case <-p.done:
+		p.closeItem(ctx, info.item, batchChanges)
+
+		return xerrors.WithStackTrace(errClosedPool)
+	default:
 		if err := p.idle.PutWithCheckLimit(info, p.config.limit); err != nil {
 			p.closeItem(ctx, info.item, batchChanges)
 

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -126,7 +126,12 @@ func getItemWithFlush[PT ItemConstraint[T], T any](
 	var batchChanges dynamicStats
 	defer p.applyBatchStats(&batchChanges)
 
-	return p.getItem(ctx, &batchChanges)
+	info, slotTransferred, err := p.getItem(ctx, &batchChanges)
+	if slotTransferred {
+		return nil, errors.New("unexpected semaphore slot transfer")
+	}
+
+	return info, err
 }
 
 func putItemWithFlush[PT ItemConstraint[T], T any](
@@ -2251,6 +2256,204 @@ func TestPoolWith_doesNotRetryOnNothingIdleItemsWhenContextCanceled(t *testing.T
 	case <-time.After(time.Second):
 		t.Fatal("pool.With did not finish after context cancel")
 	}
+}
+
+func TestPoolWithCallerContextStopsWaitingForItemCreation(t *testing.T) {
+	for _, tt := range []struct {
+		name             string
+		timeout          time.Duration
+		cancelAfterStart bool
+		wantErr          error
+	}{
+		{
+			name:             "Canceled",
+			cancelAfterStart: true,
+			wantErr:          context.Canceled,
+		},
+		{
+			name:    "DeadlineExceeded",
+			timeout: 100 * time.Millisecond,
+			wantErr: context.DeadlineExceeded,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				createCalls  atomic.Int32
+				callbackRuns atomic.Int32
+				releaseOnce  sync.Once
+			)
+			createStarted := make(chan context.Context, 1)
+			releaseCreate := make(chan struct{})
+			release := func() {
+				releaseOnce.Do(func() {
+					close(releaseCreate)
+				})
+			}
+
+			p := mustNewPool[*testItem, testItem](t,
+				WithLimit[*testItem, testItem](1),
+				WithItemUsageLimit[*testItem, testItem](1),
+				WithCreateItemTimeout[*testItem, testItem](time.Second),
+				WithCreateItemFunc(func(ctx context.Context) (*testItem, error) {
+					id := createCalls.Add(1)
+					createStarted <- ctx
+
+					select {
+					case <-releaseCreate:
+						return &testItem{v: id}, nil
+					case <-ctx.Done():
+						return nil, ctx.Err()
+					}
+				}),
+			)
+			t.Cleanup(func() {
+				_ = p.Close(t.Context())
+			})
+			t.Cleanup(release)
+
+			var (
+				ctx    context.Context
+				cancel context.CancelFunc
+			)
+			if tt.timeout > 0 {
+				ctx, cancel = context.WithTimeout(t.Context(), tt.timeout)
+			} else {
+				ctx, cancel = context.WithCancel(t.Context())
+			}
+			defer cancel()
+
+			result := make(chan error, 1)
+			go func() {
+				result <- p.With(ctx, func(context.Context, *testItem) error {
+					callbackRuns.Add(1)
+
+					return nil
+				})
+			}()
+
+			var createCtx context.Context
+			select {
+			case createCtx = <-createStarted:
+			case <-time.After(time.Second):
+				t.Fatal("item creation did not start")
+			}
+
+			if tt.cancelAfterStart {
+				cancel()
+			}
+
+			select {
+			case err := <-result:
+				require.ErrorIs(t, err, tt.wantErr)
+			case <-time.After(time.Second):
+				t.Fatal("pool.With did not return after caller context finished")
+			}
+
+			require.Equal(t, int32(0), callbackRuns.Load())
+			require.NoError(t, createCtx.Err(), "caller context must not cancel item creation")
+			require.Eventually(t, func() bool {
+				stats := p.Stats()
+
+				return stats.Concurrency == 0 && stats.CreateInProgress == 1
+			}, time.Second, time.Millisecond)
+
+			blockedCtx, cancelBlocked := context.WithCancel(t.Context())
+			blockedResult := make(chan error, 1)
+			go func() {
+				blockedResult <- p.With(blockedCtx, func(context.Context, *testItem) error {
+					return nil
+				})
+			}()
+			require.Eventually(t, func() bool {
+				return p.Stats().Concurrency == 1
+			}, time.Second, time.Millisecond)
+			require.Equal(t, int32(1), createCalls.Load(), "detached creation must retain the pool slot")
+
+			cancelBlocked()
+			select {
+			case err := <-blockedResult:
+				require.ErrorIs(t, err, context.Canceled)
+			case <-time.After(time.Second):
+				t.Fatal("second pool.With did not return after caller context cancellation")
+			}
+
+			release()
+
+			require.Eventually(t, func() bool {
+				stats := p.Stats()
+
+				return stats.Size == 1 && stats.Idle == 1 && stats.CreateInProgress == 0
+			}, time.Second, time.Millisecond)
+
+			err := p.With(t.Context(), func(_ context.Context, item *testItem) error {
+				require.Equal(t, int32(1), item.v)
+
+				return nil
+			})
+			require.NoError(t, err)
+			require.Equal(t, int32(1), createCalls.Load())
+		})
+	}
+}
+
+func TestPoolCloseCancelsDetachedItemCreation(t *testing.T) {
+	createStarted := make(chan struct{})
+	createCanceled := make(chan struct{})
+
+	p := mustNewPool[*testItem, testItem](t,
+		WithLimit[*testItem, testItem](1),
+		WithCreateItemTimeout[*testItem, testItem](time.Minute),
+		WithCreateItemFunc(func(ctx context.Context) (*testItem, error) {
+			close(createStarted)
+			<-ctx.Done()
+			close(createCanceled)
+
+			return nil, ctx.Err()
+		}),
+	)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	result := make(chan error, 1)
+	go func() {
+		result <- p.With(ctx, func(context.Context, *testItem) error {
+			return nil
+		})
+	}()
+
+	select {
+	case <-createStarted:
+	case <-time.After(time.Second):
+		t.Fatal("item creation did not start")
+	}
+
+	cancel()
+
+	select {
+	case err := <-result:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("pool.With did not return after caller context cancellation")
+	}
+
+	closeResult := make(chan error, 1)
+	go func() {
+		closeResult <- p.Close(t.Context())
+	}()
+
+	select {
+	case <-createCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("pool close did not cancel detached item creation")
+	}
+
+	select {
+	case err := <-closeResult:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("pool close did not wait for detached item creation")
+	}
+
+	requirePoolStats(t, p, poolStats(1, nil))
 }
 
 func TestNothingIdleItems_isFastRetryable(t *testing.T) {

--- a/internal/pool/stats.go
+++ b/internal/pool/stats.go
@@ -15,3 +15,11 @@ type (
 		WarmUp int
 	}
 )
+
+func (s *dynamicStats) add(other dynamicStats) {
+	s.Size += other.Size
+	s.Idle += other.Idle
+	s.CreateInProgress += other.CreateInProgress
+	s.Concurrency += other.Concurrency
+	s.InUse += other.InUse
+}


### PR DESCRIPTION
## Summary

- return from session acquisition when the caller context is canceled or reaches its deadline
- keep an already-started session creation running under the pool lifecycle context and configured creation timeout
- transfer the pool semaphore slot to background creation, then store a successfully created session for reuse
- cancel and drain detached creation when the pool closes

## Root cause

Session creation intentionally uses a pool-controlled context because the created session belongs to the pool rather than to one request. However, session acquisition waited synchronously for that creation to finish. A caller could therefore remain blocked until `WithSessionPoolCreateSessionTimeout` even after its own context had finished.

## Impact

The caller context now bounds how long `Table().Do`, `Query().Do`, and other session-pool operations wait for a newly created session. Cancellation does not waste useful work: successful background creation populates the idle pool, retains the original pool capacity accounting, and can be reused by a later request.

This is separate from the eager driver warm-up change in #2262.

Related to #2250.

## Testing

- `go test -race ./...`
- repeated race runs of the cancellation, deadline, slot-retention, reuse, and pool-close scenarios
- `golangci-lint v2.11.4 run --timeout=5m ./...`
