### PR TITLE
chore(deps): update ydb-go-genproto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Updated ydb-go-genproto and added bridge pile state to discovered endpoint metadata
+
 ## v3.147.1
 * Fixed table session not being deleted on the server when `Session.Close` is called with an already canceled or expired context (pool shutdown, expired caller deadline); `DeleteSession` is now sent on a detached context, as the query service session already does
 

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -70,7 +70,7 @@ require (
 	github.com/tidwall/btree v1.1.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/yandex-cloud/go-genproto v0.0.0-20220815090733-4c139c0154e2 // indirect
-	github.com/ydb-platform/ydb-go-genproto v0.0.0-20260428144813-1c07baab7f7b // indirect
+	github.com/ydb-platform/ydb-go-genproto v0.0.0-20260810122915-65bfd5c4b705 // indirect
 	github.com/ydb-platform/ydb-go-yc-metadata v0.6.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.44.0 // indirect

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -3562,8 +3562,8 @@ github.com/ydb-platform/gorm-driver v0.1.3 h1:uewwScbRuCixNPC0LF7gDKvWcB13/iLj76
 github.com/ydb-platform/gorm-driver v0.1.3/go.mod h1:49cSoG5J18muQTiKj4StL2dHs1/dB94OitnHOvetK24=
 github.com/ydb-platform/xorm v0.0.3 h1:MXk42lANB6r/MMLg/XdJfyXJycGUDlCeLiMlLGDKVPw=
 github.com/ydb-platform/xorm v0.0.3/go.mod h1:hFsU7EUF0o3S+l5c0eyP2yPVjJ0d4gsFdqCsyazzwBc=
-github.com/ydb-platform/ydb-go-genproto v0.0.0-20260428144813-1c07baab7f7b h1:xeiobG1riqe6dTMZuTcOvwOY0BbFidSk3gRLyVeLfJA=
-github.com/ydb-platform/ydb-go-genproto v0.0.0-20260428144813-1c07baab7f7b/go.mod h1:Er+FePu1dNUieD+XTMDduGpQuCPssK5Q4BjF+IIXJ3I=
+github.com/ydb-platform/ydb-go-genproto v0.0.0-20260810122915-65bfd5c4b705 h1:7VKlOrBIQ8L8acJ9wFCt6lWzLDbOhc05VLpL31743tU=
+github.com/ydb-platform/ydb-go-genproto v0.0.0-20260810122915-65bfd5c4b705/go.mod h1:Er+FePu1dNUieD+XTMDduGpQuCPssK5Q4BjF+IIXJ3I=
 github.com/ydb-platform/ydb-go-sdk-auth-environ v0.3.0 h1:JxSvw+Moont8qCmibP2MjSEIHfkWJLkw0fHZemAk+d0=
 github.com/ydb-platform/ydb-go-sdk-auth-environ v0.3.0/go.mod h1:YzCPoNrTbrXZg9bO2YkbjI6eQLkaRIE9Bq8ponu0g8A=
 github.com/ydb-platform/ydb-go-sdk-otel v0.11.1 h1:C4BSDfPeVUylsMhqo2yzbJhMNmvqrgfthquUxIlK1A8=

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/google/uuid v1.6.0
 	github.com/jonboulle/clockwork v0.5.0
-	github.com/ydb-platform/ydb-go-genproto v0.0.0-20260428144813-1c07baab7f7b
+	github.com/ydb-platform/ydb-go-genproto v0.0.0-20260810122915-65bfd5c4b705
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/sync v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/ydb-platform/ydb-go-genproto v0.0.0-20260428144813-1c07baab7f7b h1:xeiobG1riqe6dTMZuTcOvwOY0BbFidSk3gRLyVeLfJA=
 github.com/ydb-platform/ydb-go-genproto v0.0.0-20260428144813-1c07baab7f7b/go.mod h1:Er+FePu1dNUieD+XTMDduGpQuCPssK5Q4BjF+IIXJ3I=
+github.com/ydb-platform/ydb-go-genproto v0.0.0-20260810122915-65bfd5c4b705 h1:7VKlOrBIQ8L8acJ9wFCt6lWzLDbOhc05VLpL31743tU=
+github.com/ydb-platform/ydb-go-genproto v0.0.0-20260810122915-65bfd5c4b705/go.mod h1:Er+FePu1dNUieD+XTMDduGpQuCPssK5Q4BjF+IIXJ3I=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/otel v1.38.0 h1:RkfdswUDRimDg0m2Az18RKOsnI8UDzppJAtj01/Ymk8=

--- a/internal/discovery/discovery.go
+++ b/internal/discovery/discovery.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/ydb-platform/ydb-go-genproto/Ydb_Discovery_V1"
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb"
+	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Bridge"
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Discovery"
 	"google.golang.org/grpc"
 
@@ -70,28 +71,73 @@ func Discover(
 	}
 
 	location = result.GetSelfLocation()
-	endpoints = make([]endpoint.Endpoint, 0, len(result.GetEndpoints()))
-	for _, e := range result.GetEndpoints() {
-		if e.GetSsl() == config.Secure() {
-			endpoints = append(endpoints, endpoint.New(
-				net.JoinHostPort(
-					config.MutateAddress(e.GetAddress()),
-					strconv.Itoa(int(e.GetPort())),
-				),
-				endpoint.WithLocation(e.GetLocation()),
-				endpoint.WithID(e.GetNodeId()),
-				endpoint.WithLoadFactor(e.GetLoadFactor()),
-				endpoint.WithLocalDC(e.GetLocation() == location),
-				endpoint.WithServices(e.GetService()),
-				endpoint.WithLastUpdated(config.Clock().Now()),
-				endpoint.WithIPV4(e.GetIpV4()),
-				endpoint.WithIPV6(e.GetIpV6()),
-				endpoint.WithSslTargetNameOverride(e.GetSslTargetNameOverride()),
+	endpoints = endpointsFromDiscovery(&result, config)
+
+	return endpoints, location, nil
+}
+
+func endpointsFromDiscovery(result *Ydb_Discovery.ListEndpointsResult, config *config.Config) []endpoint.Endpoint {
+	pileStates := make(map[string]endpoint.PileState, len(result.GetPileStates()))
+	for _, pile := range result.GetPileStates() {
+		pileStates[pile.GetPileName()] = bridgePileState(pile.GetState())
+	}
+
+	endpoints := make([]endpoint.Endpoint, 0, len(result.GetEndpoints()))
+	for _, candidate := range result.GetEndpoints() {
+		if candidate.GetSsl() == config.Secure() {
+			endpoints = append(endpoints, endpointFromDiscovery(
+				candidate, result.GetSelfLocation(), pileStates, config,
 			))
 		}
 	}
 
-	return endpoints, result.GetSelfLocation(), nil
+	return endpoints
+}
+
+func endpointFromDiscovery(
+	candidate *Ydb_Discovery.EndpointInfo,
+	selfLocation string,
+	pileStates map[string]endpoint.PileState,
+	config *config.Config,
+) endpoint.Endpoint {
+	metadata := endpoint.Metadata{LocalDC: candidate.GetLocation() == selfLocation}
+	if pileName := candidate.GetBridgePileName(); pileName != "" {
+		metadata.BridgePileState = pileStates[pileName]
+	}
+
+	return endpoint.New(
+		net.JoinHostPort(config.MutateAddress(candidate.GetAddress()), strconv.Itoa(int(candidate.GetPort()))),
+		endpoint.WithLocation(candidate.GetLocation()),
+		endpoint.WithID(candidate.GetNodeId()),
+		endpoint.WithLoadFactor(candidate.GetLoadFactor()),
+		endpoint.WithMetadata(metadata),
+		endpoint.WithServices(candidate.GetService()),
+		endpoint.WithLastUpdated(config.Clock().Now()),
+		endpoint.WithIPV4(candidate.GetIpV4()),
+		endpoint.WithIPV6(candidate.GetIpV6()),
+		endpoint.WithSslTargetNameOverride(candidate.GetSslTargetNameOverride()),
+	)
+}
+
+func bridgePileState(state Ydb_Bridge.PileState_State) endpoint.PileState {
+	switch state {
+	case Ydb_Bridge.PileState_PRIMARY:
+		return endpoint.PileStatePrimary
+	case Ydb_Bridge.PileState_PROMOTED:
+		return endpoint.PileStatePromoted
+	case Ydb_Bridge.PileState_SYNCHRONIZED:
+		return endpoint.PileStateSynchronized
+	case Ydb_Bridge.PileState_NOT_SYNCHRONIZED:
+		return endpoint.PileStateNotSynchronized
+	case Ydb_Bridge.PileState_SUSPENDED:
+		return endpoint.PileStateSuspended
+	case Ydb_Bridge.PileState_DISCONNECTED:
+		return endpoint.PileStateDisconnected
+	case Ydb_Bridge.PileState_UNSPECIFIED:
+		return endpoint.PileStateUnknown
+	default:
+		return endpoint.PileStateUnknown
+	}
 }
 
 // Discover cluster endpoints

--- a/internal/discovery/discovery_test.go
+++ b/internal/discovery/discovery_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb"
+	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Bridge"
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Discovery"
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Operations"
 	"go.uber.org/mock/gomock"
@@ -47,18 +48,35 @@ func TestDiscover(t *testing.T) {
 							Ssl:      true,
 						},
 						{
-							Address: "node3",
-							Port:    3,
-							Ssl:     false,
+							Address:        "node3",
+							Port:           3,
+							Ssl:            false,
+							BridgePileName: "pile-a",
 						},
 						{
-							Address:  "node4",
-							Port:     4,
-							Location: "AZ0",
-							Ssl:      false,
+							Address:        "node4",
+							Port:           4,
+							Location:       "AZ0",
+							Ssl:            false,
+							BridgePileName: "pile-b",
+						},
+						{
+							Address:        "node5",
+							Port:           5,
+							Ssl:            false,
+							BridgePileName: "missing-pile",
+						},
+						{
+							Address: "node6",
+							Port:    6,
+							Ssl:     false,
 						},
 					},
 					SelfLocation: "AZ0",
+					PileStates: []*Ydb_Bridge.PileState{
+						{PileName: "pile-a", State: Ydb_Bridge.PileState_PRIMARY},
+						{PileName: "pile-b", State: Ydb_Bridge.PileState_SYNCHRONIZED},
+					},
 				})),
 			},
 		}, nil)
