### PR TITLE
fix(topic): apply custom raw decoders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed custom topic decoders registered for the raw codec being ignored
+
 ## v3.146.2
 * Fixed server-side gRPC stream errors being incorrectly classified as client-side context cancellation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-* Fixed custom topic decoders registered for the raw codec being ignored
+* Fixed custom topic decoders registered for the raw codec being ignored; raw decoder overrides are discouraged and will be rejected in a future release
 
 ## v3.146.2
 * Fixed server-side gRPC stream errors being incorrectly classified as client-side context cancellation

--- a/internal/topic/topicreadercommon/decoders.go
+++ b/internal/topic/topicreadercommon/decoders.go
@@ -115,12 +115,12 @@ func (d *MultiDecoder) AddDecoder(codec rawtopiccommon.Codec, createFunc PublicC
 }
 
 func (d *MultiDecoder) Decode(codec rawtopiccommon.Codec, input io.Reader) (io.Reader, error) {
-	if codec == rawtopiccommon.CodecRaw {
-		return input, nil
-	}
-
 	if creator, ok := d.m[codec]; ok {
 		return creator.getDecoder(input)
+	}
+
+	if codec == rawtopiccommon.CodecRaw {
+		return input, nil
 	}
 
 	return nil, xerrors.WithStackTrace(xerrors.Wrap(

--- a/internal/topic/topicreadercommon/decoders_test.go
+++ b/internal/topic/topicreadercommon/decoders_test.go
@@ -30,6 +30,16 @@ func TestMultiDecoder(t *testing.T) {
 		return buf
 	}
 
+	t.Run("CustomRawDecoder", func(t *testing.T) {
+		testMultiDecoder := NewMultiDecoder()
+		testMultiDecoder.AddDecoder(rawtopiccommon.CodecRaw, func(io.Reader) (io.Reader, error) {
+			return nil, io.ErrUnexpectedEOF
+		})
+
+		_, err := testMultiDecoder.Decode(rawtopiccommon.CodecRaw, bytes.NewReader(nil))
+		require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	})
+
 	t.Run("NotResettableReader", func(t *testing.T) {
 		testMultiDecoder := NewMultiDecoder()
 		require.Len(t, testMultiDecoder.m, defaultDecodersCount)

--- a/topic/topicoptions/topicoptions_listener.go
+++ b/topic/topicoptions/topicoptions_listener.go
@@ -28,8 +28,12 @@ func WithListenerBufferSizeBytes(size int) ListenerOption {
 // It allows to set decoders fabric for custom codec and replace internal decoders.
 //
 // Replacing the decoder for topictypes.CodecRaw is discouraged because raw payloads are
-// expected to pass through unchanged. Use a custom codec ID, or decode raw messages at
-// the application level, for example using helpers from topic/topicsugar.
+// expected to pass through unchanged. Use a user-defined codec ID in the [10000, 19999]
+// range reserved by the protocol:
+// https://github.com/ydb-platform/ydb-api-protos/blob/d9841fab/protos/ydb_topic.proto#L27
+// This link refers to commit d9841fab4f5e7851294efd4801478e5b1a100799.
+// Alternatively, decode raw messages at the application level, for example using helpers
+// from topic/topicsugar.
 // A future release will reject custom decoders for topictypes.CodecRaw with an error.
 //
 // Experimental: https://github.com/ydb-platform/ydb-go-sdk/blob/master/VERSIONING.md#experimental

--- a/topic/topicoptions/topicoptions_listener.go
+++ b/topic/topicoptions/topicoptions_listener.go
@@ -27,6 +27,11 @@ func WithListenerBufferSizeBytes(size int) ListenerOption {
 // WithListenerAddDecoder add decoder for a codec.
 // It allows to set decoders fabric for custom codec and replace internal decoders.
 //
+// Replacing the decoder for topictypes.CodecRaw is discouraged because raw payloads are
+// expected to pass through unchanged. Use a custom codec ID, or decode raw messages at
+// the application level, for example using helpers from topic/topicsugar.
+// A future release will reject custom decoders for topictypes.CodecRaw with an error.
+//
 // Experimental: https://github.com/ydb-platform/ydb-go-sdk/blob/master/VERSIONING.md#experimental
 func WithListenerAddDecoder(codec topictypes.Codec, decoderCreate CreateDecoderFunc) ListenerOption {
 	return func(cfg *topiclistenerinternal.StreamListenerConfig) {

--- a/topic/topicoptions/topicoptions_reader.go
+++ b/topic/topicoptions/topicoptions_reader.go
@@ -167,6 +167,11 @@ type CreateDecoderFunc = topicreadercommon.PublicCreateDecoderFunc
 
 // WithAddDecoder add decoder for a codec.
 // It allows to set decoders fabric for custom codec and replace internal decoders.
+//
+// Replacing the decoder for topictypes.CodecRaw is discouraged because raw payloads are
+// expected to pass through unchanged. Use a custom codec ID, or decode raw messages at
+// the application level, for example using helpers from topic/topicsugar.
+// A future release will reject custom decoders for topictypes.CodecRaw with an error.
 func WithAddDecoder(codec topictypes.Codec, decoderCreate CreateDecoderFunc) ReaderOption {
 	return func(cfg *topicreaderinternal.ReaderConfig) {
 		cfg.Decoders.AddDecoder(rawtopiccommon.Codec(codec), decoderCreate)

--- a/topic/topicoptions/topicoptions_reader.go
+++ b/topic/topicoptions/topicoptions_reader.go
@@ -169,8 +169,12 @@ type CreateDecoderFunc = topicreadercommon.PublicCreateDecoderFunc
 // It allows to set decoders fabric for custom codec and replace internal decoders.
 //
 // Replacing the decoder for topictypes.CodecRaw is discouraged because raw payloads are
-// expected to pass through unchanged. Use a custom codec ID, or decode raw messages at
-// the application level, for example using helpers from topic/topicsugar.
+// expected to pass through unchanged. Use a user-defined codec ID in the [10000, 19999]
+// range reserved by the protocol:
+// https://github.com/ydb-platform/ydb-api-protos/blob/d9841fab/protos/ydb_topic.proto#L27
+// This link refers to commit d9841fab4f5e7851294efd4801478e5b1a100799.
+// Alternatively, decode raw messages at the application level, for example using helpers
+// from topic/topicsugar.
 // A future release will reject custom decoders for topictypes.CodecRaw with an error.
 func WithAddDecoder(codec topictypes.Codec, decoderCreate CreateDecoderFunc) ReaderOption {
 	return func(cfg *topicreaderinternal.ReaderConfig) {


### PR DESCRIPTION
Restores registered `CodecRaw` decoders by checking the decoder map before raw pass-through.

Checks: `go test -race ./...`; `golangci-lint run ./...`.
