### PR TITLE
fix(query): publish session pool metrics during operations and retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-* Fixed query session pool busy and idle metrics being published only after the operation completed
+* Fixed query session pool metrics during checkout, session creation and warm-up, retries, and waiting for a session
 * Fixed session invalidation to follow the shared error policy for Query Service and Table API requests executed through Query Service, preserving sessions after gRPC `RESOURCE_EXHAUSTED` and `OUT_OF_RANGE`
 
 ## v3.151.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed query session pool busy and idle metrics being published only after the operation completed
+
 ## v3.151.2
 * Fixed `HashPartitionChooser` in topic multiwriter (now it works like in Kafka)
 

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -485,11 +485,7 @@ func (p *Pool[PT, T]) With(
 	f func(ctx context.Context, item PT) error,
 	opts ...retry.Option,
 ) (finalErr error) {
-	p.stats.Change(func(old dynamicStats) dynamicStats {
-		old.Concurrency++
-
-		return old
-	})
+	p.applyBatchStats(&dynamicStats{Concurrency: 1})
 
 	var batchChanges dynamicStats
 	defer func() {

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -178,7 +178,7 @@ func New[PT ItemConstraint[T], T any](
 
 	var batchChanges dynamicStats
 	err = p.warmUp(ctx, &batchChanges)
-	p.applyBatchStats(&batchChanges)
+	p.flushStats(&batchChanges)
 	if err != nil {
 		_ = p.Close(ctx)
 
@@ -221,16 +221,8 @@ func (p *Pool[PT, T]) warmUp(ctx context.Context, batchChanges *dynamicStats) er
 				defer cancel()
 			}
 
-			p.stats.Change(func(old dynamicStats) dynamicStats {
-				old.CreateInProgress++
-
-				return old
-			})
-			defer p.stats.Change(func(old dynamicStats) dynamicStats {
-				old.CreateInProgress--
-
-				return old
-			})
+			p.changeStats(dynamicStats{CreateInProgress: 1})
+			defer p.changeStats(dynamicStats{CreateInProgress: -1})
 
 			item, err := p.config.createItemFunc(ctx)
 			if err != nil {
@@ -287,12 +279,8 @@ func (p *Pool[PT, T]) warmUp(ctx context.Context, batchChanges *dynamicStats) er
 // not propagated. Creation is canceled when the pool is done, and
 // Config.createTimeout is applied when configured.
 func (p *Pool[PT, T]) createItem(ctx context.Context, batchChanges *dynamicStats) (PT, error) {
-	p.applyBatchStats(&dynamicStats{CreateInProgress: 1})
-	defer p.stats.Change(func(old dynamicStats) dynamicStats {
-		old.CreateInProgress--
-
-		return old
-	})
+	p.changeStats(dynamicStats{CreateInProgress: 1})
+	defer p.changeStats(dynamicStats{CreateInProgress: -1})
 
 	createCtx, cancelCreate := xcontext.WithDone(xcontext.ValueOnly(ctx), p.done)
 	defer cancelCreate()
@@ -370,7 +358,7 @@ func (p *Pool[PT, T]) checkItemAndError(item PT, err error) error {
 
 //nolint:funlen
 func (p *Pool[PT, T]) try(ctx context.Context,
-	f func(ctx context.Context, item PT) error, batchChanges *dynamicStats,
+	f func(ctx context.Context, item PT) error,
 ) (finalErr error) {
 	if onTry := p.config.trace.OnTry; onTry != nil {
 		onDone := onTry(&ctx,
@@ -401,12 +389,10 @@ func (p *Pool[PT, T]) try(ctx context.Context,
 		}()
 	}
 
-	defer func() {
-		p.applyBatchStats(batchChanges)
-		*batchChanges = dynamicStats{}
-	}()
+	var batchChanges dynamicStats
+	defer p.flushStats(&batchChanges)
 
-	info, err := p.getItem(ctx, batchChanges)
+	info, err := p.getItem(ctx, &batchChanges)
 	if err != nil {
 		if isRetriable(err) {
 			return xerrors.WithStackTrace(xerrors.Retryable(err))
@@ -426,7 +412,7 @@ func (p *Pool[PT, T]) try(ctx context.Context,
 	// Keep a successfully created item in the pool when the caller gives up, so
 	// the next request can reuse it.
 	if err := ctx.Err(); err != nil {
-		_ = p.putItem(ctx, info, batchChanges)
+		_ = p.putItem(ctx, info, &batchChanges)
 
 		return xerrors.WithStackTrace(err)
 	}
@@ -437,16 +423,15 @@ func (p *Pool[PT, T]) try(ctx context.Context,
 		batchChanges.InUse--
 
 		if err := p.checkItemAndError(info.item, finalErr); err != nil {
-			p.closeItem(ctx, info.item, batchChanges)
+			p.closeItem(ctx, info.item, &batchChanges)
 
 			return
 		}
 
-		_ = p.putItem(ctx, info, batchChanges)
+		_ = p.putItem(ctx, info, &batchChanges)
 	}()
 
-	p.applyBatchStats(batchChanges)
-	*batchChanges = dynamicStats{}
+	p.flushStats(&batchChanges)
 	err = f(ctx, info.item)
 	if err != nil {
 		return xerrors.WithStackTrace(err)
@@ -455,18 +440,23 @@ func (p *Pool[PT, T]) try(ctx context.Context,
 	return nil
 }
 
-func (p *Pool[PT, T]) applyBatchStats(batch *dynamicStats) {
+func (p *Pool[PT, T]) flushStats(batch *dynamicStats) {
+	p.changeStats(*batch)
+	*batch = dynamicStats{}
+}
+
+func (p *Pool[PT, T]) changeStats(delta dynamicStats) {
 	onChange := p.config.trace.OnChange
 
 	var stats dynamicStats
 	p.stats.Change(func(old dynamicStats) dynamicStats {
 		stats = old
 
-		stats.Concurrency += batch.Concurrency
-		stats.CreateInProgress += batch.CreateInProgress
-		stats.InUse += batch.InUse
-		stats.Idle += batch.Idle
-		stats.Size += batch.Size
+		stats.Concurrency += delta.Concurrency
+		stats.CreateInProgress += delta.CreateInProgress
+		stats.InUse += delta.InUse
+		stats.Idle += delta.Idle
+		stats.Size += delta.Size
 
 		return stats
 	})
@@ -485,14 +475,8 @@ func (p *Pool[PT, T]) With(
 	f func(ctx context.Context, item PT) error,
 	opts ...retry.Option,
 ) (finalErr error) {
-	p.applyBatchStats(&dynamicStats{Concurrency: 1})
-
-	var batchChanges dynamicStats
-	defer func() {
-		batchChanges.Concurrency--
-
-		p.applyBatchStats(&batchChanges)
-	}()
+	p.changeStats(dynamicStats{Concurrency: 1})
+	defer p.changeStats(dynamicStats{Concurrency: -1})
 
 	var attempts int
 
@@ -509,7 +493,7 @@ func (p *Pool[PT, T]) With(
 
 	err := retry.Retry(ctx, func(ctx context.Context) error {
 		attempts++
-		err := p.try(ctx, f, &batchChanges)
+		err := p.try(ctx, f)
 		if err != nil {
 			return xerrors.WithStackTrace(err)
 		}
@@ -547,7 +531,7 @@ func (p *Pool[PT, T]) Close(ctx context.Context) (finalErr error) {
 			batchChanges dynamicStats
 		)
 
-		defer p.applyBatchStats(&batchChanges)
+		defer p.flushStats(&batchChanges)
 
 		// Drain sema with one goroutine per slot (not a single loop) so all tokens are
 		// acquired in parallel: faster occupancy of the semaphore and shorter Close().

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -444,6 +444,8 @@ func (p *Pool[PT, T]) try(ctx context.Context,
 		_ = p.putItem(ctx, info, batchChanges)
 	}()
 
+	p.applyBatchStats(batchChanges)
+	*batchChanges = dynamicStats{}
 	err = f(ctx, info.item)
 	if err != nil {
 		return xerrors.WithStackTrace(err)

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -287,11 +287,7 @@ func (p *Pool[PT, T]) warmUp(ctx context.Context, batchChanges *dynamicStats) er
 // not propagated. Creation is canceled when the pool is done, and
 // Config.createTimeout is applied when configured.
 func (p *Pool[PT, T]) createItem(ctx context.Context, batchChanges *dynamicStats) (PT, error) {
-	p.stats.Change(func(old dynamicStats) dynamicStats {
-		old.CreateInProgress++
-
-		return old
-	})
+	p.applyBatchStats(&dynamicStats{CreateInProgress: 1})
 	defer p.stats.Change(func(old dynamicStats) dynamicStats {
 		old.CreateInProgress--
 

--- a/internal/pool/pool.go
+++ b/internal/pool/pool.go
@@ -401,6 +401,11 @@ func (p *Pool[PT, T]) try(ctx context.Context,
 		}()
 	}
 
+	defer func() {
+		p.applyBatchStats(batchChanges)
+		*batchChanges = dynamicStats{}
+	}()
+
 	info, err := p.getItem(ctx, batchChanges)
 	if err != nil {
 		if isRetriable(err) {

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -58,6 +58,28 @@ func TestPoolWithPublishesBusyStats(t *testing.T) {
 	}))
 }
 
+func TestPoolCreateItemPublishesInProgressStats(t *testing.T) {
+	var stats Stats
+	p := mustNewPool(t,
+		WithCreateItemFunc(func(context.Context) (*testItem, error) {
+			assert.Equal(t, 1, stats.CreateInProgress, "CreateInProgress")
+
+			return &testItem{}, nil
+		}),
+		WithTrace(&Trace[*testItem, testItem]{
+			OnChange: func(s Stats) {
+				stats = s
+			},
+		}),
+	)
+	defer mustClose(t, p)
+
+	var batchChanges dynamicStats
+	item, err := p.createItem(t.Context(), &batchChanges)
+	require.NoError(t, err)
+	require.NoError(t, item.Close(t.Context()))
+}
+
 type testItem struct {
 	v int32
 

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -80,6 +80,28 @@ func TestPoolCreateItemPublishesInProgressStats(t *testing.T) {
 	require.NoError(t, item.Close(t.Context()))
 }
 
+func TestPoolTryPublishesReturnedItemStats(t *testing.T) {
+	var stats Stats
+	p := mustNewPool(t,
+		WithLimit[*testItem](1),
+		WithTrace(&Trace[*testItem, testItem]{
+			OnChange: func(s Stats) {
+				stats = s
+			},
+		}),
+	)
+	defer mustClose(t, p)
+
+	retryErr := grpcStatus.Error(grpcCodes.ResourceExhausted, "retry operation")
+	var batchChanges dynamicStats
+	err := p.try(t.Context(), func(context.Context, *testItem) error {
+		return retryErr
+	}, &batchChanges)
+	require.ErrorIs(t, err, retryErr)
+	assert.Equal(t, 1, stats.Idle, "Idle")
+	assert.Equal(t, 0, stats.InUse, "InUse")
+}
+
 type testItem struct {
 	v int32
 

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -59,25 +59,36 @@ func TestPoolWithPublishesBusyStats(t *testing.T) {
 }
 
 func TestPoolCreateItemPublishesInProgressStats(t *testing.T) {
-	var stats Stats
-	p := mustNewPool(t,
-		WithCreateItemFunc(func(context.Context) (*testItem, error) {
-			assert.Equal(t, 1, stats.CreateInProgress, "CreateInProgress")
+	for _, createErr := range []error{nil, errors.New("create item failed")} {
+		var stats Stats
+		p := mustNewPool(t,
+			WithCreateItemFunc(func(context.Context) (*testItem, error) {
+				assert.Equal(t, 1, stats.CreateInProgress, "CreateInProgress")
+				if createErr != nil {
+					return nil, createErr
+				}
 
-			return &testItem{}, nil
-		}),
-		WithTrace(&Trace[*testItem, testItem]{
-			OnChange: func(s Stats) {
-				stats = s
-			},
-		}),
-	)
-	defer mustClose(t, p)
+				return &testItem{}, nil
+			}),
+			WithTrace(&Trace[*testItem, testItem]{
+				OnChange: func(s Stats) {
+					stats = s
+				},
+			}),
+		)
+		defer mustClose(t, p)
 
-	var batchChanges dynamicStats
-	item, err := p.createItem(t.Context(), &batchChanges)
-	require.NoError(t, err)
-	require.NoError(t, item.Close(t.Context()))
+		<-p.sema
+		defer func() { p.sema <- struct{}{} }()
+
+		var batchChanges dynamicStats
+		item, err := p.createItem(t.Context(), &batchChanges)
+		require.ErrorIs(t, err, createErr)
+		assert.Zero(t, stats.CreateInProgress, "CreateInProgress after creation (error: %v)", createErr)
+		if item != nil {
+			require.NoError(t, item.Close(t.Context()))
+		}
+	}
 }
 
 func TestPoolTryPublishesReturnedItemStats(t *testing.T) {
@@ -93,10 +104,9 @@ func TestPoolTryPublishesReturnedItemStats(t *testing.T) {
 	defer mustClose(t, p)
 
 	retryErr := grpcStatus.Error(grpcCodes.ResourceExhausted, "retry operation")
-	var batchChanges dynamicStats
 	err := p.try(t.Context(), func(context.Context, *testItem) error {
 		return retryErr
-	}, &batchChanges)
+	})
 	require.ErrorIs(t, err, retryErr)
 	assert.Equal(t, 1, stats.Idle, "Idle")
 	assert.Equal(t, 0, stats.InUse, "InUse")
@@ -218,7 +228,7 @@ func getItemWithFlush[PT ItemConstraint[T], T any](
 	p *Pool[PT, T],
 ) (*itemInfo[PT, T], error) {
 	var batchChanges dynamicStats
-	defer p.applyBatchStats(&batchChanges)
+	defer p.flushStats(&batchChanges)
 
 	return p.getItem(ctx, &batchChanges)
 }
@@ -229,7 +239,7 @@ func putItemWithFlush[PT ItemConstraint[T], T any](
 	info *itemInfo[PT, T],
 ) error {
 	var batchChanges dynamicStats
-	defer p.applyBatchStats(&batchChanges)
+	defer p.flushStats(&batchChanges)
 
 	return p.putItem(ctx, info, &batchChanges)
 }
@@ -1344,7 +1354,7 @@ func TestPool(t *testing.T) { //nolint:gocyclo
 						)
 						defer childCancel()
 						var batchChanges dynamicStats
-						defer p.applyBatchStats(&batchChanges)
+						defer p.flushStats(&batchChanges)
 
 						s, err := p.createItem(childCtx, &batchChanges)
 						if s == nil && err == nil {
@@ -2599,7 +2609,7 @@ func TestPoolPutItemRejectsWhenIdleAtLimit(t *testing.T) {
 	var createBatch dynamicStats
 	extraItem, err := p.createItem(ctx, &createBatch)
 	require.NoError(t, err)
-	p.applyBatchStats(&createBatch)
+	p.flushStats(&createBatch)
 
 	requirePoolStats(t, p, poolStats(limit, func(s *Stats) {
 		s.Size = limit + 1
@@ -2614,7 +2624,7 @@ func TestPoolPutItemRejectsWhenIdleAtLimit(t *testing.T) {
 
 	var putBatch dynamicStats
 	err = p.putItem(ctx, extraInfo, &putBatch)
-	p.applyBatchStats(&putBatch)
+	p.flushStats(&putBatch)
 
 	require.ErrorIs(t, err, errPoolIsOverflow)
 	require.Equal(t, int32(1), closed.Load())

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/ydb-platform/ydb-go-genproto/protos/Ydb"
 	grpcCodes "google.golang.org/grpc/codes"
@@ -30,6 +31,32 @@ import (
 	"github.com/ydb-platform/ydb-go-sdk/v3/testutil"
 	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
 )
+
+func TestPoolWithPublishesBusyStats(t *testing.T) {
+	// Regression: https://github.com/ydb-platform/ydb-go-sdk/issues/2295
+	var stats Stats
+	p := mustNewPool(t,
+		WithLimit[*testItem, testItem](1),
+		WithTrace(&Trace[*testItem, testItem]{
+			OnChange: func(s Stats) {
+				stats = s
+			},
+		}),
+	)
+	defer mustClose(t, p)
+
+	require.NoError(t, p.With(t.Context(), func(context.Context, *testItem) error {
+		assert.Equal(t, 1, stats.InUse, "InUse")
+
+		return nil
+	}))
+
+	require.NoError(t, p.With(t.Context(), func(context.Context, *testItem) error {
+		assert.Equal(t, 0, stats.Idle, "Idle")
+
+		return nil
+	}))
+}
 
 type testItem struct {
 	v int32

--- a/internal/pool/pool_test.go
+++ b/internal/pool/pool_test.go
@@ -102,6 +102,27 @@ func TestPoolTryPublishesReturnedItemStats(t *testing.T) {
 	assert.Equal(t, 0, stats.InUse, "InUse")
 }
 
+func TestPoolWithPublishesConcurrencyBeforeAttempt(t *testing.T) {
+	var stats Stats
+	p := mustNewPool(t,
+		WithTrace(&Trace[*testItem, testItem]{
+			OnChange: func(s Stats) {
+				stats = s
+			},
+			OnWith: func(*context.Context, stack.Caller) func(int, error) {
+				assert.Equal(t, 1, stats.Concurrency, "Concurrency")
+
+				return nil
+			},
+		}),
+	)
+	defer mustClose(t, p)
+
+	require.NoError(t, p.With(t.Context(), func(context.Context, *testItem) error {
+		return nil
+	}))
+}
+
 type testItem struct {
 	v int32
 

--- a/tests/integration/database_sql_metrics_test.go
+++ b/tests/integration/database_sql_metrics_test.go
@@ -21,14 +21,8 @@ func TestDatabaseSqlMetrics(t *testing.T) {
 
 	var (
 		scope    = newScope(t)
-		registry = &registryConfig{
-			details:    trace.DatabaseSQLEvents,
-			gauges:     newVec[gaugeVec](),
-			counters:   newVec[counterVec](),
-			timers:     newVec[timerVec](),
-			histograms: newVec[histogramVec](),
-		}
-		db = scope.SQLDriver(ydb.WithDatabaseSQLTrace(metrics.DatabaseSQL(registry)))
+		registry = newRegistryConfig(trace.DatabaseSQLEvents)
+		db       = scope.SQLDriver(ydb.WithDatabaseSQLTrace(metrics.DatabaseSQL(registry)))
 	)
 
 	require.Equal(t,
@@ -40,40 +34,39 @@ func TestDatabaseSqlMetrics(t *testing.T) {
 	cc1, err := db.Conn(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, cc1)
-	require.NotNil(t, registry.gauges.data["database.sql.conns{}"].gauges["database.sql.conns{}"])
-	require.EqualValues(t, 1, registry.gauges.data["database.sql.conns{}"].gauges["database.sql.conns{}"].value)
+	registry.gauges.AssertEqual(t, "database.sql.conns", 1)
 	require.Empty(t, registry.gauges.data["database.sql.tx{}"].gauges)
 
 	cc2, err := db.Conn(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, cc2)
-	require.EqualValues(t, 2, registry.gauges.data["database.sql.conns{}"].gauges["database.sql.conns{}"].value)
+	registry.gauges.AssertEqual(t, "database.sql.conns", 2)
 	require.Empty(t, registry.gauges.data["database.sql.tx{}"].gauges)
 
 	tx1, err := cc1.BeginTx(ctx, nil)
 	require.NoError(t, err)
 	require.NotNil(t, tx1)
 	require.NotEmpty(t, registry.gauges.data["database.sql.tx{}"].gauges)
-	require.EqualValues(t, 1, registry.gauges.data["database.sql.tx{}"].gauges["database.sql.tx{}"].value)
+	registry.gauges.AssertEqual(t, "database.sql.tx", 1)
 
 	require.NoError(t, tx1.Commit())
-	require.EqualValues(t, 0, registry.gauges.data["database.sql.tx{}"].gauges["database.sql.tx{}"].value)
+	registry.gauges.AssertEqual(t, "database.sql.tx", 0)
 
 	require.NoError(t, cc1.Close())
-	require.EqualValues(t, 2, registry.gauges.data["database.sql.conns{}"].gauges["database.sql.conns{}"].value)
+	registry.gauges.AssertEqual(t, "database.sql.conns", 2)
 
 	tx2, err := cc2.BeginTx(ctx, nil)
 	require.NoError(t, err)
 	require.NotNil(t, tx2)
 	require.NotEmpty(t, registry.gauges.data["database.sql.tx{}"].gauges)
-	require.EqualValues(t, 1, registry.gauges.data["database.sql.tx{}"].gauges["database.sql.tx{}"].value)
+	registry.gauges.AssertEqual(t, "database.sql.tx", 1)
 
 	require.NoError(t, tx2.Rollback())
-	require.EqualValues(t, 0, registry.gauges.data["database.sql.tx{}"].gauges["database.sql.tx{}"].value)
+	registry.gauges.AssertEqual(t, "database.sql.tx", 0)
 
 	require.NoError(t, cc2.Close())
-	require.EqualValues(t, 2, registry.gauges.data["database.sql.conns{}"].gauges["database.sql.conns{}"].value)
+	registry.gauges.AssertEqual(t, "database.sql.conns", 2)
 
 	require.NoError(t, db.Close())
-	require.EqualValues(t, 0, registry.gauges.data["database.sql.conns{}"].gauges["database.sql.conns{}"].value)
+	registry.gauges.AssertEqual(t, "database.sql.conns", 0)
 }

--- a/tests/integration/grpc_stopper_helper_test.go
+++ b/tests/integration/grpc_stopper_helper_test.go
@@ -50,6 +50,7 @@ func NewGrpcStopper(closeError error) *GrpcStopper {
 }
 
 // Stop interrupts the listed methods, or all methods if none are listed, until Start.
+// An interrupted RPC may keep running until its caller cancels the RPC context.
 func (l *GrpcStopper) Stop(methods ...string) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -87,7 +88,8 @@ func (l *GrpcStopper) Start() {
 
 // Pause holds unary calls and stream creation until Start, Stop, or context cancellation.
 // It applies to the listed methods, or all methods if none are listed.
-// Each call that reaches the pause sends a notification on the returned channel.
+// Repeated calls while paused keep the original methods and notification channel.
+// Each paused call sends a notification unless Start, Stop, or context cancellation releases it first.
 func (l *GrpcStopper) Pause(methods ...string) <-chan struct{} {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -175,22 +177,16 @@ func (l *GrpcStopper) UnaryClientInterceptor(
 		return err
 	}
 
-	result := make(chan error, 1)
-	go func() {
-		result <- invoker(ctx, method, req, reply, cc, opts...)
-	}()
-	select {
-	case <-stopChannel:
-		return l.stopError
-	case <-ctx.Done():
-		return ctx.Err()
-	case err := <-result:
-		if pauseErr := l.wait(ctx, method, stopChannel); pauseErr != nil {
-			return pauseErr
+	return l.intercept(method, func() error {
+		err := invoker(ctx, method, req, reply, cc, opts...)
+		if l.pauseState(method) != nil {
+			if pauseErr := l.wait(ctx, method, stopChannel); pauseErr != nil {
+				return pauseErr
+			}
 		}
 
 		return err
-	}
+	})
 }
 
 func (l *GrpcStopper) StreamClientInterceptor(

--- a/tests/integration/grpc_stopper_helper_test.go
+++ b/tests/integration/grpc_stopper_helper_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 // GrpcStopper interrupts gRPC calls with stopError between Stop and Start.
-// PauseOnlyOnMethods holds unary requests and responses, and stream creation, until Start.
+// Pause holds unary requests and responses, and stream creation, until Start.
 //
 // Usage:
 //
@@ -85,10 +85,10 @@ func (l *GrpcStopper) Start() {
 	}
 }
 
-// PauseOnlyOnMethods holds unary calls and stream creation until Start, Stop, or context cancellation.
+// Pause holds unary calls and stream creation until Start, Stop, or context cancellation.
 // It applies to the listed methods, or all methods if none are listed.
 // Each call that reaches the pause sends a notification on the returned channel.
-func (l *GrpcStopper) PauseOnlyOnMethods(methods ...string) <-chan struct{} {
+func (l *GrpcStopper) Pause(methods ...string) <-chan struct{} {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	if l.pause == nil {

--- a/tests/integration/metrics_registry_test.go
+++ b/tests/integration/metrics_registry_test.go
@@ -399,8 +399,10 @@ type gaugeCollection struct {
 }
 
 // AssertEqual checks an already published gauge without labels; it never creates a missing metric.
-func (gauges *gaugeCollection) AssertEqual(t testing.TB, name string, want float64) {
-	t.Helper()
+func (gauges *gaugeCollection) AssertEqual(t assert.TestingT, name string, want float64) {
+	if h, ok := t.(interface{ Helper() }); ok {
+		h.Helper()
+	}
 
 	key := nameLabelValuesToString(name, nil)
 	vec := gauges.get(key)

--- a/tests/integration/metrics_registry_test.go
+++ b/tests/integration/metrics_registry_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/ydb-platform/ydb-go-sdk/v3"
 	"github.com/ydb-platform/ydb-go-sdk/v3/metrics"
 	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
@@ -297,9 +299,21 @@ func (g *gauge) Name() string {
 }
 
 func (g *gauge) Value() string {
+	return fmt.Sprintf("%f", g.Float64())
+}
+
+func (g *gauge) Float64() float64 {
 	g.m.RLock()
 	defer g.m.RUnlock()
-	return fmt.Sprintf("%f", g.value)
+
+	return g.value
+}
+
+func (vec *gaugeVec) get(name string) *gauge {
+	vec.m.RLock()
+	defer vec.m.RUnlock()
+
+	return vec.gauges[name]
 }
 
 func (vec *gaugeVec) With(labels map[string]string) metrics.Gauge {
@@ -373,14 +387,53 @@ func (v *vec[T]) iterate(f func(element *T)) {
 	}
 }
 
+func (v *vec[T]) get(key string) *T {
+	v.mtx.RLock()
+	defer v.mtx.RUnlock()
+
+	return v.data[key]
+}
+
+type gaugeCollection struct {
+	*vec[gaugeVec]
+}
+
+// AssertEqual checks an already published gauge without labels; it never creates a missing metric.
+func (gauges *gaugeCollection) AssertEqual(t testing.TB, name string, want float64) {
+	t.Helper()
+
+	key := nameLabelValuesToString(name, nil)
+	vec := gauges.get(key)
+	if !assert.NotNil(t, vec, "metric vector %s must be registered", name) {
+		return
+	}
+
+	g := vec.get(key)
+	if !assert.NotNil(t, g, "metric %s must have been published", name) {
+		return
+	}
+
+	assert.Equal(t, want, g.Float64(), name)
+}
+
 // define custom registryConfig
 type registryConfig struct {
 	prefix     string
 	details    trace.Details
-	gauges     *vec[gaugeVec]
+	gauges     *gaugeCollection
 	counters   *vec[counterVec]
 	timers     *vec[timerVec]
 	histograms *vec[histogramVec]
+}
+
+func newRegistryConfig(details trace.Details) *registryConfig {
+	return &registryConfig{
+		details:    details,
+		gauges:     &gaugeCollection{vec: newVec[gaugeVec]()},
+		counters:   newVec[counterVec](),
+		timers:     newVec[timerVec](),
+		histograms: newVec[histogramVec](),
+	}
 }
 
 func (registry *registryConfig) CounterVec(name string, labelNames ...string) metrics.CounterVec {
@@ -431,13 +484,7 @@ func (registry *registryConfig) Details() trace.Details {
 }
 
 func withMetrics(t testing.TB, details trace.Details, interval time.Duration) ydb.Option {
-	registry := &registryConfig{
-		details:    details,
-		gauges:     newVec[gaugeVec](),
-		counters:   newVec[counterVec](),
-		timers:     newVec[timerVec](),
-		histograms: newVec[histogramVec](),
-	}
+	registry := newRegistryConfig(details)
 	var (
 		done       = make(chan struct{})
 		printState = func(log func(format string, args ...interface{}), header string) {

--- a/tests/integration/query_pool_metrics_test.go
+++ b/tests/integration/query_pool_metrics_test.go
@@ -1,0 +1,104 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ydb-platform/ydb-go-sdk/v3"
+	"github.com/ydb-platform/ydb-go-sdk/v3/metrics"
+	"github.com/ydb-platform/ydb-go-sdk/v3/query"
+	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
+)
+
+func TestQueryPoolMetricsWhileSessionIsCheckedOut(t *testing.T) {
+	// Regression: https://github.com/ydb-platform/ydb-go-sdk/issues/2295
+	scope := newScope(t)
+	ctx, cancel := context.WithTimeout(scope.Ctx, 30*time.Second)
+	defer cancel()
+
+	registry := &registryConfig{
+		details:    trace.QueryPoolEvents,
+		gauges:     newVec[gaugeVec](),
+		counters:   newVec[counterVec](),
+		timers:     newVec[timerVec](),
+		histograms: newVec[histogramVec](),
+	}
+	db := scope.Driver(
+		ydb.WithSessionPoolSizeLimit(1),
+		metrics.WithTraces(registry),
+	)
+
+	// Prime the explicit session pool without relying on the warm-up option.
+	var sessionID string
+	require.NoError(t, db.Query().Do(ctx, func(ctx context.Context, s query.Session) error {
+		sessionID = s.ID()
+
+		return s.Exec(ctx, "SELECT 1")
+	}, query.WithIdempotent()))
+	require.NotEmpty(t, sessionID)
+
+	t.Run("IdleBeforeCheckout", func(t *testing.T) {
+		assertQueryPoolOccupancy(t, registry, 0, 1)
+	})
+
+	require.NoError(t, db.Query().Do(ctx, func(ctx context.Context, s query.Session) error {
+		if err := s.Exec(ctx, "SELECT 1"); err != nil {
+			return err
+		}
+
+		// Do retains the session until this callback returns, even after Exec completes.
+		// Inspect the actual metrics adapter output while the only pool slot is occupied.
+		t.Run("CheckedOut", func(t *testing.T) {
+			require.Equal(t, sessionID, s.ID(), "the primed session must be reused")
+			assertQueryPoolOccupancy(t, registry, 1, 0)
+		})
+
+		return nil
+	}, query.WithIdempotent()))
+
+	t.Run("IdleAfterReturn", func(t *testing.T) {
+		assertQueryPoolOccupancy(t, registry, 0, 1)
+	})
+}
+
+func assertQueryPoolOccupancy(t *testing.T, registry *registryConfig, inUse, idle float64) {
+	t.Helper()
+
+	for name, want := range map[string]float64{
+		"limit":              1,
+		"index":              1,
+		"create_in_progress": 0,
+		"in_use":             inUse,
+		"idle":               idle,
+	} {
+		metricName := "ydb.query.pool.size." + name + "{}"
+		assert.Equal(t, want, queryPoolGaugeValue(t, registry, metricName), metricName)
+	}
+}
+
+func queryPoolGaugeValue(t *testing.T, registry *registryConfig, name string) float64 {
+	t.Helper()
+
+	registry.gauges.mtx.RLock()
+	defer registry.gauges.mtx.RUnlock()
+
+	vec := registry.gauges.data[name]
+	require.NotNil(t, vec, "metric vector %s must be registered", name)
+
+	vec.m.RLock()
+	defer vec.m.RUnlock()
+
+	g := vec.gauges[name]
+	require.NotNil(t, g, "metric %s must have been published", name)
+
+	g.m.RLock()
+	defer g.m.RUnlock()
+
+	return g.value
+}

--- a/tests/integration/query_pool_metrics_test.go
+++ b/tests/integration/query_pool_metrics_test.go
@@ -5,9 +5,7 @@ package integration
 import (
 	"context"
 	"testing"
-	"time"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3"
@@ -19,86 +17,33 @@ import (
 func TestQueryPoolMetricsWhileSessionIsCheckedOut(t *testing.T) {
 	// Regression: https://github.com/ydb-platform/ydb-go-sdk/issues/2295
 	scope := newScope(t)
-	ctx, cancel := context.WithTimeout(scope.Ctx, 30*time.Second)
-	defer cancel()
 
-	registry := &registryConfig{
-		details:    trace.QueryPoolEvents,
-		gauges:     newVec[gaugeVec](),
-		counters:   newVec[counterVec](),
-		timers:     newVec[timerVec](),
-		histograms: newVec[histogramVec](),
-	}
+	registry := newRegistryConfig(trace.QueryPoolEvents)
 	db := scope.Driver(
 		ydb.WithSessionPoolSizeLimit(1),
 		metrics.WithTraces(registry),
 	)
 
-	// Prime the explicit session pool without relying on the warm-up option.
-	var sessionID string
-	require.NoError(t, db.Query().Do(ctx, func(ctx context.Context, s query.Session) error {
-		sessionID = s.ID()
-
-		return s.Exec(ctx, "SELECT 1")
-	}, query.WithIdempotent()))
-	require.NotEmpty(t, sessionID)
-
-	t.Run("IdleBeforeCheckout", func(t *testing.T) {
-		assertQueryPoolOccupancy(t, registry, 0, 1)
-	})
-
-	require.NoError(t, db.Query().Do(ctx, func(ctx context.Context, s query.Session) error {
+	require.NoError(t, db.Query().Do(scope.Ctx, func(ctx context.Context, s query.Session) error {
 		if err := s.Exec(ctx, "SELECT 1"); err != nil {
 			return err
 		}
 
 		// Do retains the session until this callback returns, even after Exec completes.
 		// Inspect the actual metrics adapter output while the only pool slot is occupied.
-		t.Run("CheckedOut", func(t *testing.T) {
-			require.Equal(t, sessionID, s.ID(), "the primed session must be reused")
-			assertQueryPoolOccupancy(t, registry, 1, 0)
-		})
+		registry.gauges.AssertEqual(t, "ydb.query.pool.size.in_use", 1)
 
 		return nil
 	}, query.WithIdempotent()))
 
-	t.Run("IdleAfterReturn", func(t *testing.T) {
-		assertQueryPoolOccupancy(t, registry, 0, 1)
-	})
-}
+	require.NoError(t, db.Query().Do(scope.Ctx, func(ctx context.Context, s query.Session) error {
+		if err := s.Exec(ctx, "SELECT 1"); err != nil {
+			return err
+		}
 
-func assertQueryPoolOccupancy(t *testing.T, registry *registryConfig, inUse, idle float64) {
-	t.Helper()
+		// The reused session is checked out again and must no longer be counted as idle.
+		registry.gauges.AssertEqual(t, "ydb.query.pool.size.idle", 0)
 
-	for name, want := range map[string]float64{
-		"limit":              1,
-		"index":              1,
-		"create_in_progress": 0,
-		"in_use":             inUse,
-		"idle":               idle,
-	} {
-		metricName := "ydb.query.pool.size." + name + "{}"
-		assert.Equal(t, want, queryPoolGaugeValue(t, registry, metricName), metricName)
-	}
-}
-
-func queryPoolGaugeValue(t *testing.T, registry *registryConfig, name string) float64 {
-	t.Helper()
-
-	registry.gauges.mtx.RLock()
-	defer registry.gauges.mtx.RUnlock()
-
-	vec := registry.gauges.data[name]
-	require.NotNil(t, vec, "metric vector %s must be registered", name)
-
-	vec.m.RLock()
-	defer vec.m.RUnlock()
-
-	g := vec.gauges[name]
-	require.NotNil(t, g, "metric %s must have been published", name)
-
-	g.m.RLock()
-	defer g.m.RUnlock()
-
-	return g.value
+		return nil
+	}, query.WithIdempotent()))
 }

--- a/tests/integration/query_pool_metrics_test.go
+++ b/tests/integration/query_pool_metrics_test.go
@@ -70,7 +70,7 @@ func TestQueryPoolMetricsWhileSessionIsBeingCreated(t *testing.T) {
 		))),
 	)
 	client := db.Query()
-	paused := stopper.PauseOnlyOnMethods(Ydb_Query_V1.QueryService_CreateSession_FullMethodName)
+	paused := stopper.Pause(Ydb_Query_V1.QueryService_CreateSession_FullMethodName)
 
 	go func() {
 		select {
@@ -122,7 +122,7 @@ func TestQueryPoolMetricsWhileWaitingForSession(t *testing.T) {
 		))),
 	)
 	client := db.Query()
-	paused := stopper.PauseOnlyOnMethods(Ydb_Query_V1.QueryService_ExecuteQuery_FullMethodName)
+	paused := stopper.Pause(Ydb_Query_V1.QueryService_ExecuteQuery_FullMethodName)
 	group, ctx := errgroup.WithContext(scope.Ctx)
 	group.Go(func() error {
 		return client.Do(ctx, func(ctx context.Context, s query.Session) error {

--- a/tests/integration/query_pool_metrics_test.go
+++ b/tests/integration/query_pool_metrics_test.go
@@ -4,11 +4,20 @@ package integration
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/ydb-platform/ydb-go-genproto/Ydb_Query_V1"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3"
+	"github.com/ydb-platform/ydb-go-sdk/v3/config"
 	"github.com/ydb-platform/ydb-go-sdk/v3/metrics"
 	"github.com/ydb-platform/ydb-go-sdk/v3/query"
 	"github.com/ydb-platform/ydb-go-sdk/v3/trace"
@@ -46,4 +55,108 @@ func TestQueryPoolMetricsWhileSessionIsCheckedOut(t *testing.T) {
 
 		return nil
 	}, query.WithIdempotent()))
+}
+
+func TestQueryPoolMetricsWhileSessionIsBeingCreated(t *testing.T) {
+	scope := newScope(t)
+	registry := newRegistryConfig(trace.QueryPoolEvents)
+	stopper := NewGrpcStopper(errors.New("stop gRPC for test"))
+
+	db := scope.Driver(
+		ydb.WithSessionPoolSizeLimit(1),
+		metrics.WithTraces(registry),
+		ydb.With(config.WithGrpcOptions(grpc.WithChainUnaryInterceptor(
+			stopper.UnaryClientInterceptor,
+		))),
+	)
+	client := db.Query()
+	paused := stopper.PauseOnlyOnMethods(Ydb_Query_V1.QueryService_CreateSession_FullMethodName)
+
+	go func() {
+		select {
+		case <-paused:
+			registry.gauges.AssertEqual(t, "ydb.query.pool.size.concurrency", 1)
+			registry.gauges.AssertEqual(t, "ydb.query.pool.size.create_in_progress", 1)
+		case <-scope.Ctx.Done():
+		}
+		stopper.Start()
+	}()
+	require.NoError(t, client.Do(scope.Ctx, func(ctx context.Context, s query.Session) error {
+		return s.Exec(ctx, "SELECT 1")
+	}, query.WithIdempotent()))
+}
+
+func TestQueryPoolMetricsBetweenRetryAttempts(t *testing.T) {
+	scope := newScope(t)
+	registry := newRegistryConfig(trace.QueryPoolEvents)
+	stopper := NewGrpcStopper(status.Error(codes.ResourceExhausted, "retry operation"))
+	stopper.Stop(Ydb_Query_V1.QueryService_ExecuteQuery_FullMethodName)
+	db := scope.Driver(
+		ydb.WithSessionPoolSizeLimit(1),
+		metrics.WithTraces(registry),
+		ydb.With(config.WithGrpcOptions(grpc.WithChainStreamInterceptor(
+			stopper.StreamClientInterceptor,
+		))),
+	)
+	require.NoError(t, db.Query().Do(scope.Ctx, func(ctx context.Context, s query.Session) error {
+		return s.Exec(ctx, "SELECT 1")
+	}, query.WithIdempotent(), query.WithRetryBudget(retryBudgetFunc(func(context.Context) error {
+		// Acquire runs after the session is returned and before the next attempt.
+		registry.gauges.AssertEqual(t, "ydb.query.pool.size.idle", 1)
+		registry.gauges.AssertEqual(t, "ydb.query.pool.size.in_use", 0)
+		stopper.Start()
+
+		return nil
+	}))))
+}
+
+func TestQueryPoolMetricsWhileWaitingForSession(t *testing.T) {
+	scope := newScope(t)
+	registry := newRegistryConfig(trace.QueryPoolEvents)
+	stopper := NewGrpcStopper(errors.New("stop gRPC for test"))
+	db := scope.Driver(
+		ydb.WithSessionPoolSizeLimit(1),
+		metrics.WithTraces(registry),
+		ydb.With(config.WithGrpcOptions(grpc.WithChainStreamInterceptor(
+			stopper.StreamClientInterceptor,
+		))),
+	)
+	client := db.Query()
+	paused := stopper.PauseOnlyOnMethods(Ydb_Query_V1.QueryService_ExecuteQuery_FullMethodName)
+	group, ctx := errgroup.WithContext(scope.Ctx)
+	group.Go(func() error {
+		return client.Do(ctx, func(ctx context.Context, s query.Session) error {
+			return s.Exec(ctx, "SELECT 1")
+		}, query.WithIdempotent())
+	})
+	// Let the initial checkout publish its metrics before starting the next Do.
+	select {
+	case <-paused:
+	case <-ctx.Done():
+	}
+	group.Go(func() error {
+		return client.Do(ctx, func(ctx context.Context, s query.Session) error {
+			return s.Exec(ctx, "SELECT 1")
+		}, query.WithIdempotent())
+	})
+	group.Go(func() error {
+		defer stopper.Start()
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		// One Do holds the only session until these checks finish.
+		assert.EventuallyWithT(t, func(t *assert.CollectT) {
+			registry.gauges.AssertEqual(t, "ydb.query.pool.size.concurrency", 2)
+			registry.gauges.AssertEqual(t, "ydb.query.pool.size.waiters_queue", 1)
+		}, time.Second, time.Millisecond)
+
+		return nil
+	})
+	require.NoError(t, group.Wait())
+}
+
+type retryBudgetFunc func(context.Context) error
+
+func (f retryBudgetFunc) Acquire(ctx context.Context) error {
+	return f(ctx)
 }

--- a/tests/integration/topic_grpc_stopper_helper_test.go
+++ b/tests/integration/topic_grpc_stopper_helper_test.go
@@ -1,72 +1,199 @@
 //go:build integration
-// +build integration
 
 package integration
 
 import (
 	"context"
+	"slices"
+	"sync"
 
 	"google.golang.org/grpc"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/empty"
 )
 
-// GrpcStopper use interceptors for stop any real grpc activity on grpc channel and return error for any calls
+// GrpcStopper interrupts gRPC calls with stopError between Stop and Start.
+// PauseOnlyOnMethods holds unary requests and responses, and stream creation, until Start.
 //
 // Usage:
 //
-//		grpcStopper := xtest.NewGrpcStopper()
+//	grpcStopper := NewGrpcStopper(errors.New("test error"))
 //
-//		db, err := ydb.Open(context.Background(), connectionString,
-//	     ...
-//			ydb.With(config.WithGrpcOptions(grpc.WithChainUnaryInterceptor(grpcStopper.UnaryClientInterceptor)),
-//			ydb.With(config.WithGrpcOptions(grpc.WithStreamInterceptor(grpcStopper.StreamClientInterceptor)),
-//		),
+//	db, err := ydb.Open(context.Background(), connectionString,
+//		ydb.With(config.WithGrpcOptions(
+//			grpc.WithChainUnaryInterceptor(grpcStopper.UnaryClientInterceptor),
+//			grpc.WithChainStreamInterceptor(grpcStopper.StreamClientInterceptor),
+//		)),
+//	)
 //
-//		grpcStopper.Stop(errors.New("test error"))
-//
-// )
+//	grpcStopper.Stop()  // Inject the configured error into gRPC calls.
+//	grpcStopper.Start() // Allow subsequent calls through again.
 type GrpcStopper struct {
-	stopChannel empty.Chan
-	stopError   error
+	mu           sync.Mutex
+	stopped      bool
+	stopChannels map[string]empty.Chan
+	stopError    error
+	pause        *grpcPause
 }
 
-func NewGrpcStopper(closeError error) GrpcStopper {
-	return GrpcStopper{
-		stopChannel: make(empty.Chan),
-		stopError:   closeError,
+type grpcPause struct {
+	reached empty.Chan
+	resume  empty.Chan
+	methods []string
+}
+
+func NewGrpcStopper(closeError error) *GrpcStopper {
+	return &GrpcStopper{
+		stopChannels: make(map[string]empty.Chan),
+		stopError:    closeError,
 	}
 }
 
-func (l GrpcStopper) Stop() {
-	close(l.stopChannel)
+// Stop interrupts the listed methods, or all methods if none are listed, until Start.
+func (l *GrpcStopper) Stop(methods ...string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if len(methods) == 0 {
+		l.stopped = true
+	}
+	for _, method := range methods {
+		if l.stopChannels[method] == nil {
+			l.stopChannels[method] = make(empty.Chan)
+		}
+	}
+	for method, ch := range l.stopChannels {
+		if (l.stopped || slices.Contains(methods, method)) && !isClosed(ch) {
+			close(ch)
+		}
+	}
 }
 
-func (l GrpcStopper) UnaryClientInterceptor(
+// Start resumes paused calls and allows subsequent calls through, including calls on existing streams.
+// Calls interrupted by Stop are not retried; closed streams stay closed.
+func (l *GrpcStopper) Start() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.stopped = false
+	for method, ch := range l.stopChannels {
+		if isClosed(ch) {
+			l.stopChannels[method] = make(empty.Chan)
+		}
+	}
+	if l.pause != nil {
+		close(l.pause.resume)
+		l.pause = nil
+	}
+}
+
+// PauseOnlyOnMethods holds unary calls and stream creation until Start, Stop, or context cancellation.
+// It applies to the listed methods, or all methods if none are listed.
+// Each call that reaches the pause sends a notification on the returned channel.
+func (l *GrpcStopper) PauseOnlyOnMethods(methods ...string) <-chan struct{} {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.pause == nil {
+		l.pause = &grpcPause{
+			reached: make(empty.Chan),
+			resume:  make(empty.Chan),
+			methods: slices.Clone(methods),
+		}
+	}
+
+	return l.pause.reached
+}
+
+func (l *GrpcStopper) pauseState(method string) *grpcPause {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.pause == nil {
+		return nil
+	}
+	if len(l.pause.methods) > 0 && !slices.Contains(l.pause.methods, method) {
+		return nil
+	}
+
+	return l.pause
+}
+
+func (l *GrpcStopper) wait(ctx context.Context, method string, stopChannel empty.Chan) error {
+	for {
+		if isClosed(stopChannel) {
+			return l.stopError
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		pause := l.pauseState(method)
+		if pause == nil {
+			return nil
+		}
+		select {
+		case pause.reached <- struct{}{}:
+		case <-pause.resume:
+			continue
+		case <-stopChannel:
+			return l.stopError
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		select {
+		case <-pause.resume:
+		case <-stopChannel:
+			return l.stopError
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func (l *GrpcStopper) stopSignal(method string) empty.Chan {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	ch := l.stopChannels[method]
+	if ch == nil {
+		ch = make(empty.Chan)
+		l.stopChannels[method] = ch
+		if l.stopped {
+			close(ch)
+		}
+	}
+
+	return ch
+}
+
+func (l *GrpcStopper) UnaryClientInterceptor(
 	ctx context.Context,
 	method string,
-	req, reply interface{},
+	req, reply any,
 	cc *grpc.ClientConn,
 	invoker grpc.UnaryInvoker,
 	opts ...grpc.CallOption,
 ) error {
-	if isClosed(l.stopChannel) {
-		return l.stopError
+	stopChannel := l.stopSignal(method)
+	if err := l.wait(ctx, method, stopChannel); err != nil {
+		return err
 	}
 
-	resChan := make(chan error, 1)
+	result := make(chan error, 1)
 	go func() {
-		resChan <- invoker(ctx, method, req, reply, cc, opts...)
+		result <- invoker(ctx, method, req, reply, cc, opts...)
 	}()
 	select {
-	case <-l.stopChannel:
+	case <-stopChannel:
 		return l.stopError
-	case err := <-resChan:
+	case <-ctx.Done():
+		return ctx.Err()
+	case err := <-result:
+		if pauseErr := l.wait(ctx, method, stopChannel); pauseErr != nil {
+			return pauseErr
+		}
+
 		return err
 	}
 }
 
-func (l GrpcStopper) StreamClientInterceptor(
+func (l *GrpcStopper) StreamClientInterceptor(
 	ctx context.Context,
 	desc *grpc.StreamDesc,
 	cc *grpc.ClientConn,
@@ -74,81 +201,54 @@ func (l GrpcStopper) StreamClientInterceptor(
 	streamer grpc.Streamer,
 	opts ...grpc.CallOption,
 ) (grpc.ClientStream, error) {
-	select {
-	case <-l.stopChannel:
-		// grpc stopped
-		return nil, l.stopError
-	default:
+	if err := l.wait(ctx, method, l.stopSignal(method)); err != nil {
+		return nil, err
 	}
 
 	stream, err := streamer(ctx, desc, cc, method, opts...)
-	streamWrapper := newGrpcStopperStream(stream, l.stopChannel, l.stopError)
 	if stream != nil {
-		stream = streamWrapper
+		stream = GrpcStopperStream{ClientStream: stream, stopper: l, method: method}
 	}
+
 	return stream, err
 }
 
-type GrpcStopperStream struct {
-	stopChannel empty.Chan
-	stopError   error
-	grpc.ClientStream
+func (l *GrpcStopper) intercept(method string, call func() error) error {
+	// Keep this generation so Start cannot hide Stop from an in-flight call.
+	stopChannel := l.stopSignal(method)
+	if isClosed(stopChannel) {
+		return l.stopError
+	}
+
+	resChan := make(chan error, 1)
+	go func() {
+		resChan <- call()
+	}()
+	select {
+	case <-stopChannel:
+		return l.stopError
+	case err := <-resChan:
+		return err
+	}
 }
 
-func newGrpcStopperStream(stream grpc.ClientStream, stopChannel empty.Chan, stopError error) GrpcStopperStream {
-	return GrpcStopperStream{stopChannel: stopChannel, ClientStream: stream, stopError: stopError}
+type GrpcStopperStream struct {
+	grpc.ClientStream
+
+	stopper *GrpcStopper
+	method  string
 }
 
 func (g GrpcStopperStream) CloseSend() error {
-	if isClosed(g.stopChannel) {
-		return g.stopError
-	}
-
-	resChan := make(chan error, 1)
-	go func() {
-		resChan <- g.ClientStream.CloseSend()
-	}()
-	select {
-	case <-g.stopChannel:
-		return g.stopError
-	case err := <-resChan:
-		return err
-	}
+	return g.stopper.intercept(g.method, g.ClientStream.CloseSend)
 }
 
-func (g GrpcStopperStream) SendMsg(m interface{}) error {
-	if isClosed(g.stopChannel) {
-		return g.stopError
-	}
-
-	resChan := make(chan error, 1)
-	go func() {
-		resChan <- g.ClientStream.SendMsg(m)
-	}()
-	select {
-	case <-g.stopChannel:
-		return g.stopError
-	case err := <-resChan:
-		return err
-	}
+func (g GrpcStopperStream) SendMsg(m any) error {
+	return g.stopper.intercept(g.method, func() error { return g.ClientStream.SendMsg(m) })
 }
 
-func (g GrpcStopperStream) RecvMsg(m interface{}) error {
-	if isClosed(g.stopChannel) {
-		return g.stopError
-	}
-
-	resChan := make(chan error, 1)
-	go func() {
-		resChan <- g.ClientStream.RecvMsg(m)
-	}()
-
-	select {
-	case <-g.stopChannel:
-		return g.stopError
-	case err := <-resChan:
-		return err
-	}
+func (g GrpcStopperStream) RecvMsg(m any) error {
+	return g.stopper.intercept(g.method, func() error { return g.ClientStream.RecvMsg(m) })
 }
 
 func isClosed(ch empty.Chan) bool {


### PR DESCRIPTION
Query pool metrics could report all sessions as idle while operations were holding them. Creation, retry, and semaphore-waiting states were also missing from published snapshots. This change publishes the relevant state before it is observed by an operation or retry caller. Fixes #2295.

- Publish checkout before the operation callback and return-to-pool changes before the next retry attempt.
- Publish concurrency when entering and leaving `With`, including calls waiting for a session.
- Publish both creation transitions, including completion with an error and pool warm-up.
- Keep each attempt's pending changes inside `try`, with shared `changeStats` and `flushStats` helpers.

Unit tests cover the nearest publication points. Four integration regressions check real exported gauges during checkout, creation, retries, and waiting for the only session. They use the shared metrics registry and `GrpcStopper`, whose method-filtered `Pause` supports per-call notifications and preserves the shared completed-result priority.

A successful attempt reusing a session now publishes four snapshots: entry concurrency, checkout, return, and exit concurrency. Creation and retries can add notifications. This increases gauge-update and enabled DEBUG-log volume; batching these observable transitions together would hide the states this PR fixes.

Validation on the local implementation:

- `go test -race ./...`: passed.
- `golangci-lint run ./...`: passed.
- All four query pool metrics integration tests passed against local YDB with `-race`, three runs each.
- Creation-completion assertions fail with 1 instead of 0 when an overlay restores the old unpublished decrement; they pass with this implementation for both successful and failed creation.
- A separate real-YDB lifecycle audit checked all seven exported pool gauges during creation, first checkout, return, and session reuse; all matched for this implementation.

The existing pool benchmark was compared before and after refactoring, with 22 allocations/op unchanged. It has no `OnChange` subscriber, so it does not measure the Prometheus-adapter or DEBUG-logging cost.
