### PR TITLE
test: wait for topic in TestSchemeList

### DIFF
--- a/tests/integration/topic_client_test.go
+++ b/tests/integration/topic_client_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
@@ -666,18 +667,20 @@ func TestSchemeList(t *testing.T) {
 	db := connect(t)
 
 	topicPath := createTopic(ctx, t, db)
-	list, err := db.Scheme().ListDirectory(ctx, db.Name())
-	require.NoError(t, err)
-
 	topicName := path.Base(topicPath)
 
-	hasTopic := false
-	for _, e := range list.Children {
-		if e.IsTopic() && topicName == e.Name {
-			hasTopic = true
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		list, err := db.Scheme().ListDirectory(ctx, db.Name())
+		require.NoError(collect, err)
+
+		hasTopic := false
+		for _, e := range list.Children {
+			if e.IsTopic() && topicName == e.Name {
+				hasTopic = true
+			}
 		}
-	}
-	require.True(t, hasTopic)
+		require.True(collect, hasTopic)
+	}, 10*time.Second, 100*time.Millisecond)
 }
 
 func TestReaderWithoutConsumer(t *testing.T) {


### PR DESCRIPTION
## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

`TestSchemeList` assumes a topic is immediately visible through `Scheme().ListDirectory` after `Topic().Create` returns. On nightly YDB this can race with scheme visibility and fail even though both calls succeed.

Fixes ydb-platform/ydb#50971.

## What is the new behavior?

- Poll `ListDirectory` with `EventuallyWithT` for up to 10 seconds.
- Retry every 100 ms while preserving assertion diagnostics for list errors and a missing topic.

## Other information

Validation:

- `go test -race -tags integration ./tests/integration -run '^TestSchemeList$' -count=20`
- `go test -race ./...`
- repository formatter and `git diff --check`