### PR TITLE
fix(balancer): allow disabling periodic discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Restored support for disabling background endpoint discovery with `WithDiscoveryInterval(-1)` for all balancer policies
+
 ## v3.150.1
 * Fixed coordination sessions spuriously reconnecting immediately after creation, which could cause non-idempotent operations to fail with `operation status is unknown`
 

--- a/internal/balancer/balancer.go
+++ b/internal/balancer/balancer.go
@@ -36,12 +36,7 @@ import (
 
 var ErrNoEndpoints = xerrors.Wrap(xerrors.Retryable(fmt.Errorf("no endpoints"), xerrors.WithBackoff(backoff.TypeSlow)))
 
-var (
-	errBalancerClosed            = xerrors.Wrap(fmt.Errorf("internal ydb sdk balancer closed"))
-	errPeriodicDiscoveryDisabled = xerrors.Wrap(fmt.Errorf(
-		"periodic discovery must be enabled for non-single-connection balancer",
-	))
-)
+var errBalancerClosed = xerrors.Wrap(fmt.Errorf("internal ydb sdk balancer closed"))
 
 // streamWrapper wraps grpc.ClientStream and triggers pool.Ban on RecvMsg/SendMsg/CloseSend
 // errors that qualify as bad connection (same logic as wrapCall defer).
@@ -444,9 +439,6 @@ func New(ctx context.Context, driverConfig *config.Config, pool *conn.Pool, opts
 	}
 
 	b.discover = makeDiscoveryFunc(b.driverConfig, b.discoveryConfig)
-	if !policy.SingleConnection() && b.discoveryConfig.Interval() <= 0 {
-		return nil, xerrors.WithStackTrace(errPeriodicDiscoveryDisabled)
-	}
 
 	if policy.SingleConnection() {
 		b.applyDiscoveredEndpoints(ctx, []endpoint.Endpoint{
@@ -456,11 +448,13 @@ func New(ctx context.Context, driverConfig *config.Config, pool *conn.Pool, opts
 		if err := b.clusterDiscovery(ctx); err != nil {
 			return nil, xerrors.WithStackTrace(err)
 		}
-		b.discoveryRepeater = repeater.New(xcontext.ValueOnly(ctx),
-			b.discoveryConfig.Interval(), b.clusterDiscoveryAttemptWithDial,
-			repeater.WithName("discovery"),
-			repeater.WithTrace(b.driverConfig.Trace()),
-		)
+		if interval := b.discoveryConfig.Interval(); interval > 0 {
+			b.discoveryRepeater = repeater.New(xcontext.ValueOnly(ctx),
+				interval, b.clusterDiscoveryAttemptWithDial,
+				repeater.WithName("discovery"),
+				repeater.WithTrace(b.driverConfig.Trace()),
+			)
+		}
 	}
 
 	return b, nil

--- a/internal/balancer/balancer_test.go
+++ b/internal/balancer/balancer_test.go
@@ -836,16 +836,23 @@ func TestNew(t *testing.T) {
 		require.Nil(t, b.discoveryRepeater)
 		require.NoError(t, b.Close(ctx))
 	})
-	t.Run("non-single policy requires periodic discovery", func(t *testing.T) {
+	t.Run("non-single policy supports disabled periodic discovery", func(t *testing.T) {
 		ctx := t.Context()
-		cfg := config.New()
+		srv := startDynamicDiscoveryServer(t, []uint32{1})
+		cfg := config.New(
+			config.WithEndpoint(srv.endpoint()),
+			config.WithDatabase("/local"),
+			config.WithGrpcOptions(grpc.WithTransportCredentials(insecure.NewCredentials())),
+		)
 		pool := conn.NewPool(ctx, cfg)
 		defer func() { require.NoError(t, pool.RemoveRef(ctx)) }()
 
 		b, err := New(ctx, cfg, pool, discoveryConfig.WithInterval(-time.Nanosecond))
 
-		require.ErrorIs(t, err, errPeriodicDiscoveryDisabled)
-		require.Nil(t, b)
+		require.NoError(t, err)
+		require.Len(t, b.connections().All(), 1)
+		require.Nil(t, b.discoveryRepeater)
+		require.NoError(t, b.Close(ctx))
 	})
 }
 

--- a/internal/discovery/config/config.go
+++ b/internal/discovery/config/config.go
@@ -145,9 +145,7 @@ func WithTrace(t trace.Discovery) Option {
 //
 // If Interval is zero then the DefaultInterval is used.
 //
-// A negative interval disables background discovery. This is supported only by
-// a single-connection balancer; other policies require periodic discovery and
-// make driver initialization fail.
+// If Interval is negative, background discovery is disabled.
 func WithInterval(interval time.Duration) Option {
 	return func(c *Config) {
 		switch {

--- a/options.go
+++ b/options.go
@@ -407,8 +407,7 @@ func MergeOptions(opts ...Option) Option {
 }
 
 // WithDiscoveryInterval sets interval between cluster discovery calls.
-// A negative interval is supported only with balancers.SingleConn; other policies
-// require periodic discovery and make driver initialization return an error.
+// A negative interval disables background cluster discovery.
 func WithDiscoveryInterval(discoveryInterval time.Duration) Option {
 	return func(ctx context.Context, d *Driver) error {
 		d.discoveryOptions = append(d.discoveryOptions, discoveryConfig.WithInterval(discoveryInterval))


### PR DESCRIPTION
## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

After #2269, driver initialization fails for non-single-connection balancers when clients pass `WithDiscoveryInterval(-1)`. Some clients rely on this option to disable background endpoint discovery.

Issue Number: N/A

## What is the new behavior?

- A negative discovery interval is supported by all balancer policies again.
- Initial endpoint discovery still runs, while the background discovery repeater is not started.
- Public documentation, changelog, and a regression test reflect the restored behavior.

## Other information

Validated with:

- `go test -race ./...`
- `golangci-lint run ./...`
