### PR TITLE
fix(topic): reconnect listener streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed topic listener reconnects to wait for active partition callbacks before replacing a stream and to preserve the original shutdown reason across stream cancellation
+
 ## v3.151.1
 * Fixed `database/sql` Query Service requests failing on session creation attempt timeouts while the caller context remained active
 

--- a/internal/topic/topiclistenerinternal/listener_close_lifecycle_test.go
+++ b/internal/topic/topiclistenerinternal/listener_close_lifecycle_test.go
@@ -1,0 +1,391 @@
+package topiclistenerinternal
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/background"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawtopic/rawtopiccommon"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawtopic/rawtopicreader"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawydb"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/topic/topicreadercommon"
+	"github.com/ydb-platform/ydb-go-sdk/v3/pkg/xtest"
+	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
+)
+
+func TestTopicListenerReconnectorCloseWaitsForBlockedReadCallback(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	listener, client, stream, handler, release := newBlockedTopicListenerReconnector(t)
+	require.NoError(t, listener.WaitInit(ctx))
+	waitReconnectorCall(ctx, t, client, 0)
+	stream.messages <- testStartPartitionSessionMessage()
+	stream.messages <- testReadMessage()
+	waitForBlockedReadCallback(t, handler)
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- listener.Close(context.Background(), ErrUserCloseTopic)
+	}()
+
+	select {
+	case err := <-closeDone:
+		t.Fatalf("Close returned before the read callback was released: %v", err)
+	case <-time.After(1100 * time.Millisecond):
+	}
+	select {
+	case <-handler.readDone:
+		t.Fatal("read callback finished before its release")
+	default:
+	}
+
+	release()
+	select {
+	case <-handler.readDone:
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for read callback to finish")
+	}
+	select {
+	case err := <-closeDone:
+		require.NoError(t, err)
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for Close")
+	}
+	require.NoError(t, listener.WaitStop(ctx))
+}
+
+func TestStreamListenerCloseWaitsForCleanupAfterDeadline(t *testing.T) {
+	listener, handler, release := newBlockedStreamListener(t)
+	waitForBlockedReadCallback(t, handler)
+
+	closeCtx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- listener.Close(closeCtx, ErrUserCloseTopic)
+	}()
+	select {
+	case err := <-closeDone:
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for Close deadline")
+	}
+	cancel()
+	select {
+	case <-handler.readDone:
+		t.Fatal("read callback finished before its release")
+	default:
+	}
+
+	release()
+	select {
+	case <-handler.readDone:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for read callback to finish")
+	}
+	require.NoError(t, listener.Close(context.Background(), ErrUserCloseTopic))
+}
+
+func TestStreamListenerCloseReportsAlreadyClosedWorker(t *testing.T) {
+	listener, worker := newStoppedWorkerStreamListener(t)
+	require.NoError(t, worker.Close(context.Background(), ErrUserCloseTopic))
+
+	closeErr := listener.Close(context.Background(), ErrUserCloseTopic)
+	require.ErrorIs(t, closeErr, background.ErrAlreadyClosed)
+	require.Equal(t, closeErr, listener.Close(context.Background(), ErrUserCloseTopic))
+}
+
+func TestStreamListenerCloseJoinsWorkerRemovedDuringShutdown(t *testing.T) {
+	listener, handler, release := newBlockedStreamListener(t)
+	waitForBlockedReadCallback(t, handler)
+
+	var worker *PartitionWorker
+	listener.m.WithLock(func() {
+		for _, candidate := range listener.workers {
+			worker = candidate
+		}
+	})
+	require.NotNil(t, worker)
+
+	callbackReturn := make(chan struct{})
+	var callbackReturnOnce sync.Once
+	releaseCallback := func() {
+		callbackReturnOnce.Do(func() { close(callbackReturn) })
+	}
+	t.Cleanup(releaseCallback)
+
+	removed := make(chan struct{})
+	worker.onStopped = func(id rawtopicreader.PartitionSessionID, reason error) {
+		listener.onWorkerStopped(worker, id, reason)
+		close(removed)
+		<-callbackReturn
+	}
+	listener.background.Start("wait until canceled worker is removed", func(ctx context.Context) {
+		<-ctx.Done()
+		release()
+		<-removed
+	})
+
+	closeDone := make(chan error, 1)
+	go func() {
+		closeDone <- listener.Close(context.Background(), ErrUserCloseTopic)
+	}()
+
+	select {
+	case <-removed:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for worker removal")
+	}
+	closeCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	closeErr := listener.Close(closeCtx, ErrUserCloseTopic)
+	require.ErrorIs(t, closeErr, context.DeadlineExceeded)
+
+	releaseCallback()
+	select {
+	case err := <-closeDone:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for listener Close")
+	}
+	require.NoError(t, listener.Close(context.Background(), ErrUserCloseTopic))
+	select {
+	case <-worker.bgWorker.StopDone():
+	default:
+		t.Fatal("listener Close returned while the partition worker starter was still alive")
+	}
+}
+
+func TestTopicListenerReconnectorWaitStopWaitsAfterCloseDeadline(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	listener, client, stream, handler, release := newBlockedTopicListenerReconnector(t)
+	require.NoError(t, listener.WaitInit(ctx))
+	waitReconnectorCall(ctx, t, client, 0)
+	stream.messages <- testStartPartitionSessionMessage()
+	stream.messages <- testReadMessage()
+	waitForBlockedReadCallback(t, handler)
+
+	closeCtx, closeCancel := context.WithTimeout(ctx, 50*time.Millisecond)
+	closeErr := listener.Close(closeCtx, ErrUserCloseTopic)
+	closeCancel()
+	require.ErrorIs(t, closeErr, context.DeadlineExceeded)
+
+	waitDone := make(chan error, 1)
+	go func() {
+		waitDone <- listener.WaitStop(context.Background())
+	}()
+	select {
+	case err := <-waitDone:
+		t.Fatalf("WaitStop returned before the read callback was released: %v", err)
+	case <-time.After(1100 * time.Millisecond):
+	}
+	select {
+	case <-handler.readDone:
+		t.Fatal("read callback finished before its release")
+	default:
+	}
+
+	release()
+	select {
+	case <-handler.readDone:
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for read callback to finish")
+	}
+	select {
+	case err := <-waitDone:
+		require.NoError(t, err)
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for WaitStop")
+	}
+}
+
+type listenerLifecycleHandler struct {
+	readStarted chan struct{}
+	readRelease <-chan struct{}
+	readDone    chan struct{}
+	startedOnce sync.Once
+	doneOnce    sync.Once
+}
+
+func (h *listenerLifecycleHandler) OnStartPartitionSessionRequest(
+	_ context.Context,
+	event *PublicEventStartPartitionSession,
+) error {
+	event.Confirm()
+
+	return nil
+}
+
+func (h *listenerLifecycleHandler) OnReadMessages(_ context.Context, _ *PublicReadMessages) error {
+	h.startedOnce.Do(func() { close(h.readStarted) })
+	<-h.readRelease
+	h.doneOnce.Do(func() { close(h.readDone) })
+
+	return nil
+}
+
+func (h *listenerLifecycleHandler) OnStopPartitionSessionRequest(
+	_ context.Context,
+	event *PublicEventStopPartitionSession,
+) error {
+	event.Confirm()
+
+	return nil
+}
+
+func newBlockedTopicListenerReconnector(
+	t *testing.T,
+) (*TopicListenerReconnector, *reconnectorTestClient, *reconnectorTestStream, *listenerLifecycleHandler, func()) {
+	t.Helper()
+
+	stream := newReconnectorTestStream("session-1")
+	client := newReconnectorTestClient(reconnectorTestConnectResult{stream: stream})
+	cfg := NewStreamListenerConfig()
+	cfg.Consumer = "test-consumer"
+	cfg.Selectors = []*topicreadercommon.PublicReadSelector{{Path: "test-topic"}}
+
+	releaseChannel := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() { close(releaseChannel) })
+	}
+	handler := &listenerLifecycleHandler{
+		readStarted: make(chan struct{}),
+		readRelease: releaseChannel,
+		readDone:    make(chan struct{}),
+	}
+	listener := newTopicListenerReconnector(client, &cfg, handler, xtest.FastClock(t))
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = listener.Close(cleanupCtx, ErrUserCloseTopic)
+		_ = listener.WaitStop(cleanupCtx)
+	})
+	t.Cleanup(release)
+
+	return listener, client, stream, handler, release
+}
+
+func newBlockedStreamListener(t *testing.T) (*streamListener, *listenerLifecycleHandler, func()) {
+	t.Helper()
+
+	releaseChannel := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() { close(releaseChannel) })
+	}
+	handler := &listenerLifecycleHandler{
+		readStarted: make(chan struct{}),
+		readRelease: releaseChannel,
+		readDone:    make(chan struct{}),
+	}
+	listener := &streamListener{
+		background: *background.NewWorker(context.Background(), "test stream listener"),
+		handler:    handler,
+		tracer:     &trace.Topic{},
+		listenerID: "test-listener-id",
+		sessionID:  "test-session-id",
+	}
+	listener.initVars(&atomic.Int64{})
+	listener.syncCommitter = topicreadercommon.NewCommitterStopped(
+		listener.tracer,
+		context.Background(),
+		topicreadercommon.CommitModeSync,
+		func(rawtopicreader.ClientMessage) error { return nil },
+	)
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = listener.Close(cleanupCtx, ErrUserCloseTopic)
+	})
+	t.Cleanup(release)
+
+	session := topicreadercommon.NewPartitionSession(
+		context.Background(),
+		"test-topic",
+		0,
+		0,
+		listener.sessionID,
+		rawtopicreader.PartitionSessionID(1),
+		1,
+		rawtopiccommon.NewOffset(0),
+	)
+	worker := listener.createWorkerForPartition(session)
+
+	batch, err := topicreadercommon.NewBatch(session, nil)
+	require.NoError(t, err)
+	worker.AddMessagesBatch(
+		rawtopiccommon.ServerMessageMetadata{Status: rawydb.StatusSuccess},
+		batch,
+	)
+
+	return listener, handler, release
+}
+
+func newStoppedWorkerStreamListener(t *testing.T) (*streamListener, *PartitionWorker) {
+	t.Helper()
+
+	listener := &streamListener{
+		background: *background.NewWorker(context.Background(), "test stream listener"),
+		handler:    &listenerLifecycleHandler{},
+		tracer:     &trace.Topic{},
+		listenerID: "test-listener-id",
+		sessionID:  "test-session-id",
+	}
+	listener.initVars(&atomic.Int64{})
+	listener.syncCommitter = topicreadercommon.NewCommitterStopped(
+		listener.tracer,
+		context.Background(),
+		topicreadercommon.CommitModeSync,
+		func(rawtopicreader.ClientMessage) error { return nil },
+	)
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_ = listener.Close(cleanupCtx, ErrUserCloseTopic)
+	})
+
+	session := topicreadercommon.NewPartitionSession(
+		context.Background(),
+		"test-topic",
+		0,
+		0,
+		listener.sessionID,
+		rawtopicreader.PartitionSessionID(1),
+		1,
+		rawtopiccommon.NewOffset(0),
+	)
+	worker := NewPartitionWorker(
+		session.StreamPartitionSessionID,
+		session,
+		listener,
+		listener.handler,
+		func(rawtopicreader.PartitionSessionID, error) {},
+		listener.tracer,
+		listener.listenerID,
+	)
+	listener.m.WithLock(func() {
+		listener.workers[session.StreamPartitionSessionID] = worker
+		listener.workerStateLocked(worker)
+	})
+	worker.Start(listener.background.Context())
+
+	return listener, worker
+}
+
+func waitForBlockedReadCallback(t *testing.T, handler *listenerLifecycleHandler) {
+	t.Helper()
+
+	select {
+	case <-handler.readStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for blocked read callback")
+	}
+}

