### PR TITLE
fix(coordination): prevent spurious reconnect after session start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed coordination sessions spuriously reconnecting immediately after creation, which could cause non-idempotent operations to fail with `operation status is unknown`
+
 ## v3.149.0
 * Added `balancers.PreferPrimaryPile` and `balancers.PreferPrimaryPileWithFallback` endpoint selection policies
 

--- a/internal/coordination/session.go
+++ b/internal/coordination/session.go
@@ -442,8 +442,10 @@ func (s *session) receiveLoop( //nolint:funlen
 
 			return
 		case *Ydb_Coordination.SessionResponse_SessionStarted_:
-			sessionStarted <- message.GetSessionStarted()
+			// mainLoop may enter the keep-alive loop as soon as the notification is received.
+			// Publish it only after the timestamp used by that loop has been initialized.
 			s.updateLastGoodResponseTime()
+			sessionStarted <- message.GetSessionStarted()
 		case *Ydb_Coordination.SessionResponse_SessionStopped_:
 			sessionStopped <- message.GetSessionStopped()
 			s.cancel()

--- a/internal/coordination/session_test.go
+++ b/internal/coordination/session_test.go
@@ -14,9 +14,14 @@ import (
 )
 
 func TestReceiveLoopUpdatesLastGoodResponseTimeBeforeSessionStarted(t *testing.T) {
+	const testTimeout = 5 * time.Second
+
 	ctrl := gomock.NewController(t)
 	client := NewMockCoordinationService_SessionClient(ctrl)
+	testCtx, cancelTest := context.WithTimeout(context.Background(), testTimeout)
+	defer cancelTest()
 	streamCtx, cancelStream := context.WithCancel(context.Background())
+	defer cancelStream()
 	startedResponse := &Ydb_Coordination.SessionResponse_SessionStarted{
 		SessionId: 42,
 	}
@@ -46,22 +51,54 @@ func TestReceiveLoopUpdatesLastGoodResponseTimeBeforeSessionStarted(t *testing.T
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	s.mutex.Lock()
-	go s.receiveLoop(&wg, client, cancelStream, sessionStarted, sessionStopped)
+	receiveLoopDone := make(chan struct{})
+	go func() {
+		defer close(receiveLoopDone)
+		s.receiveLoop(&wg, client, cancelStream, sessionStarted, sessionStopped)
+	}()
 
-	<-recvReturned
+	select {
+	case <-recvReturned:
+	case <-receiveLoopDone:
+		s.mutex.Unlock()
+		t.Fatal("receive loop exited before the first Recv returned")
+	case <-testCtx.Done():
+		s.mutex.Unlock()
+		t.Fatal("timed out waiting for the first Recv")
+	}
 	var start *Ydb_Coordination.SessionResponse_SessionStarted
+	orderCheckTimer := time.NewTimer(100 * time.Millisecond) //nolint:mnd
 	select {
 	case start = <-sessionStarted:
-	case <-time.After(100 * time.Millisecond): //nolint:mnd
+	case <-orderCheckTimer.C:
+	case <-receiveLoopDone:
+		orderCheckTimer.Stop()
+		s.mutex.Unlock()
+		t.Fatal("receive loop exited before publishing session started")
+	case <-testCtx.Done():
+		orderCheckTimer.Stop()
+		s.mutex.Unlock()
+		t.Fatal("timed out checking session started publication order")
 	}
+	orderCheckTimer.Stop()
 	publishedBeforeTimestamp := start != nil
 	s.mutex.Unlock()
 	if start == nil {
-		start = <-sessionStarted
+		select {
+		case start = <-sessionStarted:
+		case <-receiveLoopDone:
+			t.Fatal("receive loop exited before publishing session started")
+		case <-testCtx.Done():
+			t.Fatal("timed out waiting for session started")
+		}
 	}
 
 	cancelStream()
-	wg.Wait()
+	select {
+	case <-receiveLoopDone:
+	case <-testCtx.Done():
+		t.Fatal("timed out waiting for receive loop to stop")
+	}
 	require.False(t, publishedBeforeTimestamp, "session started was published before the keep-alive timestamp update")
 	require.Same(t, startedResponse, start)
 	require.False(t, s.getLastGoodResponseTime().IsZero())

--- a/internal/coordination/session_test.go
+++ b/internal/coordination/session_test.go
@@ -1,10 +1,71 @@
 package coordination
 
 import (
+	"context"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Coordination"
+	"go.uber.org/mock/gomock"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
 )
+
+func TestReceiveLoopUpdatesLastGoodResponseTimeBeforeSessionStarted(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	client := NewMockCoordinationService_SessionClient(ctrl)
+	streamCtx, cancelStream := context.WithCancel(context.Background())
+	startedResponse := &Ydb_Coordination.SessionResponse_SessionStarted{
+		SessionId: 42,
+	}
+	recvReturned := make(chan struct{})
+
+	firstRecv := client.EXPECT().Recv().DoAndReturn(func() (*Ydb_Coordination.SessionResponse, error) {
+		close(recvReturned)
+
+		return &Ydb_Coordination.SessionResponse{
+			Response: &Ydb_Coordination.SessionResponse_SessionStarted_{
+				SessionStarted: startedResponse,
+			},
+		}, nil
+	})
+	secondRecv := client.EXPECT().Recv().DoAndReturn(func() (*Ydb_Coordination.SessionResponse, error) {
+		<-streamCtx.Done()
+
+		return nil, streamCtx.Err()
+	})
+	gomock.InOrder(firstRecv.Call, secondRecv.Call)
+
+	s := &session{
+		trace: &trace.Coordination{},
+	}
+	sessionStarted := make(chan *Ydb_Coordination.SessionResponse_SessionStarted, 1)
+	sessionStopped := make(chan *Ydb_Coordination.SessionResponse_SessionStopped, 1)
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	s.mutex.Lock()
+	go s.receiveLoop(&wg, client, cancelStream, sessionStarted, sessionStopped)
+
+	<-recvReturned
+	var start *Ydb_Coordination.SessionResponse_SessionStarted
+	select {
+	case start = <-sessionStarted:
+	case <-time.After(100 * time.Millisecond): //nolint:mnd
+	}
+	publishedBeforeTimestamp := start != nil
+	s.mutex.Unlock()
+	if start == nil {
+		start = <-sessionStarted
+	}
+
+	cancelStream()
+	wg.Wait()
+	require.False(t, publishedBeforeTimestamp, "session started was published before the keep-alive timestamp update")
+	require.Same(t, startedResponse, start)
+	require.False(t, s.getLastGoodResponseTime().IsZero())
+}
 
 func TestNewProtectionKey(t *testing.T) {
 	key1 := newProtectionKey()


### PR DESCRIPTION
## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

`receiveLoop` publishes the `session_started` response before updating `lastGoodResponseTime`. `mainLoop` can receive that notification first, enter the keep-alive loop with the zero `time.Time`, and immediately cancel a healthy stream. A concurrent non-idempotent operation such as `CreateSemaphore` then fails with `operation status is unknown`.

This is the failure shown in recent Actions logs: a keep-alive timeout with `lastGoodResponseTime` equal to `0001-01-01`, immediately after session creation and before the explicit test `Reconnect()`.

Fixes #2112.

## What is the new behavior?

- Update `lastGoodResponseTime` before publishing `session_started`, so the channel handoff guarantees `mainLoop` observes initialized keep-alive state.
- Add a deterministic regression test that prevents the timestamp update and verifies the session-start notification cannot overtake it. The test fails with the previous ordering.
- Document the user-visible fix in `CHANGELOG.md`.

Unlike #2113, this does not increase grace periods or reduce reconnect delays; it removes the underlying production race.

## Other information

Validation:

- `golangci-lint run ./...`
- `go test -race ./...`
- Regression test repeated 10 times under `-race`
