### PR TITLE
fix(query): handle session creation timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed Query Service session handling: `database/sql` retries internal session creation timeouts while the caller context remains active, and the native Query session pool reuses a session that finished creating after caller cancellation
+
 * Added the `ydb.query.session.closed` counter with query session pool name and close reason attributes:
   `pool_idle_timeout`, `pool_graceful_shutdown`, `client_timeout`, `client_cancelled`, `attach_closed`,
   `transport_error`, `node_shutdown`, `session_shutdown`, `bad_session`, and `session_busy`; bumped the metrics

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -422,6 +422,14 @@ func (p *Pool[PT, T]) try(ctx context.Context,
 		return xerrors.WithStackTrace(err)
 	}
 
+	// Keep a successfully created item in the pool when the caller gives up, so
+	// the next request can reuse it.
+	if err := ctx.Err(); err != nil {
+		_ = p.putItem(ctx, info, batchChanges)
+
+		return xerrors.WithStackTrace(err)
+	}
+
 	batchChanges.InUse++
 
 	defer func() {

--- a/internal/query/client.go
+++ b/internal/query/client.go
@@ -772,22 +772,24 @@ func (c *Client) DoTx(ctx context.Context, op query.TxOperation, opts ...options
 
 func CreateSession(ctx context.Context, client Ydb_Query_V1.QueryServiceClient, cfg *config.Config) (*Session, error) {
 	s, err := retry.RetryWithResult(ctx, func(ctx context.Context) (*Session, error) {
-		var (
-			createCtx    context.Context
-			cancelCreate context.CancelFunc
-		)
+		createCtx := ctx
 		if d := cfg.SessionCreateTimeout(); d > 0 {
+			var cancelCreate context.CancelFunc
 			createCtx, cancelCreate = xcontext.WithTimeout(ctx, d)
-		} else {
-			createCtx, cancelCreate = xcontext.WithCancel(ctx)
+			defer cancelCreate()
 		}
-		defer cancelCreate()
 
 		s, err := createSession(createCtx, client,
 			WithDeleteTimeout(cfg.SessionDeleteTimeout()),
 			WithTrace(cfg.Trace()),
 		)
 		if err != nil {
+			// Do not fail the request on an internal session creation timeout while
+			// the caller is still willing to wait.
+			if xerrors.IsContextError(err) && ctx.Err() == nil {
+				err = xerrors.Retryable(err)
+			}
+
 			return nil, xerrors.WithStackTrace(err)
 		}
 

--- a/internal/query/client_test.go
+++ b/internal/query/client_test.go
@@ -7,6 +7,7 @@ import (
 	"math/rand"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/ydb-platform/ydb-go-genproto/Ydb_Query_V1"
@@ -29,6 +30,34 @@ import (
 	"github.com/ydb-platform/ydb-go-sdk/v3/query"
 	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
 )
+
+func TestCreateSessionDoesNotRetryNonRetryableErrorAfterAttemptContextDeadline(t *testing.T) {
+	const createSessionTimeout = 10 * time.Millisecond
+
+	nonRetryableErr := xerrors.Operation(xerrors.WithStatusCode(Ydb.StatusIds_BAD_REQUEST))
+	ctrl := gomock.NewController(t)
+	client := NewMockQueryServiceClient(ctrl)
+	client.EXPECT().CreateSession(gomock.Any(), gomock.Any()).Return(nil, nonRetryableErr)
+
+	cfg := config.New(
+		config.WithSessionCreateTimeout(createSessionTimeout),
+		config.WithTrace(&trace.Query{
+			OnSessionCreate: func(info trace.QuerySessionCreateStartInfo) func(trace.QuerySessionCreateDoneInfo) {
+				createCtx := *info.Context
+
+				return func(info trace.QuerySessionCreateDoneInfo) {
+					if info.Error != nil {
+						<-createCtx.Done()
+					}
+				}
+			},
+		}),
+	)
+
+	_, err := CreateSession(t.Context(), client, cfg)
+
+	require.True(t, xerrors.IsOperationError(err, Ydb.StatusIds_BAD_REQUEST))
+}
 
 func TestClient(t *testing.T) {
 	ctx := t.Context()

--- a/tests/integration/database_sql_query_session_create_timeout_test.go
+++ b/tests/integration/database_sql_query_session_create_timeout_test.go
@@ -1,0 +1,120 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/ydb-platform/ydb-go-genproto/Ydb_Query_V1"
+	"google.golang.org/grpc"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3"
+	"github.com/ydb-platform/ydb-go-sdk/v3/balancers"
+	"github.com/ydb-platform/ydb-go-sdk/v3/config"
+	"github.com/ydb-platform/ydb-go-sdk/v3/query"
+)
+
+func TestDatabaseSQLQueryServiceRetriesCreateSessionAttemptTimeout(t *testing.T) {
+	const createSessionTimeout = 100 * time.Millisecond
+
+	var createSessionCalls atomic.Int32
+	interceptor := func(
+		ctx context.Context,
+		method string,
+		req, reply any,
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
+		if method != Ydb_Query_V1.QueryService_CreateSession_FullMethodName {
+			return invoker(ctx, method, req, reply, cc, opts...)
+		}
+
+		if createSessionCalls.Add(1) == 1 {
+			<-ctx.Done()
+
+			return ctx.Err()
+		}
+
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+
+	scope := newScope(t)
+	scope.Driver(
+		// Keep the only local endpoint usable after the simulated attempt deadline.
+		ydb.WithBalancer(balancers.SingleConn()),
+		ydb.WithSessionPoolCreateSessionTimeout(createSessionTimeout),
+		ydb.With(config.WithGrpcOptions(
+			grpc.WithChainUnaryInterceptor(interceptor),
+		)),
+	)
+	db := scope.SQLDriver()
+
+	connectCtx, cancel := context.WithTimeout(scope.Ctx, 5*time.Second)
+	defer cancel()
+
+	err := db.PingContext(connectCtx)
+	connectCtxErr := connectCtx.Err()
+
+	require.NoError(t, connectCtxErr, "the caller context must remain active after the attempt timeout")
+	require.NoError(t, err, "the internal session creation timeout must be retried")
+}
+
+func TestQuerySessionPoolKeepsCreatingSessionAfterCallerContextCancellation(t *testing.T) {
+	scope := newScope(t)
+	requestCtx, cancel := context.WithCancel(scope.Ctx)
+	defer cancel()
+
+	var createSessionCalls atomic.Int32
+	createSessionStarted := make(chan struct{})
+	interceptor := func(
+		ctx context.Context,
+		method string,
+		req, reply any,
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
+		if method != Ydb_Query_V1.QueryService_CreateSession_FullMethodName {
+			return invoker(ctx, method, req, reply, cc, opts...)
+		}
+
+		if createSessionCalls.Add(1) == 1 {
+			close(createSessionStarted)
+			<-requestCtx.Done()
+		}
+
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+
+	driver := scope.Driver(
+		ydb.WithBalancer(balancers.SingleConn()),
+		ydb.WithSessionPoolCreateSessionTimeout(5*time.Second),
+		ydb.With(config.WithGrpcOptions(
+			grpc.WithChainUnaryInterceptor(interceptor),
+		)),
+	)
+
+	firstRequestDone := make(chan error, 1)
+	go func() {
+		firstRequestDone <- driver.Query().Do(requestCtx, func(ctx context.Context, _ query.Session) error {
+			return ctx.Err()
+		})
+	}()
+
+	<-createSessionStarted
+	cancel()
+
+	require.ErrorIs(t, <-firstRequestDone, context.Canceled)
+	require.NoError(t, driver.Query().Do(scope.Ctx, func(context.Context, query.Session) error {
+		return nil
+	}))
+	require.EqualValues(t, 1, createSessionCalls.Load(),
+		"the session created for the canceled request must be reused",
+	)
+}


### PR DESCRIPTION
## Pull request type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

The `database/sql` Query Service connector returns an internal per-attempt session creation deadline as a non-retryable error even while the caller context is still active. The native Query session pool can also discard a session that finishes creating after the caller cancels its request, forcing the next request to create another session.

Issue Number: N/A

## What is the new behavior?

- Context errors caused by the internal Query session creation timeout are retried while the caller context remains active.
- Non-retryable server errors remain non-retryable even if the per-attempt context expires while the error is being processed.
- A native Query session that finishes creating after caller cancellation is returned to the pool for reuse by the next request.
- Unit and real-YDB integration tests cover session creation timeouts, error classification, and session reuse.

## Other information

Checks performed:

- `golangci-lint run ./...`
- `go test -race ./...`
- `go test -race -tags integration ./tests/integration -run '^(TestDatabaseSQLQueryServiceRetriesCreateSessionAttemptTimeout|TestQuerySessionPoolKeepsCreatingSessionAfterCallerContextCancellation)$' -count=1 -v -timeout=30s`