@@ -71,12 +89,23 @@ func TestDiscover(t *testing.T) {
 		require.EqualValues(t, "AZ0", location)
 		require.EqualValues(t, []endpoint.Endpoint{
 			endpoint.New("node3:3",
-				endpoint.WithLocalDC(false),
+				endpoint.WithMetadata(endpoint.Metadata{BridgePileState: endpoint.PileStatePrimary}),
 				endpoint.WithLastUpdated(clock.Now()),
 			),
 			endpoint.New("node4:4",
-				endpoint.WithLocalDC(true),
 				endpoint.WithLocation("AZ0"),
+				endpoint.WithMetadata(endpoint.Metadata{
+					LocalDC:         true,
+					BridgePileState: endpoint.PileStateSynchronized,
+				}),
+				endpoint.WithLastUpdated(clock.Now()),
+			),
+			endpoint.New("node5:5",
+				endpoint.WithMetadata(endpoint.Metadata{BridgePileState: endpoint.PileStateUnknown}),
+				endpoint.WithLastUpdated(clock.Now()),
+			),
+			endpoint.New("node6:6",
+				endpoint.WithMetadata(endpoint.Metadata{BridgePileState: endpoint.PileStateUnknown}),
 				endpoint.WithLastUpdated(clock.Now()),
 			),
 		}, endpoints)
@@ -165,6 +194,26 @@ func TestDiscover(t *testing.T) {
 			),
 		}, endpoints)
 	})
