### PR TITLE
fix(table): send DeleteSession when Close gets a done context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed table session not being deleted on the server when `Session.Close` is called with an already canceled or expired context (pool shutdown, expired caller deadline); `DeleteSession` is now sent on a detached context, as the query service session already does
+
 ## v3.147.0
 * Added Coordination `DescribeSemaphore` one-shot watch via `options.WithSemaphoreWatch`
 

--- a/internal/table/session.go
+++ b/internal/table/session.go
@@ -323,8 +323,14 @@ func newTableSession(
 
 func closeTableSession(c Ydb_Table_V1.TableServiceClient, cfg *config.Config, id string) func(context.Context) error {
 	return func(ctx context.Context) error {
-		if err := ctx.Err(); err != nil {
-			return xerrors.WithStackTrace(err)
+		// The caller context may already be done: the pool closes in-flight sessions
+		// after its done channel is closed, and Pool.Close passes the caller context
+		// straight through. The session id is known here, so detach from the caller
+		// cancellation and still send DeleteSession - otherwise the session stays on
+		// the server until the server-side idle timeout expires.
+		// The query service session core does the same (see query.(*sessionCore).deleteSession).
+		if ctx.Err() != nil {
+			ctx = xcontext.ValueOnly(ctx)
 		}
 
 		if t := cfg.DeleteTimeout(); t > 0 {

--- a/internal/table/session_test.go
+++ b/internal/table/session_test.go
@@ -926,3 +926,60 @@ func TestRenameTables(t *testing.T) {
 		})
 	}
 }
+
+func TestCloseTableSessionSendsDeleteOnDoneContext(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		ctx  func() (context.Context, context.CancelFunc)
+	}{
+		{
+			name: "live context",
+			ctx: func() (context.Context, context.CancelFunc) {
+				return context.WithCancel(context.Background())
+			},
+		},
+		{
+			name: "canceled context",
+			ctx: func() (context.Context, context.CancelFunc) {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+
+				return ctx, func() {}
+			},
+		},
+		{
+			name: "expired deadline",
+			ctx: func() (context.Context, context.CancelFunc) {
+				ctx, cancel := context.WithDeadline(context.Background(), time.Unix(0, 0))
+
+				return ctx, cancel
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var deleted int
+			cc := testutil.NewBalancer(
+				testutil.WithInvokeHandlers(
+					testutil.InvokeHandlers{
+						testutil.TableDeleteSession: func(any) (proto.Message, error) {
+							deleted++
+
+							return &Ydb_Table.DeleteSessionResponse{}, nil
+						},
+					},
+				),
+			)
+
+			ctx, cancel := tt.ctx()
+			defer cancel()
+
+			// A done caller context must not prevent DeleteSession: the session id is
+			// known, and skipping the call leaves the session on the server until the
+			// server-side idle timeout expires.
+			require.NoError(t, closeTableSession(
+				Ydb_Table_V1.NewTableServiceClient(cc), config.New(), "test-session",
+			)(ctx))
+			require.Equal(t, 1, deleted)
+		})
+	}
+}


### PR DESCRIPTION
When `Session.Close` is called with an already canceled or expired context, `closeTableSession` returns early and never sends `DeleteSession`. The session id is known at that point, so the client silently gives up on a session it owns, and the session stays on the server until the server-side idle timeout expires (`SessionIdleDurationSeconds`, 600s by default).

This happens on the shutdown path: the pool closes in-flight sessions after its `done` channel is closed, and `Pool.Close` passes the caller context straight through, so a short or expired `driver.Close(ctx)` makes every idle session skip its delete.

The query service session core already handles this — it reissues the delete on a detached context. This change does the same for the table session, bounded by the existing `DeleteTimeout`.