### PR TITLE
fix(balancer): release retired connections outside lock

### DIFF
--- a/internal/balancer/balancer.go
+++ b/internal/balancer/balancer.go
@@ -225,8 +225,7 @@ func (b *Balancer) clusterDiscoveryAttempt(ctx context.Context, cc *grpc.ClientC
 
 func nextState(ctx context.Context, pool interface {
 	Get(e endpoint.Endpoint) conn.Conn
-	Put(ctx context.Context, cc conn.Conn)
-}, quarantine []conn.Conn, active []conn.Conn, endpoints []endpoint.Endpoint) (
+}, active []conn.Conn, endpoints []endpoint.Endpoint) (
 	newQuarantine []conn.Conn,
 	newActive []conn.Conn,
 ) {
@@ -236,10 +235,6 @@ func nextState(ctx context.Context, pool interface {
 		}),
 		func(cc conn.Conn) bool { return cc != nil },
 	)
-
-	for _, cc := range quarantine {
-		pool.Put(ctx, cc)
-	}
 
 	for _, cc := range newActive {
 		cc.Unban(ctx)
@@ -267,15 +262,6 @@ func (b *Balancer) releaseStateConns(ctx context.Context, state *connectionsStat
 }
 
 func (b *Balancer) applyDiscoveredEndpoints(ctx context.Context, endpoints []endpoint.Endpoint, localDC string) {
-	b.closeMu.Lock()
-	defer b.closeMu.Unlock()
-
-	if b.closed {
-		b.releaseStateConns(ctx, b.connectionsState.Swap(nil))
-
-		return
-	}
-
 	var (
 		onDone = gtrace.DriverOnBalancerUpdate(
 			b.driverConfig.Trace(), &ctx,
@@ -284,15 +270,8 @@ func (b *Balancer) applyDiscoveredEndpoints(ctx context.Context, endpoints []end
 			b.balancerConfig.DetectNearestDC,
 			b.driverConfig.Database(),
 		)
-		state      = b.connectionsState.Load()
-		active     []conn.Conn
-		quarantine []conn.Conn
+		active []conn.Conn
 	)
-
-	if state != nil {
-		active = state.All()
-		quarantine = state.quarantine
-	}
 
 	defer func() {
 		_, added, dropped := xslices.Diff(xslices.Transform(active, func(cc conn.Conn) endpoint.Endpoint {
@@ -307,7 +286,40 @@ func (b *Balancer) applyDiscoveredEndpoints(ctx context.Context, endpoints []end
 		)
 	}()
 
-	quarantine, connections := nextState(ctx, b.pool, quarantine, active, endpoints)
+	var retired []conn.Conn
+	active, retired = b.updateConnectionsState(ctx, endpoints, localDC)
+	for _, connection := range retired {
+		b.pool.Put(ctx, connection)
+	}
+}
+
+func (b *Balancer) updateConnectionsState(
+	ctx context.Context,
+	endpoints []endpoint.Endpoint,
+	localDC string,
+) (active, retired []conn.Conn) {
+	b.closeMu.Lock()
+	defer b.closeMu.Unlock()
+
+	state := b.connectionsState.Load()
+	var quarantine []conn.Conn
+	if state != nil {
+		active = state.All()
+		quarantine = state.quarantine
+	}
+
+	if b.closed {
+		state = b.connectionsState.Swap(nil)
+		if state != nil {
+			retired = append(retired, state.quarantine...)
+			retired = append(retired, state.all...)
+		}
+
+		return active, retired
+	}
+
+	retired = quarantine
+	quarantine, connections := nextState(ctx, b.pool, active, endpoints)
 
 	b.connectionsState.Store(
 		newConnectionsState(connections,
@@ -317,6 +329,8 @@ func (b *Balancer) applyDiscoveredEndpoints(ctx context.Context, endpoints []end
 			quarantine,
 		),
 	)
+
+	return active, retired
 }
 
 func (b *Balancer) Close(ctx context.Context) (err error) {

--- a/internal/balancer/balancer_test.go
+++ b/internal/balancer/balancer_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/mock"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
 	"github.com/ydb-platform/ydb-go-sdk/v3/pkg/xtest"
+	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
 )
 
 var errNodeShutdownHint = errors.New("received node shutdown hint")
@@ -216,6 +217,37 @@ func TestApplyDiscoveredEndpointsClosedPool(t *testing.T) {
 			endpoint.New("node:2135", endpoint.WithID(1)),
 		}, "")
 	})
+}
+
+func TestApplyDiscoveredEndpointsReleasesConnectionsOutsideCloseMu(t *testing.T) {
+	ctx := t.Context()
+	closeMuFreeDuringConnClose := false
+	var b *Balancer
+	cfg := config.New(config.WithTrace(trace.Driver{
+		OnConnClose: func(trace.DriverConnCloseStartInfo) func(trace.DriverConnCloseDoneInfo) {
+			if b.closeMu.TryLock() {
+				closeMuFreeDuringConnClose = true
+				b.closeMu.Unlock()
+			}
+
+			return func(trace.DriverConnCloseDoneInfo) {}
+		},
+	}))
+	pool := conn.NewPool(ctx, cfg)
+	t.Cleanup(func() { require.NoError(t, pool.RemoveRef(ctx)) })
+	b = &Balancer{
+		driverConfig:   cfg,
+		pool:           pool,
+		balancerConfig: balancerConfig.Config{},
+	}
+
+	b.applyDiscoveredEndpoints(ctx, []endpoint.Endpoint{
+		endpoint.New("retired:2135", endpoint.WithID(1)),
+	}, "")
+	b.applyDiscoveredEndpoints(ctx, nil, "")
+	b.applyDiscoveredEndpoints(ctx, nil, "")
+
+	require.True(t, closeMuFreeDuringConnClose, "closeMu must be released before closing a retired connection")
 }
 
 func TestBalancer_Close(t *testing.T) {
@@ -1192,9 +1224,16 @@ func TestNextState(t *testing.T) {
 		b = endpoint.New("node-b:2135", endpoint.WithID(2))
 		c = endpoint.New("node-c:2135", endpoint.WithID(3))
 	)
+	next := func(endpoints []endpoint.Endpoint) {
+		retired := quarantine
+		quarantine, active = nextState(ctx, pool, active, endpoints)
+		for _, connection := range retired {
+			pool.Put(ctx, connection)
+		}
+	}
 
 	// Discovery #1: [a, b, c] — first acquire, nothing to release from quarantine.
-	quarantine, active = nextState(ctx, pool, quarantine, active, []endpoint.Endpoint{a, b, c})
+	next([]endpoint.Endpoint{a, b, c})
 	require.Empty(t, quarantine)
 	requireConnKeys(t, []endpoint.Endpoint{a, b, c}, active)
 	require.Equal(t, 1, pool.count(a.Key()))
@@ -1204,7 +1243,7 @@ func TestNextState(t *testing.T) {
 	connA, connB, connC := active[0], active[1], active[2]
 
 	// Discovery #2: same set — previous active moves to quarantine, Get bumps refs again.
-	quarantine, active = nextState(ctx, pool, quarantine, active, []endpoint.Endpoint{a, b, c})
+	next([]endpoint.Endpoint{a, b, c})
 	requireConnKeys(t, []endpoint.Endpoint{a, b, c}, quarantine)
 	requireConnKeys(t, []endpoint.Endpoint{a, b, c}, active)
 	require.Same(t, connA, quarantine[0])
@@ -1215,7 +1254,7 @@ func TestNextState(t *testing.T) {
 	require.Equal(t, 2, pool.count(c.Key()))
 
 	// Discovery #3: drop c — release quarantine, c stays referenced only from new quarantine.
-	quarantine, active = nextState(ctx, pool, quarantine, active, []endpoint.Endpoint{a, b})
+	next([]endpoint.Endpoint{a, b})
 	requireConnKeys(t, []endpoint.Endpoint{a, b, c}, quarantine)
 	requireConnKeys(t, []endpoint.Endpoint{a, b}, active)
 	require.Equal(t, 2, pool.count(a.Key()))
@@ -1223,7 +1262,7 @@ func TestNextState(t *testing.T) {
 	require.Equal(t, 1, pool.count(c.Key()))
 
 	// Discovery #4: same [a, b] — release full quarantine; c ref drops to zero.
-	quarantine, active = nextState(ctx, pool, quarantine, active, []endpoint.Endpoint{a, b})
+	next([]endpoint.Endpoint{a, b})
 	requireConnKeys(t, []endpoint.Endpoint{a, b}, quarantine)
 	requireConnKeys(t, []endpoint.Endpoint{a, b}, active)
 	require.Equal(t, 2, pool.count(a.Key()))
@@ -1231,7 +1270,7 @@ func TestNextState(t *testing.T) {
 	require.Equal(t, 0, pool.count(c.Key()))
 
 	// Discovery #5: c returns — new Get for c, a/b keep elevated refs.
-	quarantine, active = nextState(ctx, pool, quarantine, active, []endpoint.Endpoint{a, b, c})
+	next([]endpoint.Endpoint{a, b, c})
 	requireConnKeys(t, []endpoint.Endpoint{a, b}, quarantine)
 	requireConnKeys(t, []endpoint.Endpoint{a, b, c}, active)
 	require.Equal(t, 2, pool.count(a.Key()))
@@ -1240,7 +1279,7 @@ func TestNextState(t *testing.T) {
 	require.Same(t, connC, active[2])
 
 	// Discovery #6: cluster empty — active set moves to quarantine, one ref each.
-	quarantine, active = nextState(ctx, pool, quarantine, active, nil)
+	next(nil)
 	requireConnKeys(t, []endpoint.Endpoint{a, b, c}, quarantine)
 	require.Empty(t, active)
 	require.Equal(t, 1, pool.count(a.Key()))
@@ -1248,7 +1287,7 @@ func TestNextState(t *testing.T) {
 	require.Equal(t, 1, pool.count(c.Key()))
 
 	// Discovery #7: still empty — release quarantine, all refs reach zero.
-	quarantine, active = nextState(ctx, pool, quarantine, active, nil)
+	next(nil)
 	require.Empty(t, quarantine)
 	require.Empty(t, active)
 	require.Equal(t, 0, pool.count(a.Key()))
@@ -1261,7 +1300,7 @@ func TestNextStateClosedPool(t *testing.T) {
 	pool := conn.NewPool(ctx, config.New())
 	require.NoError(t, pool.RemoveRef(ctx))
 
-	newQuarantine, newActive := nextState(ctx, pool, nil, nil, []endpoint.Endpoint{
+	newQuarantine, newActive := nextState(ctx, pool, nil, []endpoint.Endpoint{
 		endpoint.New("node:2135", endpoint.WithID(1)),
 	})
 


### PR DESCRIPTION
## Summary

- separate construction/publication of the next balancer connection state from retirement of the previous quarantine;
- keep the state ownership transition serialized by `closeMu`;
- call `conn.Pool.Put` only after `closeMu` is released.

## Why

`conn.Pool.Put` may decrement the last reference and synchronously call `Conn.Close`. Closing a gRPC connection can block or invoke trace/user callbacks. Running it while `applyDiscoveredEndpoints` holds `closeMu` can delay or deadlock concurrent `Balancer.Close` and discovery work.

This was identified while reviewing #2269: https://github.com/ydb-platform/ydb-go-sdk/pull/2269#pullrequestreview-4905290481. It is a pre-existing issue on `master`, so the fix is intentionally isolated from the balancer strategy refactoring.

## Ownership model

The quarantine continues to delay release by one discovery generation:

```text
old quarantine -> retired after the state swap -> Pool.Put outside closeMu
old active     -> new quarantine
fresh Pool.Get -> new active
```

`closeMu` still serializes publication against `Balancer.Close`. Each retired reference is released exactly once after ownership has moved to the new immutable state.

## Safety

- no public API or endpoint-selection behavior changes;
- the existing quarantine/refcount tests continue to verify every `Get`/`Put` generation;
- a new regression test closes a real pooled connection and asserts that `closeMu` is available inside the synchronous `OnConnClose` callback.

## Validation

- `golangci-lint run ./...`
- `go test -race ./...`
- changed state-transition functions are covered at 100%.
