### PR TITLE
feat(balancer): add primary pile preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Added `balancers.PreferPrimaryPile` and `balancers.PreferPrimaryPileWithFallback` endpoint selection policies
+
 ## v3.148.0
 * Refactored balancer configuration into an immutable priority pipeline without changing existing configuration call sites or strict `Prefer*` and `*WithFallback` behavior
 * Prevented temporary errors from banning the only `SingleConn` endpoint; disabling periodic discovery is now rejected for other balancer policies

--- a/balancers/balancers.go
+++ b/balancers/balancers.go
@@ -54,6 +54,28 @@ func PreferNearestDCWithFallBack(p policy.Policy) policy.Policy {
 	})
 }
 
+// PreferPrimaryPile uses only endpoints marked as belonging to the primary pile.
+func PreferPrimaryPile(p policy.Policy) policy.Policy {
+	return preferPrimaryPile(p, false)
+}
+
+// PreferPrimaryPileWithFallback prioritizes endpoints marked as belonging to the primary pile.
+// Other endpoints, including endpoints without pile metadata, are used when all primary endpoints are unavailable.
+func PreferPrimaryPileWithFallback(p policy.Policy) policy.Policy {
+	return preferPrimaryPile(p, true)
+}
+
+func preferPrimaryPile(p policy.Policy, allowFallback bool) policy.Policy {
+	match := func(_ policy.Info, candidate endpoint.Info) bool {
+		return candidate.Metadata().BridgePileState == endpoint.PileStatePrimary
+	}
+	if allowFallback {
+		return policy.PreferWithFallback(p, "PrimaryPile", match)
+	}
+
+	return policy.Prefer(p, "PrimaryPile", match)
+}
+
 func locationsString(locations []string) string {
 	buffer := xstring.Buffer()
 	defer buffer.Free()

--- a/balancers/balancers_test.go
+++ b/balancers/balancers_test.go
@@ -28,6 +28,53 @@ func TestPreferNearestDC(t *testing.T) {
 	require.True(t, p.DetectsNearestDC())
 }
 
+func TestPreferPrimaryPile(t *testing.T) {
+	endpoints := []endpoint.Endpoint{
+		endpoint.New("primary", endpoint.WithMetadata(endpoint.Metadata{
+			BridgePileState: endpoint.PileStatePrimary,
+		})),
+		endpoint.New("synchronized", endpoint.WithMetadata(endpoint.Metadata{
+			BridgePileState: endpoint.PileStateSynchronized,
+		})),
+		endpoint.New("unknown"),
+	}
+
+	strict := PreferPrimaryPile(RandomChoice()).Prioritize(policy.Info{}, endpoints)
+	fallback := PreferPrimaryPileWithFallback(RandomChoice()).Prioritize(policy.Info{}, endpoints)
+
+	require.Equal(t, []policy.EndpointPriority{
+		{Key: endpoints[0].Key()},
+		{Key: endpoints[1].Key(), Excluded: true},
+		{Key: endpoints[2].Key(), Excluded: true},
+	}, strict)
+	require.Equal(t, []policy.EndpointPriority{
+		{Key: endpoints[0].Key()},
+		{Key: endpoints[1].Key(), Priority: 1},
+		{Key: endpoints[2].Key(), Priority: 1},
+	}, fallback)
+}
+
+func TestPreferPrimaryPileComposesWithNearestDC(t *testing.T) {
+	endpoints := []endpoint.Endpoint{
+		endpoint.New("primary-local", endpoint.WithLocation("local"), endpoint.WithMetadata(endpoint.Metadata{
+			BridgePileState: endpoint.PileStatePrimary,
+		})),
+		endpoint.New("primary-remote", endpoint.WithLocation("remote"), endpoint.WithMetadata(endpoint.Metadata{
+			BridgePileState: endpoint.PileStatePrimary,
+		})),
+		endpoint.New("secondary-local", endpoint.WithLocation("local")),
+		endpoint.New("secondary-remote", endpoint.WithLocation("remote")),
+	}
+	p := PreferPrimaryPileWithFallback(PreferNearestDCWithFallBack(RandomChoice()))
+
+	require.Equal(t, []policy.EndpointPriority{
+		{Key: endpoints[0].Key()},
+		{Key: endpoints[1].Key(), Priority: 1},
+		{Key: endpoints[2].Key(), Priority: 2},
+		{Key: endpoints[3].Key(), Priority: 3},
+	}, p.Prioritize(policy.Info{SelfLocation: "local"}, endpoints))
+}
+
 func TestPreferLocations(t *testing.T) {
 	connections := []conn.Conn{
 		&mock.Conn{AddrField: "1", LocationField: "zero", StateField: state.Online},
@@ -106,6 +153,11 @@ func TestStrictAndFallbackPreferencesDiffer(t *testing.T) {
 			name:     "custom",
 			strict:   Prefer(RandomChoice(), filter),
 			fallback: PreferWithFallback(RandomChoice(), filter),
+		},
+		{
+			name:     "primary pile",
+			strict:   PreferPrimaryPile(RandomChoice()),
+			fallback: PreferPrimaryPileWithFallback(RandomChoice()),
 		},
 	}
 

--- a/balancers/config.go
+++ b/balancers/config.go
@@ -20,8 +20,9 @@ const (
 type preferType string
 
 const (
-	preferTypeNearestDC = preferType("nearest_dc")
-	preferTypeLocations = preferType("locations")
+	preferTypeNearestDC   = preferType("nearest_dc")
+	preferTypeLocations   = preferType("locations")
+	preferTypePrimaryPile = preferType("primary_pile")
 
 	// Deprecated
 	// Will be removed after March 2025.
@@ -116,6 +117,12 @@ func CreateFromConfig(s string) (policy.Policy, error) {
 		}
 
 		return PreferLocations(b, c.Locations...), nil
+	case preferTypePrimaryPile:
+		if c.Fallback {
+			return PreferPrimaryPileWithFallback(b), nil
+		}
+
+		return PreferPrimaryPile(b), nil
 	default:
 		return b, nil
 	}

--- a/balancers/config_test.go
+++ b/balancers/config_test.go
@@ -66,6 +66,16 @@ func TestFromConfig(t *testing.T) {
 			expected: "Priority{Preferences=[Locations{AAA,BBB,CCC}(AllowFallback)]}",
 		},
 		{
+			name:     "prefer_primary_pile",
+			config:   `{"type":"random_choice","prefer":"primary_pile"}`,
+			expected: "Priority{Preferences=[PrimaryPile]}",
+		},
+		{
+			name:     "prefer_primary_pile_with_fallback",
+			config:   `{"type":"random_choice","prefer":"primary_pile","fallback":true}`,
+			expected: "Priority{Preferences=[PrimaryPile(AllowFallback)]}",
+		},
+		{
 			name:   "prefer_locations_without_locations",
 			config: `{"type":"random_choice","prefer":"locations"}`,
 			fail:   true,
@@ -155,14 +165,30 @@ func TestFromConfigLogicalCompatibility(t *testing.T) {
 			lowerPriority: []uint32{2},
 		},
 		{
+			name:       "primary pile",
+			serialized: `{"type":"random_choice","prefer":"primary_pile"}`,
+			preferred:  []uint32{1},
+			excluded:   []uint32{2, 3},
+		},
+		{
+			name:          "primary pile with fallback",
+			serialized:    `{"type":"random_choice","prefer":"primary_pile","fallback":true}`,
+			preferred:     []uint32{1},
+			lowerPriority: []uint32{2, 3},
+		},
+		{
 			name:       "unknown preference remains random choice",
 			serialized: `{"type":"random_choice","prefer":"unknown"}`,
 			preferred:  []uint32{1, 2, 3},
 		},
 	}
 	endpoints := []endpoint.Endpoint{
-		endpoint.New("a", endpoint.WithID(1), endpoint.WithLocation("a")),
-		endpoint.New("b", endpoint.WithID(2), endpoint.WithLocation("b")),
+		endpoint.New("a", endpoint.WithID(1), endpoint.WithLocation("a"), endpoint.WithMetadata(endpoint.Metadata{
+			BridgePileState: endpoint.PileStatePrimary,
+		})),
+		endpoint.New("b", endpoint.WithID(2), endpoint.WithLocation("b"), endpoint.WithMetadata(endpoint.Metadata{
+			BridgePileState: endpoint.PileStateSynchronized,
+		})),
 		endpoint.New("c", endpoint.WithID(3), endpoint.WithLocation("c")),
 	}
 

--- a/internal/balancer/balancer_test.go
+++ b/internal/balancer/balancer_test.go
@@ -1956,6 +1956,30 @@ func TestUserBalancerConfigurations(t *testing.T) {
 			},
 			allowed: nodeIDSet(2),
 		},
+		{
+			name: "prefer primary pile",
+			option: config.WithBalancer(userBalancers.PreferPrimaryPile(
+				userBalancers.RandomChoice(),
+			)),
+			connections: []conn.Conn{
+				userBalancerConnWithPileState(1, endpoint.PileStatePrimary, state.Online),
+				userBalancerConnWithPileState(2, endpoint.PileStateSynchronized, state.Online),
+				userBalancerConnWithPileState(3, endpoint.PileStateUnknown, state.Online),
+			},
+			allowed: nodeIDSet(1),
+		},
+		{
+			name: "prefer primary pile with fallback",
+			option: config.WithBalancer(userBalancers.PreferPrimaryPileWithFallback(
+				userBalancers.RandomChoice(),
+			)),
+			connections: []conn.Conn{
+				userBalancerConnWithPileState(1, endpoint.PileStatePrimary, state.Banned),
+				userBalancerConnWithPileState(2, endpoint.PileStateSynchronized, state.Online),
+				userBalancerConnWithPileState(3, endpoint.PileStateUnknown, state.Online),
+			},
+			allowed: nodeIDSet(2, 3),
+		},
 	}
 
 	for _, test := range tests {
@@ -1998,6 +2022,21 @@ func userBalancerConn(nodeID uint32, location string, connectionState state.Stat
 		LocationField: location,
 		NodeIDField:   nodeID,
 		StateField:    connectionState,
+	}
+}
+
+func userBalancerConnWithPileState(
+	nodeID uint32,
+	pileState endpoint.PileState,
+	connectionState state.State,
+) conn.Conn {
+	return &mock.Conn{
+		AddrField:   fmt.Sprintf("node-%d", nodeID),
+		NodeIDField: nodeID,
+		StateField:  connectionState,
+		MetadataField: endpoint.Metadata{
+			BridgePileState: pileState,
+		},
 	}
 }
 


### PR DESCRIPTION
## Что добавлено

PR добавляет две политики выбора endpoints по состоянию bridge pile из Discovery:

```go
ydb.WithBalancer(
    balancers.PreferPrimaryPile(
        balancers.RandomChoice(),
    ),
)
```

и вариант с fallback:

```go
ydb.WithBalancer(
    balancers.PreferPrimaryPileWithFallback(
        balancers.RandomChoice(),
    ),
)
```

Настройки также поддерживаются в `balancers.FromConfig`:

```json
{"type":"random_choice","prefer":"primary_pile","fallback":true}
```

## Семантика

Discovery уже обогащает свежие endpoints значением `Endpoint.Metadata().BridgePileState`, построенным из `EndpointInfo.BridgePileName` и `ListEndpointsResult.PileStates`.

- `PreferPrimaryPile` оставляет только endpoints со state `PRIMARY`. Все остальные состояния, включая `Unknown` при отсутствии pile metadata, исключаются.
- `PreferPrimaryPileWithFallback` назначает endpoints со state `PRIMARY` priority `0`, а все остальные endpoints — следующий priority bucket. Если кластер не возвращает pile metadata, все endpoints остаются доступны в fallback bucket.
- Existing `WithNodeID` contract не меняется и по-прежнему обходит policy selection.

Политики являются обычными stages существующего immutable priority pipeline и композируются с `PreferNearestDC*`, `PreferLocations*` и custom `Prefer*`. Например:

```go
balancers.PreferPrimaryPileWithFallback(
    balancers.PreferNearestDCWithFallBack(
        balancers.RandomChoice(),
    ),
)
```

даёт buckets в следующем порядке:

```text
primary + local      priority 0
primary + remote     priority 1
non-primary + local  priority 2
non-primary + remote priority 3
```

## Почему реализация небольшая

PR не добавляет новые runtime abstractions и не меняет discovery, endpoint metadata, `internal/balancer`, `endpointElector` или `conn.Pool`. Оба публичных конструктора являются тонкими обёртками над существующими `policy.Prefer` и `policy.PreferWithFallback` с predicate:

```go
candidate.Metadata().BridgePileState == endpoint.PileStatePrimary
```

Таким образом, используются уже существующие правила strict exclusion, fallback priority, pessimization и случайного выбора внутри лучшего bucket.

## Совместимость

- Изменение только добавляет публичные функции и новое поддерживаемое значение `primary_pile` для `balancers.FromConfig`.
- Существующие сигнатуры, конфигурационные строки и поведение политик не меняются.
- На обычных кластерах без pile metadata безопасным вариантом является `PreferPrimaryPileWithFallback`: он сохраняет доступность всех endpoints.

## Проверки

- `golangci-lint run ./...` — 0 issues.
- `go test -race ./...` — passed.
- Пакет `balancers` — 100% statement coverage.
- Тестами закреплены strict/fallback semantics, `Unknown`, композиция с nearest DC, `FromConfig` и фактический выбор соединения runtime-балансером.