--- a/internal/topic/topiclistenerinternal/listener_init_trace_cleanup_test.go
+++ b/internal/topic/topiclistenerinternal/listener_init_trace_cleanup_test.go
@@ -1,0 +1,423 @@
+package topiclistenerinternal
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Topic"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/background"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawtopic/rawtopicreader"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/topic/topicreadercommon"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
+	xtest "github.com/ydb-platform/ydb-go-sdk/v3/pkg/xtest"
+	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
+)
+
+func TestStreamListenerCloseWaitsForTraceDoneHook(t *testing.T) {
+	listener := &streamListener{
+		background: *background.NewWorker(context.Background(), "test stream listener"),
+		tracer:     &trace.Topic{},
+		listenerID: "test-listener-id",
+	}
+	listener.initVars(&atomic.Int64{})
+	listener.background.Context()
+
+	traceGate := newListenerCloseTraceGate()
+	listener.tracer.OnListenerClose = traceGate.hook
+	t.Cleanup(func() {
+		traceGate.release()
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), time.Second)
+		defer cleanupCancel()
+		_ = listener.Close(cleanupCtx, ErrUserCloseTopic)
+	})
+
+	closeCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	closeResult := make(chan error, 1)
+	go func() {
+		closeResult <- listener.Close(closeCtx, ErrUserCloseTopic)
+	}()
+
+	select {
+	case <-traceGate.started:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for listener close trace start hook")
+	}
+	select {
+	case <-traceGate.callbackStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for listener close trace done callback")
+	}
+
+	select {
+	case err := <-closeResult:
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	case <-time.After(time.Second):
+		t.Fatal("listener Close did not honor its deadline while trace done hook was blocked")
+	}
+	select {
+	case <-traceGate.done:
+		t.Fatal("listener Close trace done hook finished before it was released")
+	default:
+	}
+
+	traceGate.release()
+	select {
+	case <-traceGate.done:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for listener close trace done hook")
+	}
+	require.NoError(t, listener.Close(context.Background(), ErrUserCloseTopic))
+}
+
+func TestTopicListenerReconnectorWaitsForTraceDoneBeforeReconnect(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	first := newReconnectorTestStream("session-1")
+	second := newReconnectorTestStream("session-2")
+	client := newReconnectorTestClient(
+		reconnectorTestConnectResult{stream: first},
+		reconnectorTestConnectResult{stream: second},
+	)
+	listener, _ := newTestTopicListenerReconnector(t, client)
+
+	require.NoError(t, listener.WaitInit(ctx))
+	waitReconnectorCall(ctx, t, client, 0)
+
+	listener.m.Lock()
+	streamListener := listener.streamListener
+	listener.m.Unlock()
+	require.NotNil(t, streamListener)
+
+	traceGate := newListenerCloseTraceGate()
+	streamListener.tracer.OnListenerClose = traceGate.hook
+	t.Cleanup(traceGate.release)
+
+	first.recvErr <- xerrors.Transport(status.Error(codes.Unavailable, "stream failed"))
+	select {
+	case <-traceGate.callbackStarted:
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for listener close trace done callback")
+	}
+
+	select {
+	case call := <-client.calls:
+		t.Fatalf("reconnected with attempt %d before listener close trace done hook", call)
+	case <-time.After(time.Second):
+	}
+	closeCtx, closeCancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	closeResult := make(chan error, 1)
+	go func() {
+		closeResult <- listener.Close(closeCtx, ErrUserCloseTopic)
+	}()
+	select {
+	case err := <-closeResult:
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	case <-ctx.Done():
+		t.Fatal("listener Close did not honor its deadline while trace done hook was blocked")
+	}
+	closeCancel()
+
+	waitCtx, waitCancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	require.ErrorIs(t, listener.WaitStop(waitCtx), context.DeadlineExceeded)
+	waitCancel()
+
+	traceGate.release()
+	select {
+	case <-traceGate.done:
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for listener close trace done hook")
+	}
+	require.NoError(t, listener.WaitStop(ctx))
+}
+
+func TestNewStreamListenerWaitsForInitCleanupAndPreservesTransportError(t *testing.T) {
+	initErr := status.Error(codes.Unavailable, "init stream transport failure")
+	stream := &listenerInitFailureGRPCStream{recvErr: initErr}
+	client := &listenerInitFailureClient{first: stream}
+	traceGate := newListenerCloseStartTraceGate()
+
+	cfg := NewStreamListenerConfig()
+	cfg.Consumer = "test-consumer"
+	cfg.Selectors = []*topicreadercommon.PublicReadSelector{{Path: "test-topic"}}
+	cfg.Tracer.OnListenerClose = traceGate.hook
+
+	result := make(chan streamListenerInitResult, 1)
+	returned := make(chan struct{})
+	t.Cleanup(func() {
+		traceGate.release()
+		select {
+		case <-returned:
+		case <-time.After(time.Second):
+		}
+	})
+	go func() {
+		listener, err := newStreamListener(
+			context.Background(),
+			client,
+			newReconnectorTestHandler(),
+			&cfg,
+			&atomic.Int64{},
+		)
+		close(returned)
+		result <- streamListenerInitResult{listener: listener, err: err}
+	}()
+
+	select {
+	case <-traceGate.started:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for failed listener init cleanup trace start hook")
+	}
+	select {
+	case <-returned:
+		t.Fatal("newStreamListener returned before failed init cleanup completed")
+	case <-time.After(100 * time.Millisecond):
+	}
+	traceGate.release()
+	var initResult streamListenerInitResult
+	select {
+	case initResult = <-result:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for failed listener init cleanup")
+	}
+	require.Nil(t, initResult.listener)
+	require.ErrorIs(t, initResult.err, initErr)
+
+	select {
+	case <-traceGate.done:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for failed listener close trace done hook")
+	}
+	select {
+	case <-stream.ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for failed stream cancellation")
+	}
+	require.ErrorIs(t, context.Cause(stream.ctx), initErr)
+}
+
+func TestTopicListenerReconnectorWaitsForFailedInitCleanup(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	initErr := status.Error(codes.Unavailable, "init stream transport failure")
+	first := &listenerInitFailureGRPCStream{recvErr: initErr}
+	second := newReconnectorTestStream("session-2")
+	client := &listenerInitFailureClient{
+		first:       first,
+		replacement: second,
+		calls:       make(chan int, 4),
+	}
+
+	cfg := NewStreamListenerConfig()
+	cfg.Consumer = "test-consumer"
+	cfg.Selectors = []*topicreadercommon.PublicReadSelector{{Path: "test-topic"}}
+	traceGate := newListenerCloseStartTraceGate()
+	cfg.Tracer.OnListenerClose = traceGate.hook
+
+	listener := newTopicListenerReconnector(
+		client,
+		&cfg,
+		newReconnectorTestHandler(),
+		xtest.FastClock(t),
+	)
+	t.Cleanup(func() {
+		traceGate.release()
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), time.Second)
+		defer cleanupCancel()
+		_ = listener.Close(cleanupCtx, ErrUserCloseTopic)
+		_ = listener.WaitStop(cleanupCtx)
+	})
+
+	waitListenerInitClientCall(ctx, t, client, 0)
+	select {
+	case <-traceGate.started:
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for failed listener init cleanup trace start hook")
+	}
+
+	select {
+	case call := <-client.calls:
+		t.Fatalf("replacement connection attempt %d started before failed init cleanup completed", call)
+	case <-time.After(100 * time.Millisecond):
+	}
+	closeCtx, closeCancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	closeResult := make(chan error, 1)
+	go func() {
+		closeResult <- listener.Close(closeCtx, ErrUserCloseTopic)
+	}()
+	select {
+	case err := <-closeResult:
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	case <-ctx.Done():
+		t.Fatal("listener Close did not honor its deadline while failed init cleanup was blocked")
+	}
+	closeCancel()
+
+	waitCtx, waitCancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	require.ErrorIs(t, listener.WaitStop(waitCtx), context.DeadlineExceeded)
+	waitCancel()
+
+	traceGate.release()
+	select {
+	case <-traceGate.done:
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for failed listener close trace done hook")
+	}
+	require.NoError(t, listener.WaitStop(ctx))
+}
+
+type listenerCloseTraceGate struct {
+	started         chan struct{}
+	callbackStarted chan struct{}
+	done            chan struct{}
+	releaseChan     chan struct{}
+	startOnce       sync.Once
+	callbackOnce    sync.Once
+	doneOnce        sync.Once
+	releaseOnce     sync.Once
+}
+
+type listenerCloseStartTraceGate struct {
+	started     chan struct{}
+	done        chan struct{}
+	releaseChan chan struct{}
+	startOnce   sync.Once
+	doneOnce    sync.Once
+	releaseOnce sync.Once
+}
+
+func newListenerCloseStartTraceGate() *listenerCloseStartTraceGate {
+	return &listenerCloseStartTraceGate{
+		started:     make(chan struct{}),
+		done:        make(chan struct{}),
+		releaseChan: make(chan struct{}),
+	}
+}
+
+func (g *listenerCloseStartTraceGate) hook(
+	trace.TopicListenerCloseStartInfo,
+) func(trace.TopicListenerCloseDoneInfo) {
+	g.startOnce.Do(func() { close(g.started) })
+	<-g.releaseChan
+
+	return func(trace.TopicListenerCloseDoneInfo) {
+		g.doneOnce.Do(func() { close(g.done) })
+	}
+}
+
+func (g *listenerCloseStartTraceGate) release() {
+	g.releaseOnce.Do(func() { close(g.releaseChan) })
+}
+
+func newListenerCloseTraceGate() *listenerCloseTraceGate {
+	return &listenerCloseTraceGate{
+		started:         make(chan struct{}),
+		callbackStarted: make(chan struct{}),
+		done:            make(chan struct{}),
+		releaseChan:     make(chan struct{}),
+	}
+}
+
+func (g *listenerCloseTraceGate) hook(trace.TopicListenerCloseStartInfo) func(trace.TopicListenerCloseDoneInfo) {
+	g.startOnce.Do(func() { close(g.started) })
+
+	return func(trace.TopicListenerCloseDoneInfo) {
+		g.callbackOnce.Do(func() { close(g.callbackStarted) })
+		<-g.releaseChan
+		g.doneOnce.Do(func() { close(g.done) })
+	}
+}
+
+func (g *listenerCloseTraceGate) release() {
+	g.releaseOnce.Do(func() { close(g.releaseChan) })
+}
+
+type streamListenerInitResult struct {
+	listener *streamListener
+	err      error
+}
+
+type listenerInitFailureGRPCStream struct {
+	ctx     context.Context //nolint:containedctx
+	recvErr error
+}
+
+func (s *listenerInitFailureGRPCStream) Send(*Ydb_Topic.StreamReadMessage_FromClient) error {
+	return nil
+}
+
+func (s *listenerInitFailureGRPCStream) Recv() (*Ydb_Topic.StreamReadMessage_FromServer, error) {
+	return nil, s.recvErr
+}
+
+func (s *listenerInitFailureGRPCStream) CloseSend() error {
+	return nil
+}
+
+type listenerInitFailureClient struct {
+	first       *listenerInitFailureGRPCStream
+	replacement *reconnectorTestStream
+	calls       chan int
+
+	m     sync.Mutex
+	count int
+}
+
+func (c *listenerInitFailureClient) StreamRead(
+	ctx context.Context,
+	_ int64,
+	_ *trace.Topic,
+) (rawtopicreader.StreamReader, error) {
+	c.m.Lock()
+	call := c.count
+	c.count++
+	c.m.Unlock()
+	if c.calls != nil {
+		c.calls <- call
+	}
+
+	if call == 0 {
+		c.first.ctx = ctx
+
+		return rawtopicreader.StreamReader{
+			Stream: c.first,
+			Tracer: &trace.Topic{},
+		}, nil
+	}
+	if c.replacement == nil {
+		<-ctx.Done()
+
+		return rawtopicreader.StreamReader{}, ctx.Err()
+	}
+	c.replacement.ctx = ctx
+
+	return rawtopicreader.StreamReader{
+		Stream: c.replacement,
+		Tracer: &trace.Topic{},
+	}, nil
+}
+
+func waitListenerInitClientCall(
+	ctx context.Context,
+	t *testing.T,
+	client *listenerInitFailureClient,
+	expected int,
+) {
+	t.Helper()
+
+	select {
+	case call := <-client.calls:
+		require.Equal(t, expected, call)
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for listener connection attempt")
+	}
+}