+}
+
+func TestBridgePileState(t *testing.T) {
+	tests := []struct {
+		proto    Ydb_Bridge.PileState_State
+		expected endpoint.PileState
+	}{
+		{Ydb_Bridge.PileState_UNSPECIFIED, endpoint.PileStateUnknown},
+		{Ydb_Bridge.PileState_PRIMARY, endpoint.PileStatePrimary},
+		{Ydb_Bridge.PileState_PROMOTED, endpoint.PileStatePromoted},
+		{Ydb_Bridge.PileState_SYNCHRONIZED, endpoint.PileStateSynchronized},
+		{Ydb_Bridge.PileState_NOT_SYNCHRONIZED, endpoint.PileStateNotSynchronized},
+		{Ydb_Bridge.PileState_SUSPENDED, endpoint.PileStateSuspended},
+		{Ydb_Bridge.PileState_DISCONNECTED, endpoint.PileStateDisconnected},
+		{Ydb_Bridge.PileState_State(100), endpoint.PileStateUnknown},
+	}
+
+	for _, test := range tests {
+		require.Equal(t, test.expected, bridgePileState(test.proto))
+	}
 }
 
 func TestClientCloseSkipsConnWithoutIOCloser(t *testing.T) {

--- a/internal/endpoint/endpoint.go
+++ b/internal/endpoint/endpoint.go
@@ -16,6 +16,7 @@ type (
 		Address() string
 		Location() string
 		LoadFactor() float32
+		Metadata() Metadata
 		OverrideHost() string
 
 		// Deprecated: LocalDC check "local" by compare endpoint location with discovery "selflocation" field.
@@ -38,6 +39,21 @@ type (
 
 		Copy(opts ...Option) Endpoint
 	}
+	Metadata struct {
+		LocalDC         bool
+		BridgePileState PileState
+	}
+	PileState uint8
+)
+
+const (
+	PileStateUnknown PileState = iota
+	PileStatePrimary
+	PileStatePromoted
+	PileStateSynchronized
+	PileStateNotSynchronized
+	PileStateSuspended
+	PileStateDisconnected
 )
 
 type endpoint struct {
@@ -49,11 +65,10 @@ type endpoint struct {
 	ipv4            []string
 	ipv6            []string
 	sslNameOverride string
+	metadata        Metadata
 
 	loadFactor  float32
 	lastUpdated time.Time
-
-	local bool
 }
 
 func (e *endpoint) Key() Key {
@@ -76,8 +91,8 @@ func (e *endpoint) Copy(opts ...Option) Endpoint {
 		ipv4:            append(make([]string, 0, len(e.ipv4)), e.ipv4...),
 		ipv6:            append(make([]string, 0, len(e.ipv6)), e.ipv6...),
 		sslNameOverride: e.sslNameOverride,
+		metadata:        e.metadata,
 		loadFactor:      e.loadFactor,
-		local:           e.local,
 		lastUpdated:     e.lastUpdated,
 	}
 
@@ -97,7 +112,7 @@ func (e *endpoint) String() string {
 	return fmt.Sprintf(`{id:%d,address:%q,local:%t,location:%q,loadFactor:%f,lastUpdated:%q}`,
 		e.id,
 		e.getAddress(), // Use getAddress() to avoid deadlock from nested RLock in Address()
-		e.local,
+		e.metadata.LocalDC,
 		e.location,
 		e.loadFactor,
 		e.lastUpdated.Format(time.RFC3339),
@@ -165,6 +180,13 @@ func (e *endpoint) Location() string {
 	return e.location
 }
 
+func (e *endpoint) Metadata() Metadata {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	return e.metadata
+}
+
 // Deprecated: LocalDC check "local" by compare endpoint location with discovery "selflocation" field.
 // It work good only if connection url always point to local dc.
 // Will be removed after Oct 2024.
@@ -173,7 +195,7 @@ func (e *endpoint) LocalDC() bool {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 
-	return e.local
+	return e.metadata.LocalDC
 }
 
 func (e *endpoint) LoadFactor() float32 {
@@ -206,7 +228,7 @@ func WithLocation(location string) Option {
 
 func WithLocalDC(local bool) Option {
 	return func(e *endpoint) {
-		e.local = local
+		e.metadata.LocalDC = local
 	}
 }
 
@@ -243,6 +265,12 @@ func WithIPV6(ipv6 []string) Option {
 func WithSslTargetNameOverride(nameOverride string) Option {
 	return func(e *endpoint) {
 		e.sslNameOverride = nameOverride
+	}
+}
+
+func WithMetadata(metadata Metadata) Option {
+	return func(e *endpoint) {
+		e.metadata = metadata
 	}
 }
 

--- a/internal/endpoint/metadata_test.go
+++ b/internal/endpoint/metadata_test.go
@@ -1,0 +1,24 @@
+package endpoint
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEndpointMetadata(t *testing.T) {
+	metadata := Metadata{
+		LocalDC:         true,
+		BridgePileState: PileStatePrimary,
+	}
+	candidate := New("node:2135", WithMetadata(metadata))
+
+	require.Equal(t, metadata, candidate.Metadata())
+	require.True(t, candidate.LocalDC())
+	require.Equal(t, metadata, candidate.Copy().Metadata())
+
+	nonLocal := candidate.Copy(WithLocalDC(false))
+	require.False(t, nonLocal.LocalDC())
+	require.Equal(t, PileStatePrimary, nonLocal.Metadata().BridgePileState)
+	require.Contains(t, candidate.String(), "local:true")
+}

--- a/internal/mock/conn.go
+++ b/internal/mock/conn.go
@@ -21,6 +21,7 @@ type Conn struct {
 	NodeIDField   uint32
 	StateField    state.State
 	LocalDCField  bool
+	MetadataField endpoint.Metadata
 }
 
 func (c *Conn) Endpoint() endpoint.Endpoint {
@@ -29,6 +30,7 @@ func (c *Conn) Endpoint() endpoint.Endpoint {
 		LocalDCField:  c.LocalDCField,
 		LocationField: c.LocationField,
 		NodeIDField:   c.NodeIDField,
+		MetadataField: c.MetadataField,
 	}
 }
 
@@ -50,6 +52,7 @@ type Endpoint struct {
 	NodeIDField       uint32
 	LocalDCField      bool
 	OverrideHostField string
+	MetadataField     endpoint.Metadata
 }
 
 func (e *Endpoint) Key() endpoint.Key {
@@ -81,6 +84,13 @@ func (e *Endpoint) LocalDC() bool {
 
 func (e *Endpoint) Location() string {
 	return e.LocationField
+}
+
+func (e *Endpoint) Metadata() endpoint.Metadata {
+	metadata := e.MetadataField
+	metadata.LocalDC = e.LocalDCField
+
+	return metadata
 }
 
 func (e *Endpoint) LastUpdated() time.Time {

--- a/internal/mock/conn_test.go
+++ b/internal/mock/conn_test.go
@@ -1,0 +1,23 @@
+package mock
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/endpoint"
+)
+
+func TestConnectionEndpointMetadata(t *testing.T) {
+	connection := &Conn{
+		AddrField:    "node:2135",
+		LocalDCField: true,
+		MetadataField: endpoint.Metadata{
+			BridgePileState: endpoint.PileStatePrimary,
+		},
+	}
+
+	metadata := connection.Endpoint().Metadata()
+	require.True(t, metadata.LocalDC)
+	require.Equal(t, endpoint.PileStatePrimary, metadata.BridgePileState)
+}

--- a/internal/query/options/execute.go
+++ b/internal/query/options/execute.go
@@ -118,8 +118,9 @@ func (syntax Syntax) applyExecuteOption(s *executeSettings) {
 }
 
 const (
-	SyntaxYQL        = Syntax(Ydb_Query.Syntax_SYNTAX_YQL_V1)
-	SyntaxPostgreSQL = Syntax(Ydb_Query.Syntax_SYNTAX_PG)
+	SyntaxYQL = Syntax(Ydb_Query.Syntax_SYNTAX_YQL_V1)
+	// Keep the legacy enum mapping for public API compatibility.
+	SyntaxPostgreSQL = Syntax(Ydb_Query.Syntax_SYNTAX_PG) //nolint:staticcheck
 )
 
 func (opt parametersOption) applyExecuteOption(s *executeSettings) {

--- a/tests/slo/go.mod
+++ b/tests/slo/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/syndtr/goleveldb v1.0.0 // indirect
 	github.com/yandex-cloud/go-genproto v0.0.0-20211115083454-9ca41db5ed9e // indirect
-	github.com/ydb-platform/ydb-go-genproto v0.0.0-20260428144813-1c07baab7f7b // indirect
+	github.com/ydb-platform/ydb-go-genproto v0.0.0-20260810122915-65bfd5c4b705 // indirect
 	github.com/ydb-platform/ydb-go-yc v0.12.1 // indirect
 	github.com/ydb-platform/ydb-go-yc-metadata v0.6.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect

--- a/tests/slo/go.sum
+++ b/tests/slo/go.sum
@@ -3522,8 +3522,8 @@ github.com/ydb-platform/gorm-driver v0.1.3 h1:uewwScbRuCixNPC0LF7gDKvWcB13/iLj76
 github.com/ydb-platform/gorm-driver v0.1.3/go.mod h1:49cSoG5J18muQTiKj4StL2dHs1/dB94OitnHOvetK24=
 github.com/ydb-platform/xorm v0.0.3 h1:MXk42lANB6r/MMLg/XdJfyXJycGUDlCeLiMlLGDKVPw=
 github.com/ydb-platform/xorm v0.0.3/go.mod h1:hFsU7EUF0o3S+l5c0eyP2yPVjJ0d4gsFdqCsyazzwBc=
-github.com/ydb-platform/ydb-go-genproto v0.0.0-20260428144813-1c07baab7f7b h1:xeiobG1riqe6dTMZuTcOvwOY0BbFidSk3gRLyVeLfJA=
-github.com/ydb-platform/ydb-go-genproto v0.0.0-20260428144813-1c07baab7f7b/go.mod h1:Er+FePu1dNUieD+XTMDduGpQuCPssK5Q4BjF+IIXJ3I=
+github.com/ydb-platform/ydb-go-genproto v0.0.0-20260810122915-65bfd5c4b705 h1:7VKlOrBIQ8L8acJ9wFCt6lWzLDbOhc05VLpL31743tU=
+github.com/ydb-platform/ydb-go-genproto v0.0.0-20260810122915-65bfd5c4b705/go.mod h1:Er+FePu1dNUieD+XTMDduGpQuCPssK5Q4BjF+IIXJ3I=
 github.com/ydb-platform/ydb-go-sdk-auth-environ v0.3.0 h1:JxSvw+Moont8qCmibP2MjSEIHfkWJLkw0fHZemAk+d0=
 github.com/ydb-platform/ydb-go-sdk-auth-environ v0.3.0/go.mod h1:YzCPoNrTbrXZg9bO2YkbjI6eQLkaRIE9Bq8ponu0g8A=
 github.com/ydb-platform/ydb-go-yc v0.12.1 h1:qw3Fa+T81+Kpu5Io2vYHJOwcrYrVjgJlT6t/0dOXJrA=


### PR DESCRIPTION
## Summary

- update `github.com/ydb-platform/ydb-go-genproto` from `1c07baab7f7b` to `65bfd5c4b705` in the root, `examples`, and `tests/slo` modules;
- read `EndpointInfo.BridgePileName` and `ListEndpointsResult.PileStates` from discovery responses;
- expose `LocalDC` and `BridgePileState` together through internal endpoint metadata;
- preserve the deprecated `Endpoint.LocalDC()` behavior;
- map endpoints without pile metadata, missing pile entries, and unknown protobuf states to `PileStateUnknown`.

This PR is intentionally independent from the balancer refactoring in #2269. It provides only the updated generated API and discovery/endpoint metadata required by future pile-aware policies.

## Compatibility

The change is internal to endpoint and discovery representations. Existing discovery filtering, address mutation, and `LocalDC()` behavior remain unchanged.

The query syntax compatibility annotation is required because the new generated module marks the legacy protobuf enum alias as deprecated while the SDK must retain its existing public constant mapping.

## Tests

- `golangci-lint run ./... --timeout=5m`
- root, `examples`, and `tests/slo`: `go test -race ./... -count=1 -timeout=15m`
- focused coverage run for `internal/discovery`, `internal/endpoint`, `internal/mock`, and `internal/query/options`

The change has a dedicated `CHANGELOG.md` entry so it can be included in a separate release.
