### PR TITLE
fix(query): close result stream when initial read fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed query transaction and session result-set streams not being closed when reading the initial result set failed
+
 ## v3.150.1
 * Fixed coordination sessions spuriously reconnecting immediately after creation, which could cause non-idempotent operations to fail with `operation status is unknown`
 

--- a/internal/query/execute_query.go
+++ b/internal/query/execute_query.go
@@ -181,6 +181,8 @@ func readAll(ctx context.Context, r *streamResult) error {
 func readResultSet(ctx context.Context, r *streamResult) (_ *resultSetWithClose, finalErr error) {
 	rs, err := r.nextResultSet(ctx)
 	if err != nil {
+		_ = r.Close(ctx)
+
 		return nil, xerrors.WithStackTrace(err)
 	}
 	rs.mustBeLastResultSet = true

--- a/internal/query/execute_query_test.go
+++ b/internal/query/execute_query_test.go
@@ -702,6 +702,28 @@ func TestExecute(t *testing.T) {
 	})
 }
 
+func TestReadResultSetClosesStreamOnError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	stream := NewMockQueryService_ExecuteQueryClient(ctrl)
+	executeCtx, opts := executeQueryStreamContextWithOnClose(stream)
+	stream.EXPECT().Recv().Return(&Ydb_Query.ExecuteQueryResponsePart{
+		Status:         Ydb.StatusIds_SUCCESS,
+		ResultSetIndex: 0,
+		ResultSet:      &Ydb.ResultSet{},
+	}, nil)
+
+	r, err := newResult(t.Context(), stream, opts...)
+	require.NoError(t, err)
+
+	readCtx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	rs, err := readResultSet(readCtx, r)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Nil(t, rs)
+	require.ErrorIs(t, executeCtx.Err(), context.Canceled)
+}
+
 // TestNewResult_DecoupledExecuteCtx verifies the semantic contract that
 // newResult succeeds when passed executeCtx (derived from a cancelled parent
 // via xcontext.ValueOnly), which is exactly what execute() does after the fix


### PR DESCRIPTION
Related ticket: https://nda.ya.ru/t/c5bh8GgX7njYQG

## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

`Transaction.QueryResultSet` and `Session.QueryResultSet` can return `nil, error` after `execute` has already created a `streamResult`. Because the error path does not close that internal result and does not return a `ClosableResultSet`, the caller has no way to release the gRPC stream. With response-part prefetch enabled, the background reader can remain alive as well.

Fixes #2277

## What is the new behavior?

- `readResultSet` closes the internal stream when initial result-set construction fails.
- Successful calls still transfer ownership to `resultSetWithClose`; streamed rows are not eagerly drained.
- A regression test verifies that a canceled initial read closes the execute-stream context.
- The user-visible fix is recorded in `CHANGELOG.md`.

## Other information

Validation:

- `go test -race ./internal/query`
- `go test -race ./...`
- `golangci-lint run ./...`