--- a/internal/topic/topiclistenerinternal/listener_shutdown_regression_test.go
+++ b/internal/topic/topiclistenerinternal/listener_shutdown_regression_test.go
@@ -1,0 +1,319 @@
+package topiclistenerinternal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/background"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawtopic/rawtopicreader"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/topic/topicreadercommon"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
+	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
+)
+
+func TestTopicListenerReconnectorDoesNotReconnectBeforeHandlerReturns(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	first := newReconnectorTestStream("session-1")
+	second := newReconnectorTestStream("session-2")
+	client := newReconnectorTestClient(
+		reconnectorTestConnectResult{stream: first},
+		reconnectorTestConnectResult{stream: second},
+	)
+	listener, handler := newTestTopicListenerReconnector(t, client)
+	readMessagesRelease := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseReadMessages := func() {
+		releaseOnce.Do(func() { close(readMessagesRelease) })
+	}
+	t.Cleanup(releaseReadMessages)
+	handler.readMessagesRelease = readMessagesRelease
+
+	require.NoError(t, listener.WaitInit(ctx))
+	waitReconnectorCall(ctx, t, client, 0)
+
+	first.messages <- testStartPartitionSessionMessage()
+	first.messages <- testReadMessage()
+	select {
+	case <-handler.readMessages:
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for blocked read handler")
+	}
+
+	listener.m.Lock()
+	streamListener := listener.streamListener
+	listener.m.Unlock()
+	require.NotNil(t, streamListener)
+	first.recvErr <- xerrors.Transport(status.Error(codes.Unavailable, "stream failed"))
+	require.Eventually(t, streamListener.closing.Load, time.Second, time.Millisecond)
+
+	select {
+	case call := <-client.calls:
+		t.Fatalf("reconnected while handler was still running: call %d", call)
+	case <-time.After(1100 * time.Millisecond):
+	}
+
+	releaseReadMessages()
+	waitReconnectorCall(ctx, t, client, 1)
+	closeTestTopicListenerReconnector(ctx, t, listener)
+}
+
+func TestTopicListenerReconnectorWaitStopWaitsForHandlerAfterCloseTimeout(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	stream := newReconnectorTestStream("session-1")
+	client := newReconnectorTestClient(reconnectorTestConnectResult{stream: stream})
+	listener, handler := newTestTopicListenerReconnector(t, client)
+	readMessagesRelease := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseReadMessages := func() {
+		releaseOnce.Do(func() { close(readMessagesRelease) })
+	}
+	t.Cleanup(releaseReadMessages)
+	handler.readMessagesRelease = readMessagesRelease
+
+	require.NoError(t, listener.WaitInit(ctx))
+	waitReconnectorCall(ctx, t, client, 0)
+	stream.messages <- testStartPartitionSessionMessage()
+	stream.messages <- testReadMessage()
+	select {
+	case <-handler.readMessages:
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for blocked read handler")
+	}
+
+	closeCtx, closeCancel := context.WithTimeout(ctx, 50*time.Millisecond)
+	closeErr := listener.Close(closeCtx, ErrUserCloseTopic)
+	closeCancel()
+	require.ErrorIs(t, closeErr, context.DeadlineExceeded)
+
+	waitCtx, waitCancel := context.WithTimeout(ctx, 50*time.Millisecond)
+	require.ErrorIs(t, listener.WaitStop(waitCtx), context.DeadlineExceeded)
+	waitCancel()
+
+	releaseReadMessages()
+	require.NoError(t, listener.WaitStop(ctx))
+}
+
+func TestTopicListenerReconnectorCloseTraceCanCallClose(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	stream := newReconnectorTestStream("session-1")
+	client := newReconnectorTestClient(reconnectorTestConnectResult{stream: stream})
+	listener, _ := newTestTopicListenerReconnector(t, client)
+
+	require.NoError(t, listener.WaitInit(ctx))
+	waitReconnectorCall(ctx, t, client, 0)
+	listener.m.Lock()
+	streamListener := listener.streamListener
+	listener.m.Unlock()
+	require.NotNil(t, streamListener)
+
+	traceResult := make(chan error, 1)
+	var traceOnce sync.Once
+	streamListener.tracer.OnListenerClose = func(
+		trace.TopicListenerCloseStartInfo,
+	) func(trace.TopicListenerCloseDoneInfo) {
+		traceOnce.Do(func() {
+			closeCtx, closeCancel := context.WithTimeout(ctx, 50*time.Millisecond)
+			defer closeCancel()
+			traceResult <- listener.Close(closeCtx, ErrUserCloseTopic)
+		})
+
+		return nil
+	}
+
+	stream.recvErr <- xerrors.Transport(status.Error(codes.Unavailable, "stream failed"))
+	select {
+	case err := <-traceResult:
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	case <-ctx.Done():
+		t.Fatal("listener close from trace callback did not return")
+	}
+	require.NoError(t, listener.WaitStop(ctx))
+}
+
+func TestStreamListenerPreservesFirstShutdownReasonWhenRecvReturnsCanceled(t *testing.T) {
+	fatalErr := errors.New("fatal send error")
+	streamCtx, cancelStream := context.WithCancel(context.Background())
+	defer cancelStream()
+
+	stream := &canceledAfterStreamClose{
+		ctx:          streamCtx,
+		recvStarted:  make(chan struct{}),
+		recvReturned: make(chan struct{}),
+	}
+	listener := &streamListener{
+		stream:     stream,
+		tracer:     &trace.Topic{},
+		listenerID: "test-listener-id",
+		streamClose: func(reason error) {
+			if errors.Is(reason, fatalErr) {
+				cancelStream()
+				<-stream.recvReturned
+			}
+		},
+	}
+	listener.background = *background.NewWorker(context.Background(), "test-listener")
+	listener.background.Start("receiver", listener.receiveMessagesLoop)
+	select {
+	case <-stream.recvStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for receiver")
+	}
+
+	go listener.goClose(context.Background(), fatalErr)
+	select {
+	case <-listener.background.Done():
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for listener shutdown")
+	}
+
+	require.ErrorIs(t, listener.background.CloseReason(), fatalErr)
+}
+
+func TestStreamListenerPreservesFirstSendReasonWhenRecvReturnsCanceled(t *testing.T) {
+	fatalErr := errors.New("fatal send error")
+	streamCtx, cancelStream := context.WithCancel(context.Background())
+	defer cancelStream()
+
+	stream := &sendFailureAfterStreamClose{
+		ctx:          streamCtx,
+		recvStarted:  make(chan struct{}),
+		recvReturned: make(chan struct{}),
+		sendErr:      xerrors.Transport(fmt.Errorf("%w: transport failure", fatalErr)),
+	}
+	listener := &streamListener{
+		stream:     stream,
+		tracer:     &trace.Topic{},
+		listenerID: "test-listener-id",
+		streamClose: func(reason error) {
+			if errors.Is(reason, fatalErr) {
+				cancelStream()
+				<-stream.recvReturned
+			}
+		},
+	}
+	listener.initVars(&atomic.Int64{})
+	listener.background = *background.NewWorker(context.Background(), "test-listener")
+	listener.background.Start("receiver", listener.receiveMessagesLoop)
+	select {
+	case <-stream.recvStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for receiver")
+	}
+	listener.background.Start("sender", listener.sendMessagesLoop)
+	listener.sendMessage(&rawtopicreader.ReadRequest{BytesSize: 1})
+
+	select {
+	case <-listener.background.Done():
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for listener shutdown")
+	}
+
+	require.ErrorIs(t, listener.background.CloseReason(), fatalErr)
+}
+
+func TestNewStreamListenerCancellationDuringInitDoesNotHang(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	client := &blockingInitClient{started: make(chan struct{})}
+	cfg := NewStreamListenerConfig()
+	cfg.Consumer = "test-consumer"
+	cfg.Selectors = []*topicreadercommon.PublicReadSelector{{Path: "test-topic"}}
+
+	result := make(chan error, 1)
+	go func() {
+		_, err := newStreamListener(ctx, client, newReconnectorTestHandler(), &cfg, nil)
+		result <- err
+	}()
+
+	select {
+	case <-client.started:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for stream initialization")
+	}
+	cancel()
+
+	select {
+	case err := <-result:
+		require.Error(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("stream initialization did not stop after cancellation")
+	}
+}
+
+type canceledAfterStreamClose struct {
+	ctx          context.Context //nolint:containedctx
+	recvStarted  chan struct{}
+	recvReturned chan struct{}
+	recvOnce     sync.Once
+}
+
+func (s *canceledAfterStreamClose) Recv() (rawtopicreader.ServerMessage, error) {
+	s.recvOnce.Do(func() { close(s.recvStarted) })
+	<-s.ctx.Done()
+	close(s.recvReturned)
+
+	return nil, xerrors.Transport(status.Error(codes.Canceled, "transport canceled"))
+}
+
+func (s *canceledAfterStreamClose) Send(rawtopicreader.ClientMessage) error {
+	return nil
+}
+
+func (s *canceledAfterStreamClose) CloseSend() error {
+	return nil
+}
+
+type sendFailureAfterStreamClose struct {
+	ctx          context.Context //nolint:containedctx
+	recvStarted  chan struct{}
+	recvReturned chan struct{}
+	sendErr      error
+	recvOnce     sync.Once
+}
+
+func (s *sendFailureAfterStreamClose) Recv() (rawtopicreader.ServerMessage, error) {
+	s.recvOnce.Do(func() { close(s.recvStarted) })
+	<-s.ctx.Done()
+	close(s.recvReturned)
+
+	return nil, xerrors.Transport(status.Error(codes.Canceled, "transport canceled"))
+}
+
+func (s *sendFailureAfterStreamClose) Send(rawtopicreader.ClientMessage) error {
+	return s.sendErr
+}
+
+func (s *sendFailureAfterStreamClose) CloseSend() error {
+	return nil
+}
+
+type blockingInitClient struct {
+	started chan struct{}
+}
+
+func (c *blockingInitClient) StreamRead(
+	ctx context.Context,
+	_ int64,
+	_ *trace.Topic,
+) (rawtopicreader.StreamReader, error) {
+	close(c.started)
+	<-ctx.Done()
+
+	return rawtopicreader.StreamReader{}, ctx.Err()
+}

--- a/internal/topic/topiclistenerinternal/stream_listener.go
+++ b/internal/topic/topiclistenerinternal/stream_listener.go
@@ -141,7 +141,7 @@ func (l *streamListener) Close(ctx context.Context, reason error) error {
 		l.streamClose(reason)
 	}
 
-	if err := l.background.Close(ctx, reason); err != nil {
+	if err := l.background.Close(ctx, reason); err != nil && !errors.Is(err, background.ErrAlreadyClosed) {
 		resErrors = append(resErrors, err)
 	}
 

--- a/internal/topic/topiclistenerinternal/stream_listener.go
+++ b/internal/topic/topiclistenerinternal/stream_listener.go
@@ -10,7 +10,6 @@ import (
 	"reflect"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/background"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/empty"
@@ -54,9 +53,29 @@ type streamListener struct {
 	closing atomic.Bool
 	tracer  *trace.Topic
 
+	shutdownInit       sync.Once
+	shutdownOnce       sync.Once
+	shutdownReasonOnce sync.Once
+	shutdownDone       chan struct{}
+	shutdownReason     error
+	shutdownErr        error
+
 	m              xsync.Mutex
 	workers        map[rawtopicreader.PartitionSessionID]*PartitionWorker
+	workerStates   map[*PartitionWorker]*partitionWorkerState
 	messagesToSend []rawtopicreader.ClientMessage
+}
+
+type partitionWorkerState struct {
+	worker       *PartitionWorker
+	closeDone    chan struct{}
+	closeStarted bool
+	closeErr     error
+}
+
+type partitionWorkerCloseTask struct {
+	state    *partitionWorkerState
+	closeNow bool
 }
 
 func newStreamListener(
@@ -92,7 +111,11 @@ func newStreamListener(
 
 	if err := res.initStream(connectionCtx, client); err != nil {
 		initDone("", err)
-		res.goClose(connectionCtx, err)
+		// Initialization may have created a stream and a stream-cancellation
+		// watchdog even though the listener itself was not returned. Complete
+		// that partial listener cleanup before allowing a reconnect attempt, but
+		// keep the initialization error as the constructor result.
+		_ = res.Close(context.Background(), err)
 
 		return nil, err
 	}
@@ -116,65 +139,133 @@ func newStreamListener(
 }
 
 func (l *streamListener) Close(ctx context.Context, reason error) error {
-	if !l.closing.CompareAndSwap(false, true) {
-		return errTopicListenerClosed
+	l.beginClose(ctx, reason)
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 
-	logCtx := ctx
-	closeDone := gtrace.TopicOnListenerClose(l.tracer, &logCtx, l.listenerID, l.sessionID, reason)
-
-	var resErrors []error
-
-	// Stop all partition workers first
-	// Copy workers to avoid holding mutex while closing them (to prevent deadlock)
-	var workers []*PartitionWorker
-	l.m.WithLock(func() {
-		workers = make([]*PartitionWorker, 0, len(l.workers))
-		for _, worker := range l.workers {
-			workers = append(workers, worker)
-		}
-	})
-
-	// Stop the read stream and background workers before closing partition workers,
-	// so receiveMessagesLoop does not route messages into shutting-down workers.
-	if l.stream != nil {
-		l.streamClose(reason)
+	select {
+	case <-l.shutdownDone:
+		return l.shutdownErr
+	case <-ctx.Done():
+		return ctx.Err()
 	}
-
-	if err := l.background.Close(ctx, reason); err != nil && !errors.Is(err, background.ErrAlreadyClosed) {
-		resErrors = append(resErrors, err)
-	}
-
-	// Close workers without holding the mutex
-	for _, worker := range workers {
-		if err := worker.Close(ctx, reason); err != nil {
-			resErrors = append(resErrors, err)
-		}
-	}
-
-	if err := l.syncCommitter.Close(ctx, reason); err != nil {
-		resErrors = append(resErrors, err)
-	}
-
-	for _, session := range l.sessions.GetAll() {
-		session.Close()
-		// For shutdown, we don't need to process stop partition requests through workers
-		// since all workers are already being closed above
-	}
-
-	finalErr := errors.Join(resErrors...)
-
-	closeDone(len(workers), finalErr)
-
-	return finalErr
 }
 
 func (l *streamListener) goClose(ctx context.Context, reason error) {
-	ctx, cancel := context.WithTimeout(xcontext.ValueOnly(ctx), time.Second)
-	l.streamClose(reason)
+	l.beginClose(ctx, reason)
+}
+
+func (l *streamListener) beginClose(ctx context.Context, reason error) {
+	l.shutdownInit.Do(func() {
+		l.shutdownDone = make(chan struct{})
+	})
+
+	l.shutdownOnce.Do(func() {
+		l.closing.Store(true)
+		l.recordShutdownReason(reason)
+
+		go func() {
+			var resErrors []error
+			logCtx := ctx
+			closeDone := gtrace.TopicOnListenerClose(
+				l.tracer,
+				&logCtx,
+				l.listenerID,
+				l.sessionID,
+				l.shutdownReason,
+			)
+
+			// Stop the read stream and wait for its receiver and sender loops before
+			// taking the worker snapshot. This prevents a receiver from creating a
+			// worker after the snapshot while shutdown is already in progress.
+			if l.streamClose != nil {
+				l.streamClose(l.shutdownReason)
+			}
+
+			// Shutdown owns this worker and must continue draining after the caller's
+			// context expires. Partition callbacks are drained below with the same
+			// detached lifetime.
+			_ = l.background.Close(context.Background(), l.shutdownReason)
+
+			// Claim all workers after the stream loops have stopped. A worker may
+			// already have stopped naturally and been removed from the routing map;
+			// its state remains retained until this close/join completes.
+			workerTasks := l.claimWorkersForClose()
+			for _, task := range workerTasks {
+				if task.closeNow {
+					l.finishWorkerClose(task.state, l.shutdownReason)
+				}
+
+				<-task.state.closeDone
+				if task.state.closeErr != nil {
+					resErrors = append(resErrors, task.state.closeErr)
+				}
+			}
+
+			if l.syncCommitter != nil {
+				_ = l.syncCommitter.Close(context.Background(), l.shutdownReason)
+			}
+
+			if l.sessions != nil {
+				for _, session := range l.sessions.GetAll() {
+					session.Close()
+					// For shutdown, we don't need to process stop partition requests through workers
+					// since all workers are already being closed above.
+				}
+			}
+
+			l.shutdownErr = errors.Join(resErrors...)
+			// The done hook is part of listener shutdown. Publish shutdownDone only
+			// after it returns so WaitStop cannot report completion while tracing is
+			// still running.
+			closeDone(len(workerTasks), l.shutdownErr)
+			close(l.shutdownDone)
+		}()
+	})
+}
+
+func (l *streamListener) claimWorkersForClose() []partitionWorkerCloseTask {
+	var tasks []partitionWorkerCloseTask
+	l.m.WithLock(func() {
+		tasks = make([]partitionWorkerCloseTask, 0, len(l.workerStates))
+		for _, state := range l.workerStates {
+			closeNow := !state.closeStarted
+			state.closeStarted = true
+			tasks = append(tasks, partitionWorkerCloseTask{state: state, closeNow: closeNow})
+		}
+	})
+
+	return tasks
+}
+
+func (l *streamListener) workerStateLocked(worker *PartitionWorker) *partitionWorkerState {
+	if state, ok := l.workerStates[worker]; ok {
+		return state
+	}
+
+	state := &partitionWorkerState{
+		worker:    worker,
+		closeDone: make(chan struct{}),
+	}
+	l.workerStates[worker] = state
+
+	return state
+}
+
+func (l *streamListener) finishWorkerClose(state *partitionWorkerState, reason error) {
+	state.closeErr = state.worker.Close(context.Background(), reason)
+	l.m.WithLock(func() {
+		if current, ok := l.workerStates[state.worker]; ok && current == state {
+			delete(l.workerStates, state.worker)
+		}
+	})
+	close(state.closeDone)
+}
+
+func (l *streamListener) closeWorkerAfterStop(state *partitionWorkerState, reason error) {
 	go func() {
-		_ = l.background.Close(ctx, reason)
-		cancel()
+		l.finishWorkerClose(state, reason)
 	}()
 }
 
@@ -191,6 +282,7 @@ func (l *streamListener) initVars(sessionIDCounter *atomic.Int64) {
 	l.sessions = &topicreadercommon.PartitionSessionStorage{}
 	l.sessionIDCounter = sessionIDCounter
 	l.workers = make(map[rawtopicreader.PartitionSessionID]*PartitionWorker)
+	l.workerStates = make(map[*PartitionWorker]*partitionWorkerState)
 	if l.cfg == nil {
 		l.cfg = &StreamListenerConfig{}
 	}
@@ -209,7 +301,7 @@ func (l *streamListener) initStream(ctx context.Context, client TopicClient) err
 			err := xerrors.WithStackTrace(xerrors.Wrap(fmt.Errorf(
 				"ydb: topic listener stream init timeout: %w", ctx.Err(),
 			)))
-			l.goClose(ctx, err)
+			l.recordShutdownReason(err)
 			l.streamClose(err)
 		case <-initDone:
 			// pass
@@ -262,6 +354,12 @@ func (l *streamListener) initStream(ctx context.Context, client TopicClient) err
 	l.sessionID = initResp.SessionID
 
 	return nil
+}
+
+func (l *streamListener) recordShutdownReason(reason error) {
+	l.shutdownReasonOnce.Do(func() {
+		l.shutdownReason = reason
+	})
 }
 
 func (l *streamListener) sendMessagesLoop(ctx context.Context) {
@@ -609,11 +707,33 @@ func (l *streamListener) SendRaw(msg rawtopicreader.ClientMessage) {
 }
 
 // onWorkerStopped handles worker stopped notifications
-func (l *streamListener) onWorkerStopped(sessionID rawtopicreader.PartitionSessionID, reason error) {
-	// Remove worker from workers map
+func (l *streamListener) onWorkerStopped(
+	worker *PartitionWorker,
+	sessionID rawtopicreader.PartitionSessionID,
+	reason error,
+) {
+	var (
+		state       *partitionWorkerState
+		closeWorker bool
+	)
 	l.m.WithLock(func() {
-		delete(l.workers, sessionID)
+		// Do not remove a replacement worker that has already claimed this
+		// session ID. Production workers pass their identity through the callback.
+		if current := l.workers[sessionID]; current == worker {
+			delete(l.workers, sessionID)
+		}
+
+		state = l.workerStateLocked(worker)
+		closeWorker = !state.closeStarted
+		state.closeStarted = true
 	})
+
+	if closeWorker {
+		// onStopped runs from the worker callback itself. Closing synchronously
+		// would wait for that callback and deadlock; the detached join also keeps
+		// the retired-worker set bounded during normal operation.
+		l.closeWorkerAfterStop(state, reason)
+	}
 
 	// Remove corresponding session
 	for _, session := range l.sessions.GetAll() {
@@ -637,19 +757,24 @@ func (l *streamListener) onWorkerStopped(sessionID rawtopicreader.PartitionSessi
 
 // createWorkerForPartition creates a new PartitionWorker for the given session
 func (l *streamListener) createWorkerForPartition(session *topicreadercommon.PartitionSession) *PartitionWorker {
-	worker := NewPartitionWorker(
+	var worker *PartitionWorker
+	worker = NewPartitionWorker(
 		session.StreamPartitionSessionID,
 		session,
 		l,
 		l.handler,
-		l.onWorkerStopped,
+		func(sessionID rawtopicreader.PartitionSessionID, reason error) {
+			l.onWorkerStopped(worker, sessionID, reason)
+		},
 		l.tracer,
 		l.listenerID,
 	)
 
-	// Store worker in map
+	// Register ownership before starting the worker. Shutdown snapshots this
+	// same state under the mutex after the stream loops have stopped.
 	l.m.WithLock(func() {
 		l.workers[session.StreamPartitionSessionID] = worker
+		l.workerStateLocked(worker)
 	})
 
 	// Start worker

--- a/internal/topic/topiclistenerinternal/topic_listener_reconnector.go
+++ b/internal/topic/topiclistenerinternal/topic_listener_reconnector.go
@@ -5,9 +5,14 @@ import (
 	"errors"
 	"sync"
 	"sync/atomic"
+	"time"
+
+	"github.com/jonboulle/clockwork"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/background"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/empty"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/topic"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xcontext"
 )
 
 var (
@@ -16,14 +21,18 @@ var (
 )
 
 type TopicListenerReconnector struct {
-	streamConfig *StreamListenerConfig
-	client       TopicClient
-	handler      EventHandler
+	streamConfig  *StreamListenerConfig
+	client        TopicClient
+	handler       EventHandler
+	clock         clockwork.Clock
+	retrySettings topic.RetrySettings
 
 	background background.Worker
 
 	connectionResult    error
 	connectionCompleted empty.Chan
+	connectionDoneOnce  sync.Once
+	stopped             empty.Chan
 	connectionIDCounter atomic.Int64
 	closing             atomic.Bool
 
@@ -36,16 +45,30 @@ func NewTopicListenerReconnector(
 	streamConfig *StreamListenerConfig,
 	handler EventHandler,
 ) (*TopicListenerReconnector, error) {
+	return newTopicListenerReconnector(client, streamConfig, handler, clockwork.NewRealClock()), nil
+}
+
+func newTopicListenerReconnector(
+	client TopicClient,
+	streamConfig *StreamListenerConfig,
+	handler EventHandler,
+	clock clockwork.Clock,
+) *TopicListenerReconnector {
 	res := &TopicListenerReconnector{
-		streamConfig:        streamConfig,
-		client:              client,
-		handler:             handler,
+		streamConfig: streamConfig,
+		client:       client,
+		handler:      handler,
+		clock:        clock,
+		retrySettings: topic.RetrySettings{
+			StartTimeout: topic.DefaultStartTimeout,
+		},
 		connectionCompleted: make(empty.Chan),
+		stopped:             make(empty.Chan),
 	}
 
-	res.background.Start("connection", res.connect)
+	res.background.Start("connection loop", res.connectionLoop)
 
-	return res, nil
+	return res
 }
 
 func (lr *TopicListenerReconnector) ReadSessionID() string {
@@ -63,9 +86,13 @@ func (lr *TopicListenerReconnector) Close(ctx context.Context, reason error) err
 	if !lr.closing.CompareAndSwap(false, true) {
 		return errTopicListenerClosed
 	}
+	lr.completeConnection(reason)
+
 	var closeErrors []error
 	err := lr.background.Close(ctx, reason)
-	closeErrors = append(closeErrors, err)
+	if err != nil && !errors.Is(err, background.ErrAlreadyClosed) {
+		closeErrors = append(closeErrors, err)
+	}
 
 	lr.m.Lock()
 	sl := lr.streamListener
@@ -73,7 +100,7 @@ func (lr *TopicListenerReconnector) Close(ctx context.Context, reason error) err
 
 	if sl != nil {
 		err = sl.Close(ctx, reason)
-		if !errors.Is(err, context.Canceled) {
+		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, errTopicListenerClosed) {
 			closeErrors = append(closeErrors, err)
 		}
 	}
@@ -81,20 +108,136 @@ func (lr *TopicListenerReconnector) Close(ctx context.Context, reason error) err
 	return errors.Join(closeErrors...)
 }
 
-func (lr *TopicListenerReconnector) connect(connectionCtx context.Context) {
-	sl, connRes := newStreamListener(
-		connectionCtx,
+func (lr *TopicListenerReconnector) completeConnection(err error) {
+	lr.connectionDoneOnce.Do(func() {
+		lr.m.Lock()
+		lr.connectionResult = err
+		lr.m.Unlock()
+		close(lr.connectionCompleted)
+	})
+}
+
+func (lr *TopicListenerReconnector) setStreamListener(sl *streamListener) {
+	lr.m.Lock()
+	lr.streamListener = sl
+	lr.m.Unlock()
+}
+
+func (lr *TopicListenerReconnector) clearStreamListener(sl *streamListener) {
+	lr.m.Lock()
+	if lr.streamListener == sl {
+		lr.streamListener = nil
+	}
+	lr.m.Unlock()
+}
+
+func (lr *TopicListenerReconnector) waitRetry(
+	ctx context.Context,
+	reason error,
+	attempt int,
+	retriesStarted time.Time,
+) bool {
+	retryBackoff, stopReason := topic.RetryDecision(
+		reason,
+		lr.retrySettings,
+		lr.clock.Since(retriesStarted),
+	)
+	if stopReason != nil {
+		lr.completeConnection(stopReason)
+		_ = lr.background.Close(ctx, stopReason)
+
+		return false
+	}
+
+	timer := lr.clock.NewTimer(retryBackoff.Delay(attempt))
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.Chan():
+		return true
+	}
+}
+
+func (lr *TopicListenerReconnector) closeStreamListener(sl *streamListener, reason error) {
+	closeCtx, cancel := context.WithTimeout(xcontext.ValueOnly(lr.background.Context()), time.Second)
+	defer cancel()
+
+	_ = sl.Close(closeCtx, reason)
+}
+
+func (lr *TopicListenerReconnector) connectStreamListener(ctx context.Context) (*streamListener, error) {
+	return newStreamListener(
+		ctx,
 		lr.client,
 		lr.handler,
 		lr.streamConfig,
 		&lr.connectionIDCounter,
 	)
-	lr.m.Lock()
-	lr.streamListener = sl
-	lr.connectionResult = connRes
-	lr.m.Unlock()
+}
 
-	close(lr.connectionCompleted)
+func (lr *TopicListenerReconnector) connectionLoop(ctx context.Context) {
+	defer close(lr.stopped)
+
+	var (
+		attempt         int
+		previousAttempt time.Time
+		retriesStarted  time.Time
+		reconnectReason error
+	)
+
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		now := lr.clock.Now()
+		if retriesStarted.IsZero() || topic.CheckResetReconnectionCounters(
+			previousAttempt,
+			now,
+			topic.DefaultStartTimeout,
+		) {
+			attempt = 0
+			retriesStarted = now
+		} else {
+			attempt++
+		}
+		previousAttempt = now
+
+		if reconnectReason != nil && !lr.waitRetry(ctx, reconnectReason, attempt, retriesStarted) {
+			return
+		}
+
+		sl, err := lr.connectStreamListener(ctx)
+		if err != nil {
+			reconnectReason = err
+
+			continue
+		}
+
+		lr.setStreamListener(sl)
+		lr.completeConnection(nil)
+
+		select {
+		case <-ctx.Done():
+			lr.closeStreamListener(sl, lr.background.CloseReason())
+			lr.clearStreamListener(sl)
+
+			return
+		case <-sl.background.Done():
+			reconnectReason = sl.background.CloseReason()
+		}
+
+		lr.closeStreamListener(sl, reconnectReason)
+		lr.clearStreamListener(sl)
+
+		if ctx.Err() != nil {
+			return
+		}
+
+		retriesStarted = lr.clock.Now()
+	}
 }
 
 func (lr *TopicListenerReconnector) WaitInit(ctx context.Context) error {
@@ -109,14 +252,18 @@ func (lr *TopicListenerReconnector) WaitInit(ctx context.Context) error {
 		return err
 	}
 
-	return lr.connectionResult
+	lr.m.Lock()
+	err := lr.connectionResult
+	lr.m.Unlock()
+
+	return err
 }
 
 func (lr *TopicListenerReconnector) WaitStop(ctx context.Context) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
-	case <-lr.background.StopDone():
+	case <-lr.stopped:
 		err := lr.background.CloseReason()
 		if errors.Is(err, ErrUserCloseTopic) {
 			return nil

--- a/internal/topic/topiclistenerinternal/topic_listener_reconnector.go
+++ b/internal/topic/topiclistenerinternal/topic_listener_reconnector.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/background"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/empty"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/topic"
-	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xcontext"
 )
 
 var (
@@ -161,10 +160,10 @@ func (lr *TopicListenerReconnector) waitRetry(
 }
 
 func (lr *TopicListenerReconnector) closeStreamListener(sl *streamListener, reason error) {
-	closeCtx, cancel := context.WithTimeout(xcontext.ValueOnly(lr.background.Context()), time.Second)
-	defer cancel()
-
-	_ = sl.Close(closeCtx, reason)
+	// The connection loop must not start a replacement stream until every
+	// callback in the old stream has finished. Its own worker context is
+	// already cancelled on shutdown, so it cannot be used as a cleanup timeout.
+	_ = sl.Close(context.Background(), reason)
 }
 
 func (lr *TopicListenerReconnector) connectStreamListener(ctx context.Context) (*streamListener, error) {

--- a/internal/topic/topiclistenerinternal/topic_listener_reconnector_test.go
+++ b/internal/topic/topiclistenerinternal/topic_listener_reconnector_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb"
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Topic"
@@ -130,7 +131,8 @@ func (c *reconnectorTestClient) callCount() int {
 }
 
 type reconnectorTestHandler struct {
-	readMessages chan *PublicReadMessages
+	readMessages        chan *PublicReadMessages
+	readMessagesRelease <-chan struct{}
 }
 
 func newReconnectorTestHandler() *reconnectorTestHandler {
@@ -150,6 +152,9 @@ func (h *reconnectorTestHandler) OnStartPartitionSessionRequest(
 
 func (h *reconnectorTestHandler) OnReadMessages(_ context.Context, event *PublicReadMessages) error {
 	h.readMessages <- event
+	if h.readMessagesRelease != nil {
+		<-h.readMessagesRelease
+	}
 
 	return nil
 }
@@ -356,5 +361,144 @@ func TestTopicListenerReconnectorCloseUnblocksWaitInit(t *testing.T) {
 
 	require.NoError(t, listener.Close(ctx, ErrUserCloseTopic))
 	require.ErrorIs(t, listener.WaitInit(ctx), ErrUserCloseTopic)
+	require.NoError(t, listener.WaitStop(ctx))
+}
+
+func TestNewTopicListenerReconnectorAndWaitStopContextCancellation(t *testing.T) {
+	ctx := xtest.Context(t)
+	stream := newReconnectorTestStream("session-1")
+	client := newReconnectorTestClient(reconnectorTestConnectResult{stream: stream})
+	cfg := NewStreamListenerConfig()
+	cfg.Consumer = "test-consumer"
+	cfg.Selectors = []*topicreadercommon.PublicReadSelector{{Path: "test-topic"}}
+
+	listener, err := NewTopicListenerReconnector(client, &cfg, newReconnectorTestHandler())
+	require.NoError(t, err)
+	require.NoError(t, listener.WaitInit(ctx))
+	waitReconnectorCall(ctx, t, client, 0)
+
+	waitCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	require.ErrorIs(t, listener.WaitStop(waitCtx), context.Canceled)
+
+	closeTestTopicListenerReconnector(ctx, t, listener)
+}
+
+func TestTopicListenerReconnectorWaitInitContextCancellation(t *testing.T) {
+	ctx := xtest.Context(t)
+	client := newReconnectorTestClient(reconnectorTestConnectResult{block: true})
+	listener, _ := newTestTopicListenerReconnector(t, client)
+	waitReconnectorCall(ctx, t, client, 0)
+
+	waitCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	require.ErrorIs(t, listener.WaitInit(waitCtx), context.Canceled)
+
+	closeTestTopicListenerReconnector(ctx, t, listener)
+}
+
+func TestTopicListenerReconnectorCloseWhileWaitingRetry(t *testing.T) {
+	ctx := xtest.Context(t)
+	clock := clockwork.NewFakeClock()
+	client := newReconnectorTestClient(reconnectorTestConnectResult{
+		err: xerrors.Transport(status.Error(codes.Unavailable, "connect failed")),
+	})
+	cfg := NewStreamListenerConfig()
+	cfg.Consumer = "test-consumer"
+	cfg.Selectors = []*topicreadercommon.PublicReadSelector{{Path: "test-topic"}}
+	listener := newTopicListenerReconnector(client, &cfg, newReconnectorTestHandler(), clock)
+	waitReconnectorCall(ctx, t, client, 0)
+	require.NoError(t, clock.BlockUntilContext(ctx, 1))
+
+	closeTestTopicListenerReconnector(ctx, t, listener)
+	require.ErrorIs(t, listener.WaitInit(ctx), ErrUserCloseTopic)
+}
+
+func TestTopicListenerReconnectorCloseReturnsDeadlineExceeded(t *testing.T) {
+	ctx := xtest.Context(t)
+	listenerRelease := make(chan struct{})
+	streamRelease := make(chan struct{})
+	t.Cleanup(func() {
+		close(listenerRelease)
+		close(streamRelease)
+	})
+
+	listenerStarted := make(chan struct{})
+	listener := &TopicListenerReconnector{
+		connectionCompleted: make(chan struct{}),
+	}
+	listener.background.Start("blocked listener", func(context.Context) {
+		close(listenerStarted)
+		<-listenerRelease
+	})
+	xtest.WaitChannelClosed(t, listenerStarted)
+
+	streamStarted := make(chan struct{})
+	streamListener := &streamListener{
+		tracer:     &trace.Topic{},
+		listenerID: "test-listener-id",
+		sessionID:  "test-session-id",
+	}
+	streamListener.initVars(&listener.connectionIDCounter)
+	streamListener.background.Start("blocked stream", func(context.Context) {
+		close(streamStarted)
+		<-streamRelease
+	})
+	streamListener.syncCommitter = topicreadercommon.NewCommitterStopped(
+		streamListener.tracer,
+		ctx,
+		topicreadercommon.CommitModeSync,
+		func(rawtopicreader.ClientMessage) error { return nil },
+	)
+	listener.streamListener = streamListener
+	xtest.WaitChannelClosed(t, streamStarted)
+
+	closeCtx, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
+	defer cancel()
+	require.ErrorIs(t, listener.Close(closeCtx, ErrUserCloseTopic), context.DeadlineExceeded)
+}
+
+func TestTopicListenerReconnectorStopsWhenContextCanceledDuringStreamCleanup(t *testing.T) {
+	ctx := xtest.Context(t)
+	stream := newReconnectorTestStream("session-1")
+	client := newReconnectorTestClient(reconnectorTestConnectResult{stream: stream})
+	listener, handler := newTestTopicListenerReconnector(t, client)
+	readMessagesRelease := make(chan struct{})
+	handler.readMessagesRelease = readMessagesRelease
+	t.Cleanup(func() {
+		select {
+		case <-readMessagesRelease:
+		default:
+			close(readMessagesRelease)
+		}
+	})
+
+	require.NoError(t, listener.WaitInit(ctx))
+	waitReconnectorCall(ctx, t, client, 0)
+	listener.m.Lock()
+	streamListener := listener.streamListener
+	listener.m.Unlock()
+	require.NotNil(t, streamListener)
+
+	stream.messages <- testStartPartitionSessionMessage()
+	stream.messages <- testReadMessage()
+	select {
+	case <-handler.readMessages:
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for blocked read handler")
+	}
+
+	stream.recvErr <- xerrors.Transport(status.Error(codes.Unavailable, "stream failed"))
+	require.Eventually(t, streamListener.closing.Load, time.Second, time.Millisecond)
+
+	closeCtx, cancel := context.WithTimeout(ctx, 50*time.Millisecond)
+	defer cancel()
+	require.ErrorIs(
+		t,
+		listener.background.Close(closeCtx, ErrUserCloseTopic),
+		context.DeadlineExceeded,
+	)
+	close(readMessagesRelease)
+
 	require.NoError(t, listener.WaitStop(ctx))
 }

--- a/internal/topic/topiclistenerinternal/topic_listener_reconnector_test.go
+++ b/internal/topic/topiclistenerinternal/topic_listener_reconnector_test.go
@@ -1,0 +1,360 @@
+package topiclistenerinternal
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb"
+	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb_Topic"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/grpcwrapper/rawtopic/rawtopicreader"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/topic/topicreadercommon"
+	"github.com/ydb-platform/ydb-go-sdk/v3/internal/xerrors"
+	xtest "github.com/ydb-platform/ydb-go-sdk/v3/pkg/xtest"
+	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
+)
+
+type reconnectorTestStream struct {
+	ctx       context.Context //nolint:containedctx
+	sessionID string
+	recvErr   chan error
+	messages  chan *Ydb_Topic.StreamReadMessage_FromServer
+	initSent  bool
+}
+
+func newReconnectorTestStream(sessionID string) *reconnectorTestStream {
+	return &reconnectorTestStream{
+		sessionID: sessionID,
+		recvErr:   make(chan error, 1),
+		messages:  make(chan *Ydb_Topic.StreamReadMessage_FromServer, 2),
+	}
+}
+
+func (s *reconnectorTestStream) Send(*Ydb_Topic.StreamReadMessage_FromClient) error {
+	return nil
+}
+
+func (s *reconnectorTestStream) Recv() (*Ydb_Topic.StreamReadMessage_FromServer, error) {
+	if !s.initSent {
+		s.initSent = true
+
+		return &Ydb_Topic.StreamReadMessage_FromServer{
+			Status: Ydb.StatusIds_SUCCESS,
+			ServerMessage: &Ydb_Topic.StreamReadMessage_FromServer_InitResponse{
+				InitResponse: &Ydb_Topic.StreamReadMessage_InitResponse{
+					SessionId: s.sessionID,
+				},
+			},
+		}, nil
+	}
+
+	select {
+	case err := <-s.recvErr:
+		return nil, err
+	case msg := <-s.messages:
+		return msg, nil
+	case <-s.ctx.Done():
+		return nil, context.Cause(s.ctx)
+	}
+}
+
+func (s *reconnectorTestStream) CloseSend() error {
+	return nil
+}
+
+type reconnectorTestConnectResult struct {
+	stream *reconnectorTestStream
+	err    error
+	block  bool
+}
+
+type reconnectorTestClient struct {
+	m       sync.Mutex
+	results []reconnectorTestConnectResult
+	calls   chan int
+	count   int
+}
+
+func newReconnectorTestClient(results ...reconnectorTestConnectResult) *reconnectorTestClient {
+	return &reconnectorTestClient{
+		results: results,
+		calls:   make(chan int, len(results)+1),
+	}
+}
+
+func (c *reconnectorTestClient) StreamRead(
+	ctx context.Context,
+	_ int64,
+	_ *trace.Topic,
+) (rawtopicreader.StreamReader, error) {
+	c.m.Lock()
+	call := c.count
+	c.count++
+	var result reconnectorTestConnectResult
+	if call < len(c.results) {
+		result = c.results[call]
+	} else {
+		result.block = true
+	}
+	c.m.Unlock()
+
+	c.calls <- call
+
+	if result.block {
+		<-ctx.Done()
+
+		return rawtopicreader.StreamReader{}, ctx.Err()
+	}
+	if result.err != nil {
+		return rawtopicreader.StreamReader{}, result.err
+	}
+
+	result.stream.ctx = ctx
+
+	return rawtopicreader.StreamReader{
+		Stream: result.stream,
+		Tracer: &trace.Topic{},
+	}, nil
+}
+
+func (c *reconnectorTestClient) callCount() int {
+	c.m.Lock()
+	defer c.m.Unlock()
+
+	return c.count
+}
+
+type reconnectorTestHandler struct {
+	readMessages chan *PublicReadMessages
+}
+
+func newReconnectorTestHandler() *reconnectorTestHandler {
+	return &reconnectorTestHandler{
+		readMessages: make(chan *PublicReadMessages, 1),
+	}
+}
+
+func (h *reconnectorTestHandler) OnStartPartitionSessionRequest(
+	_ context.Context,
+	event *PublicEventStartPartitionSession,
+) error {
+	event.Confirm()
+
+	return nil
+}
+
+func (h *reconnectorTestHandler) OnReadMessages(_ context.Context, event *PublicReadMessages) error {
+	h.readMessages <- event
+
+	return nil
+}
+
+func (h *reconnectorTestHandler) OnStopPartitionSessionRequest(
+	_ context.Context,
+	event *PublicEventStopPartitionSession,
+) error {
+	event.Confirm()
+
+	return nil
+}
+
+func newTestTopicListenerReconnector(
+	t *testing.T,
+	client TopicClient,
+) (*TopicListenerReconnector, *reconnectorTestHandler) {
+	t.Helper()
+
+	cfg := NewStreamListenerConfig()
+	cfg.Consumer = "test-consumer"
+	cfg.Selectors = []*topicreadercommon.PublicReadSelector{{Path: "test-topic"}}
+	handler := newReconnectorTestHandler()
+
+	listener := newTopicListenerReconnector(
+		client,
+		&cfg,
+		handler,
+		xtest.FastClock(t),
+	)
+	t.Cleanup(func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		_ = listener.Close(closeCtx, ErrUserCloseTopic)
+	})
+
+	return listener, handler
+}
+
+func waitReconnectorCall(ctx context.Context, t *testing.T, client *reconnectorTestClient, expected int) {
+	t.Helper()
+
+	select {
+	case call := <-client.calls:
+		require.Equal(t, expected, call)
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for listener connection attempt")
+	}
+}
+
+func closeTestTopicListenerReconnector(ctx context.Context, t *testing.T, listener *TopicListenerReconnector) {
+	t.Helper()
+
+	require.NoError(t, listener.Close(ctx, ErrUserCloseTopic))
+	require.NoError(t, listener.WaitStop(ctx))
+}
+
+func testStartPartitionSessionMessage() *Ydb_Topic.StreamReadMessage_FromServer {
+	return &Ydb_Topic.StreamReadMessage_FromServer{
+		Status: Ydb.StatusIds_SUCCESS,
+		ServerMessage: &Ydb_Topic.StreamReadMessage_FromServer_StartPartitionSessionRequest{
+			StartPartitionSessionRequest: &Ydb_Topic.StreamReadMessage_StartPartitionSessionRequest{
+				PartitionSession: &Ydb_Topic.StreamReadMessage_PartitionSession{
+					PartitionSessionId: 1,
+					Path:               "test-topic",
+					PartitionId:        0,
+				},
+				PartitionOffsets: &Ydb_Topic.OffsetsRange{Start: 0, End: 1},
+			},
+		},
+	}
+}
+
+func testReadMessage() *Ydb_Topic.StreamReadMessage_FromServer {
+	return &Ydb_Topic.StreamReadMessage_FromServer{
+		Status: Ydb.StatusIds_SUCCESS,
+		ServerMessage: &Ydb_Topic.StreamReadMessage_FromServer_ReadResponse{
+			ReadResponse: &Ydb_Topic.StreamReadMessage_ReadResponse{
+				BytesSize: 4,
+				PartitionData: []*Ydb_Topic.StreamReadMessage_ReadResponse_PartitionData{
+					{
+						PartitionSessionId: 1,
+						Batches: []*Ydb_Topic.StreamReadMessage_ReadResponse_Batch{
+							{
+								Codec:      int32(Ydb_Topic.Codec_CODEC_RAW),
+								ProducerId: "test-producer",
+								MessageData: []*Ydb_Topic.StreamReadMessage_ReadResponse_MessageData{
+									{
+										Offset:           0,
+										SeqNo:            1,
+										Data:             []byte("test"),
+										UncompressedSize: 4,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestTopicListenerReconnectorReconnectsAfterStreamFailure(t *testing.T) {
+	ctx := xtest.Context(t)
+	first := newReconnectorTestStream("session-1")
+	second := newReconnectorTestStream("session-2")
+	client := newReconnectorTestClient(
+		reconnectorTestConnectResult{stream: first},
+		reconnectorTestConnectResult{stream: second},
+	)
+	listener, handler := newTestTopicListenerReconnector(t, client)
+
+	require.NoError(t, listener.WaitInit(ctx))
+	waitReconnectorCall(ctx, t, client, 0)
+	require.Equal(t, "session-1", listener.ReadSessionID())
+
+	first.recvErr <- xerrors.Transport(status.Error(codes.Unavailable, "stream failed"))
+	waitReconnectorCall(ctx, t, client, 1)
+	require.Eventually(t, func() bool {
+		return listener.ReadSessionID() == "session-2"
+	}, time.Second, time.Millisecond)
+	second.messages <- testStartPartitionSessionMessage()
+	second.messages <- testReadMessage()
+
+	select {
+	case event := <-handler.readMessages:
+		require.Len(t, event.Batch.Messages, 1)
+		require.Equal(t, int64(0), event.Batch.Messages[0].Offset)
+	case <-ctx.Done():
+		t.Fatal("timeout waiting for message after listener reconnect")
+	}
+
+	closeTestTopicListenerReconnector(ctx, t, listener)
+}
+
+func TestTopicListenerReconnectorRetriesInitialConnection(t *testing.T) {
+	ctx := xtest.Context(t)
+	stream := newReconnectorTestStream("session-1")
+	client := newReconnectorTestClient(
+		reconnectorTestConnectResult{
+			err: xerrors.Transport(status.Error(codes.Unavailable, "connect failed")),
+		},
+		reconnectorTestConnectResult{stream: stream},
+	)
+	listener, _ := newTestTopicListenerReconnector(t, client)
+
+	require.NoError(t, listener.WaitInit(ctx))
+	waitReconnectorCall(ctx, t, client, 0)
+	waitReconnectorCall(ctx, t, client, 1)
+	require.Equal(t, "session-1", listener.ReadSessionID())
+
+	closeTestTopicListenerReconnector(ctx, t, listener)
+}
+
+func TestTopicListenerReconnectorStopsAfterUnretryableStreamFailure(t *testing.T) {
+	ctx := xtest.Context(t)
+	stream := newReconnectorTestStream("session-1")
+	client := newReconnectorTestClient(reconnectorTestConnectResult{stream: stream})
+	listener, _ := newTestTopicListenerReconnector(t, client)
+
+	require.NoError(t, listener.WaitInit(ctx))
+	waitReconnectorCall(ctx, t, client, 0)
+	listener.m.Lock()
+	streamListener := listener.streamListener
+	listener.m.Unlock()
+	require.NotNil(t, streamListener)
+
+	stream.recvErr <- status.Error(codes.InvalidArgument, "invalid stream")
+	err := listener.WaitStop(ctx)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "unretriable error")
+	require.Equal(t, 1, client.callCount())
+	require.True(t, streamListener.closing.Load())
+	listener.m.Lock()
+	streamListener = listener.streamListener
+	listener.m.Unlock()
+	require.Nil(t, streamListener)
+}
+
+func TestTopicListenerReconnectorCloseDuringReconnect(t *testing.T) {
+	ctx := xtest.Context(t)
+	stream := newReconnectorTestStream("session-1")
+	client := newReconnectorTestClient(
+		reconnectorTestConnectResult{stream: stream},
+		reconnectorTestConnectResult{block: true},
+	)
+	listener, _ := newTestTopicListenerReconnector(t, client)
+
+	require.NoError(t, listener.WaitInit(ctx))
+	waitReconnectorCall(ctx, t, client, 0)
+	stream.recvErr <- xerrors.Transport(status.Error(codes.Unavailable, "stream failed"))
+	waitReconnectorCall(ctx, t, client, 1)
+
+	closeTestTopicListenerReconnector(ctx, t, listener)
+}
+
+func TestTopicListenerReconnectorCloseUnblocksWaitInit(t *testing.T) {
+	ctx := xtest.Context(t)
+	client := newReconnectorTestClient(reconnectorTestConnectResult{block: true})
+	listener, _ := newTestTopicListenerReconnector(t, client)
+	waitReconnectorCall(ctx, t, client, 0)
+
+	require.NoError(t, listener.Close(ctx, ErrUserCloseTopic))
+	require.ErrorIs(t, listener.WaitInit(ctx), ErrUserCloseTopic)
+	require.NoError(t, listener.WaitStop(ctx))
+}


### PR DESCRIPTION
Refs #2288

fix listenerReconnctor to actually reconnect

## Pull request type


Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

`TopicListener` does not reconnect after a retryable gRPC stream failure. The affected listener stops receiving and delivering messages permanently, while `WaitStop` may remain blocked.

<img width="1140" height="616" alt="image" src="https://github.com/user-attachments/assets/d32cc8f1-eed5-460b-b8f8-e3097d69713a" />
<img width="1156" height="620" alt="image" src="https://github.com/user-attachments/assets/fafb24b2-3024-499f-aff8-3d5744d54207" />

Issue Number: #2288

## What is the new behavior?

- Recreates the listener stream after retryable connection, send, and receive failures.
- Uses the common topic retry classification and backoff mechanism.
- Cleans up the previous stream and its partition workers before reconnecting.
- Preserves correct `WaitInit`, `WaitStop`, `Close`, and `ReadSessionID` behavior across reconnects.
- Adds tests for initial connection retries, active stream failures, terminal errors, and shutdown during reconnect.
<img width="548" height="307" alt="image" src="https://github.com/user-attachments/assets/e21ab5ab-6194-40fb-a18c-9c3d4658fa96" />



