### PR TITLE
fix(query): respect session invalidation policy for transport errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-* Fixed query sessions being invalidated after gRPC `RESOURCE_EXHAUSTED`
+* Fixed session invalidation to follow the shared error policy for Query Service and Table API requests executed through Query Service, preserving sessions after gRPC `RESOURCE_EXHAUSTED` and `OUT_OF_RANGE`
 
 ## v3.151.2
 * Fixed `HashPartitionChooser` in topic multiwriter (now it works like in Kafka)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Fixed query sessions being invalidated after gRPC `RESOURCE_EXHAUSTED`
+
 ## v3.151.2
 * Fixed `HashPartitionChooser` in topic multiwriter (now it works like in Kafka)
 

--- a/internal/query/session_core.go
+++ b/internal/query/session_core.go
@@ -402,7 +402,7 @@ func StatusFromErr(err error) Status {
 	}
 
 	switch {
-	case xerrors.IsTransportError(err):
+	case xerrors.IsTransportError(err) && xerrors.MustDeleteTableOrQuerySession(err):
 		return StatusError
 	case xerrors.IsOperationError(err, Ydb.StatusIds_SESSION_BUSY):
 		return StatusError

--- a/internal/query/session_status_test.go
+++ b/internal/query/session_status_test.go
@@ -28,9 +28,19 @@ func TestStatusFromErr(t *testing.T) {
 			expected: StatusError,
 		},
 		{
-			name:     "TransportError returns StatusError",
+			name:     "TransportError UNAVAILABLE returns StatusError",
 			err:      xerrors.Transport(grpcStatus.Error(grpcCodes.Unavailable, "unavailable")),
 			expected: StatusError,
+		},
+		{
+			name:     "TransportError RESOURCE_EXHAUSTED returns StatusUnknown",
+			err:      xerrors.Transport(grpcStatus.Error(grpcCodes.ResourceExhausted, "")),
+			expected: StatusUnknown,
+		},
+		{
+			name:     "TransportError OUT_OF_RANGE returns StatusUnknown",
+			err:      xerrors.Transport(grpcStatus.Error(grpcCodes.OutOfRange, "")),
+			expected: StatusUnknown,
 		},
 		{
 			name:     "UnknownError returns StatusUnknown",

--- a/internal/query/session_test.go
+++ b/internal/query/session_test.go
@@ -48,15 +48,6 @@ func TestSessionBeginLazyTxDeadSession(t *testing.T) {
 	require.True(t, xerrors.IsOperationError(err, Ydb.StatusIds_BAD_SESSION))
 }
 
-func TestSessionResourceExhaustedKeepsAlive(t *testing.T) {
-	s := &Session{Core: &sessionCore{}}
-	s.SetStatus(StatusInUse)
-
-	s.onSessionError(xerrors.Transport(grpcStatus.Error(grpcCodes.ResourceExhausted, "retry operation")))
-
-	require.True(t, s.IsAlive())
-}
-
 func TestSessionOnErrorRespectsDeletionPolicy(t *testing.T) {
 	testErrors := []error{
 		errors.New("user error"),

--- a/internal/query/session_test.go
+++ b/internal/query/session_test.go
@@ -47,6 +47,15 @@ func TestSessionBeginLazyTxDeadSession(t *testing.T) {
 	require.True(t, xerrors.IsOperationError(err, Ydb.StatusIds_BAD_SESSION))
 }
 
+func TestSessionResourceExhaustedKeepsAlive(t *testing.T) {
+	s := &Session{Core: &sessionCore{}}
+	s.SetStatus(StatusInUse)
+
+	s.onSessionError(xerrors.Transport(grpcStatus.Error(grpcCodes.ResourceExhausted, "retry operation")))
+
+	require.True(t, s.IsAlive())
+}
+
 func TestSessionClosedOnQueryError(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/query/session_test.go
+++ b/internal/query/session_test.go
@@ -2,6 +2,7 @@ package query
 
 import (
 	"context"
+	"errors"
 	"io"
 	"testing"
 
@@ -54,6 +55,36 @@ func TestSessionResourceExhaustedKeepsAlive(t *testing.T) {
 	s.onSessionError(xerrors.Transport(grpcStatus.Error(grpcCodes.ResourceExhausted, "retry operation")))
 
 	require.True(t, s.IsAlive())
+}
+
+func TestSessionOnErrorRespectsDeletionPolicy(t *testing.T) {
+	testErrors := []error{
+		errors.New("user error"),
+		io.EOF,
+		context.Canceled,
+		context.DeadlineExceeded,
+	}
+	for code := grpcCodes.Canceled; code <= grpcCodes.Unauthenticated; code++ {
+		err := grpcStatus.Error(code, "")
+		testErrors = append(testErrors, err, xerrors.Transport(err))
+	}
+	for code := range Ydb.StatusIds_StatusCode_name {
+		status := Ydb.StatusIds_StatusCode(code)
+		if status != Ydb.StatusIds_SUCCESS {
+			testErrors = append(testErrors, xerrors.Operation(xerrors.WithStatusCode(status)))
+		}
+	}
+
+	for _, err := range testErrors {
+		t.Run(err.Error(), func(t *testing.T) {
+			s := &Session{Core: &sessionCore{}}
+			s.SetStatus(StatusInUse)
+
+			s.onSessionError(err)
+
+			require.Equal(t, !xerrors.MustDeleteTableOrQuerySession(err), s.IsAlive())
+		})
+	}
 }
 
 func TestSessionClosedOnQueryError(t *testing.T) {

--- a/internal/table/test/execute_test.go
+++ b/internal/table/test/execute_test.go
@@ -5,12 +5,52 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/ydb-platform/ydb-go-genproto/Ydb_Query_V1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3"
+	"github.com/ydb-platform/ydb-go-sdk/v3/config"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/mock"
 	"github.com/ydb-platform/ydb-go-sdk/v3/table"
 	"github.com/ydb-platform/ydb-go-sdk/v3/table/result/indexed"
 )
+
+func TestTableSessionExecuteOverQueryKeepsAlive(t *testing.T) {
+	for _, code := range []codes.Code{codes.ResourceExhausted, codes.OutOfRange} {
+		t.Run(code.String(), func(t *testing.T) {
+			mockSrv := mock.Server(t)
+			ctx := t.Context()
+			driver, err := ydb.Open(ctx, mockSrv.ConnString(),
+				ydb.WithAnonymousCredentials(),
+				ydb.WithExecuteDataQueryOverQueryClient(true),
+				ydb.With(config.WithGrpcOptions(grpc.WithChainStreamInterceptor(
+					func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn,
+						method string, streamer grpc.Streamer, opts ...grpc.CallOption,
+					) (grpc.ClientStream, error) {
+						if method == Ydb_Query_V1.QueryService_ExecuteQuery_FullMethodName {
+							return nil, status.Error(code, "query failed")
+						}
+
+						return streamer(ctx, desc, cc, method, opts...)
+					},
+				))),
+			)
+			require.NoError(t, err)
+			defer func() { require.NoError(t, driver.Close(ctx)) }()
+
+			err = driver.Table().Do(ctx, func(ctx context.Context, s table.Session) error {
+				_, _, err := s.Execute(ctx, table.DefaultTxControl(), "SELECT 42", nil)
+				require.True(t, ydb.IsTransportError(err, code))
+				require.Equal(t, table.SessionReady, s.Status())
+
+				return nil
+			})
+			require.NoError(t, err)
+		})
+	}
+}
 
 // TestTableSessionExecuteWithExecuteDataQueryOverQueryClient verifies
 // that the ydb.WithExecuteDataQueryOverQueryClient option correctly switches the

--- a/tests/integration/grpc_stopper_helper_test.go
+++ b/tests/integration/grpc_stopper_helper_test.go
@@ -135,7 +135,13 @@ func (l *GrpcStopper) intercept(method string, call func() error) error {
 	}()
 	select {
 	case <-stopChannel:
-		return l.stopError
+		// Preserve a completed result when both channels are ready.
+		select {
+		case err := <-resChan:
+			return err
+		default:
+			return l.stopError
+		}
 	case err := <-resChan:
 		return err
 	}

--- a/tests/integration/query_regression_test.go
+++ b/tests/integration/query_regression_test.go
@@ -14,8 +14,13 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+	"github.com/ydb-platform/ydb-go-genproto/Ydb_Query_V1"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3"
+	"github.com/ydb-platform/ydb-go-sdk/v3/config"
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/query/options"
 	"github.com/ydb-platform/ydb-go-sdk/v3/query"
 	"github.com/ydb-platform/ydb-go-sdk/v3/table"
@@ -384,4 +389,30 @@ func TestCloseSessionOnCustomerErrorsIssue1607(t *testing.T) {
 	})
 
 	scope.Require.Equal(sessionID1, sessionID2)
+}
+
+// https://github.com/ydb-platform/ydb-go-sdk/issues/2297
+func TestQueryResourceExhaustedKeepsSessionIssue2297(t *testing.T) {
+	scope := newScope(t)
+
+	grpcStopper := NewGrpcStopper(status.Error(codes.ResourceExhausted, "retry operation"))
+	grpcStopper.Stop(Ydb_Query_V1.QueryService_ExecuteQuery_FullMethodName)
+
+	db := scope.Driver(
+		ydb.WithSessionPoolSizeLimit(1),
+		ydb.With(config.WithGrpcOptions(
+			grpc.WithChainStreamInterceptor(grpcStopper.StreamClientInterceptor),
+		)),
+	)
+
+	var sessionIDs []string
+	err := db.Query().Do(scope.Ctx, func(ctx context.Context, s query.Session) error {
+		defer grpcStopper.Start()
+		sessionIDs = append(sessionIDs, s.ID())
+
+		return s.Exec(ctx, "SELECT 1")
+	}, query.WithIdempotent())
+	require.NoError(t, err)
+	require.Len(t, sessionIDs, 2)
+	require.Equal(t, sessionIDs[0], sessionIDs[1], "RESOURCE_EXHAUSTED must not recreate the session")
 }

--- a/tests/integration/topic_grpc_stopper_helper_test.go
+++ b/tests/integration/topic_grpc_stopper_helper_test.go
@@ -1,72 +1,108 @@
 //go:build integration
-// +build integration
 
 package integration
 
 import (
 	"context"
+	"slices"
+	"sync"
 
 	"google.golang.org/grpc"
 
 	"github.com/ydb-platform/ydb-go-sdk/v3/internal/empty"
 )
 
-// GrpcStopper use interceptors for stop any real grpc activity on grpc channel and return error for any calls
+// GrpcStopper interrupts gRPC calls with stopError between Stop and Start.
 //
 // Usage:
 //
-//		grpcStopper := xtest.NewGrpcStopper()
+//	grpcStopper := NewGrpcStopper(errors.New("test error"))
 //
-//		db, err := ydb.Open(context.Background(), connectionString,
-//	     ...
-//			ydb.With(config.WithGrpcOptions(grpc.WithChainUnaryInterceptor(grpcStopper.UnaryClientInterceptor)),
-//			ydb.With(config.WithGrpcOptions(grpc.WithStreamInterceptor(grpcStopper.StreamClientInterceptor)),
-//		),
+//	db, err := ydb.Open(context.Background(), connectionString,
+//		ydb.With(config.WithGrpcOptions(
+//			grpc.WithChainUnaryInterceptor(grpcStopper.UnaryClientInterceptor),
+//			grpc.WithChainStreamInterceptor(grpcStopper.StreamClientInterceptor),
+//		)),
+//	)
 //
-//		grpcStopper.Stop(errors.New("test error"))
-//
-// )
+//	grpcStopper.Stop()  // Inject the configured error into gRPC calls.
+//	grpcStopper.Start() // Allow subsequent calls through again.
 type GrpcStopper struct {
-	stopChannel empty.Chan
-	stopError   error
+	mu           sync.Mutex
+	stopped      bool
+	stopChannels map[string]empty.Chan
+	stopError    error
 }
 
-func NewGrpcStopper(closeError error) GrpcStopper {
-	return GrpcStopper{
-		stopChannel: make(empty.Chan),
-		stopError:   closeError,
+func NewGrpcStopper(closeError error) *GrpcStopper {
+	return &GrpcStopper{
+		stopChannels: make(map[string]empty.Chan),
+		stopError:    closeError,
 	}
 }
 
-func (l GrpcStopper) Stop() {
-	close(l.stopChannel)
+// Stop interrupts the listed methods, or all methods if none are listed, until Start.
+func (l *GrpcStopper) Stop(methods ...string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if len(methods) == 0 {
+		l.stopped = true
+	}
+	for _, method := range methods {
+		if l.stopChannels[method] == nil {
+			l.stopChannels[method] = make(empty.Chan)
+		}
+	}
+	for method, ch := range l.stopChannels {
+		if (l.stopped || slices.Contains(methods, method)) && !isClosed(ch) {
+			close(ch)
+		}
+	}
 }
 
-func (l GrpcStopper) UnaryClientInterceptor(
+// Start allows subsequent calls through, including calls on existing streams.
+// Calls interrupted by Stop are not retried; closed streams stay closed.
+func (l *GrpcStopper) Start() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.stopped = false
+	for method, ch := range l.stopChannels {
+		if isClosed(ch) {
+			l.stopChannels[method] = make(empty.Chan)
+		}
+	}
+}
+
+func (l *GrpcStopper) stopSignal(method string) empty.Chan {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	ch := l.stopChannels[method]
+	if ch == nil {
+		ch = make(empty.Chan)
+		l.stopChannels[method] = ch
+		if l.stopped {
+			close(ch)
+		}
+	}
+
+	return ch
+}
+
+func (l *GrpcStopper) UnaryClientInterceptor(
 	ctx context.Context,
 	method string,
-	req, reply interface{},
+	req, reply any,
 	cc *grpc.ClientConn,
 	invoker grpc.UnaryInvoker,
 	opts ...grpc.CallOption,
 ) error {
-	if isClosed(l.stopChannel) {
-		return l.stopError
-	}
-
-	resChan := make(chan error, 1)
-	go func() {
-		resChan <- invoker(ctx, method, req, reply, cc, opts...)
-	}()
-	select {
-	case <-l.stopChannel:
-		return l.stopError
-	case err := <-resChan:
-		return err
-	}
+	return l.intercept(method, func() error {
+		return invoker(ctx, method, req, reply, cc, opts...)
+	})
 }
 
-func (l GrpcStopper) StreamClientInterceptor(
+func (l *GrpcStopper) StreamClientInterceptor(
 	ctx context.Context,
 	desc *grpc.StreamDesc,
 	cc *grpc.ClientConn,
@@ -74,81 +110,54 @@ func (l GrpcStopper) StreamClientInterceptor(
 	streamer grpc.Streamer,
 	opts ...grpc.CallOption,
 ) (grpc.ClientStream, error) {
-	select {
-	case <-l.stopChannel:
-		// grpc stopped
+	if isClosed(l.stopSignal(method)) {
 		return nil, l.stopError
-	default:
 	}
 
 	stream, err := streamer(ctx, desc, cc, method, opts...)
-	streamWrapper := newGrpcStopperStream(stream, l.stopChannel, l.stopError)
 	if stream != nil {
-		stream = streamWrapper
+		stream = GrpcStopperStream{ClientStream: stream, stopper: l, method: method}
 	}
+
 	return stream, err
 }
 
-type GrpcStopperStream struct {
-	stopChannel empty.Chan
-	stopError   error
-	grpc.ClientStream
+func (l *GrpcStopper) intercept(method string, call func() error) error {
+	// Keep this generation so Start cannot hide Stop from an in-flight call.
+	stopChannel := l.stopSignal(method)
+	if isClosed(stopChannel) {
+		return l.stopError
+	}
+
+	resChan := make(chan error, 1)
+	go func() {
+		resChan <- call()
+	}()
+	select {
+	case <-stopChannel:
+		return l.stopError
+	case err := <-resChan:
+		return err
+	}
 }
 
-func newGrpcStopperStream(stream grpc.ClientStream, stopChannel empty.Chan, stopError error) GrpcStopperStream {
-	return GrpcStopperStream{stopChannel: stopChannel, ClientStream: stream, stopError: stopError}
+type GrpcStopperStream struct {
+	grpc.ClientStream
+
+	stopper *GrpcStopper
+	method  string
 }
 
 func (g GrpcStopperStream) CloseSend() error {
-	if isClosed(g.stopChannel) {
-		return g.stopError
-	}
-
-	resChan := make(chan error, 1)
-	go func() {
-		resChan <- g.ClientStream.CloseSend()
-	}()
-	select {
-	case <-g.stopChannel:
-		return g.stopError
-	case err := <-resChan:
-		return err
-	}
+	return g.stopper.intercept(g.method, g.ClientStream.CloseSend)
 }
 
-func (g GrpcStopperStream) SendMsg(m interface{}) error {
-	if isClosed(g.stopChannel) {
-		return g.stopError
-	}
-
-	resChan := make(chan error, 1)
-	go func() {
-		resChan <- g.ClientStream.SendMsg(m)
-	}()
-	select {
-	case <-g.stopChannel:
-		return g.stopError
-	case err := <-resChan:
-		return err
-	}
+func (g GrpcStopperStream) SendMsg(m any) error {
+	return g.stopper.intercept(g.method, func() error { return g.ClientStream.SendMsg(m) })
 }
 
-func (g GrpcStopperStream) RecvMsg(m interface{}) error {
-	if isClosed(g.stopChannel) {
-		return g.stopError
-	}
-
-	resChan := make(chan error, 1)
-	go func() {
-		resChan <- g.ClientStream.RecvMsg(m)
-	}()
-
-	select {
-	case <-g.stopChannel:
-		return g.stopError
-	case err := <-resChan:
-		return err
-	}
+func (g GrpcStopperStream) RecvMsg(m any) error {
+	return g.stopper.intercept(g.method, func() error { return g.ClientStream.RecvMsg(m) })
 }
 
 func isClosed(ch empty.Chan) bool {


### PR DESCRIPTION
Query execution could discard reusable sessions after transport errors such as `RESOURCE_EXHAUSTED` and `OUT_OF_RANGE`. Apply the existing session invalidation policy before marking a session as broken. This covers both the Query API and Table API requests executed through Query Service with `WithExecuteDataQueryOverQueryClient(true)`.

Closes #2297.

## Pull request type

- [x] Bugfix

## What is the current behavior?

`StatusFromErr` maps every transport error to `StatusError`, even when `MustDeleteTableOrQuerySession` allows reuse. This invalidates the Query session before the pool can apply its error policy. The Table API executor that calls Query Service uses the same mapping and also invalidates its session.

## What is the new behavior?

Transport errors produce `StatusError` only when `MustDeleteTableOrQuerySession` requires invalidation. Sessions remain reusable after `RESOURCE_EXHAUSTED` and `OUT_OF_RANGE`; errors that require invalidation retain their existing behavior.

- A unit test checks `onSessionError` against the shared policy for every defined gRPC error code (raw and wrapped), every non-success YDB status, context errors, EOF, and a user error. The policy classifications are independently tested in `internal/xerrors`.
- `TestStatusFromErr` explicitly covers `RESOURCE_EXHAUSTED`, `OUT_OF_RANGE`, and `UNAVAILABLE`. A Table API test with an in-process mock server checks that both preserving errors leave the session ready after `ExecuteQuery` fails.
- The integration regression test injects `RESOURCE_EXHAUSTED` on the first `ExecuteQuery` and verifies that the retry uses the same session ID.
- `GrpcStopper` supports selecting methods and restarting interception, and preserves an already available call result when stopping. Its helper file is renamed to `grpc_stopper_helper_test.go` to reflect its use across services.

## Other information

Validation:

- `go test -race ./...`: passed.
- `golangci-lint run ./...`: passed.
- Integration lint for changed code: passed.
- Targeted Query and Topic integration tests with `-race` against local YDB: `TestQueryResourceExhaustedKeepsSessionIssue2297` and `TestSendSyncMessages` passed.
- The policy, status-mapping, and Table API regression tests fail for `RESOURCE_EXHAUSTED` and `OUT_OF_RANGE` with the pre-fix implementation.

The separate issue of forcing retries for non-retryable errors before sending a request is tracked in #2299.
