### PR TITLE
docs: reserve SLO label for manual developer action

### DIFF
--- a/.agents/context/techContext.md
+++ b/.agents/context/techContext.md
@@ -56,6 +56,7 @@ Stress a single flaky integration test: add `-count=N -run 'TestName$'` to the `
 | `check-codegen.yml` | PR | `go generate` trace/gstack diff |
 | `breaking.yml` | PR | `gorelease` (skip: `broken changes`) |
 | `examples.yml` | PR | examples vs local YDB (skip: `no examples`) |
+| `check-slo-label.yml` | PR | requires a developer to add `SLO` manually (skip: `no slo`) |
 | `slo.yml` | push/PR + manual | SLO benchmarks (active in go-sdk) |
 | `publish.yml` | manual | version bump + release |
 
@@ -63,7 +64,7 @@ The `SLO` label is added **manually by a developer**, only after all other revie
 
 ## PR labels that skip CI gates
 
-`no lint`, `no tests`, `no integration tests`, `no changelog`, `no examples`, `broken changes`
+`no lint`, `no tests`, `no integration tests`, `no changelog`, `no examples`, `no slo`, `broken changes`
 
 ## Changelog (unreleased)
 

--- a/.agents/context/techContext.md
+++ b/.agents/context/techContext.md
@@ -59,6 +59,8 @@ Stress a single flaky integration test: add `-count=N -run 'TestName$'` to the `
 | `slo.yml` | push/PR + manual | SLO benchmarks (active in go-sdk) |
 | `publish.yml` | manual | version bump + release |
 
+The `SLO` label is added **manually by a developer**, only after all other review feedback and failing tests have been addressed. Agents must not add it automatically, even if `check-slo-label` fails. See [the SLO label rule](../rules/workflow.md#slo-label-developer-only).
+
 ## PR labels that skip CI gates
 
 `no lint`, `no tests`, `no integration tests`, `no changelog`, `no examples`, `broken changes`

--- a/.agents/rules/workflow.md
+++ b/.agents/rules/workflow.md
@@ -25,6 +25,12 @@ User: "Fix the build using method M"
 Agent: "Method M failed, so I implemented alternative N instead."
 ```
 
+## SLO label (developer only)
+
+- Agents must not add the `SLO` label automatically.
+- Only a developer adds `SLO` manually, after all other review feedback and failing tests have been addressed.
+- A failing `check-slo-label` check is not authorization to add the label or bypass the gate. Finish the other fixes and checks, and leave SLO activation to the developer.
+
 ## Code reuse
 
 1. Search the repo (`rg`, IDE search) for similar helpers before adding new utilities.


### PR DESCRIPTION
The `SLO` label must be added manually by a developer after all other review feedback and failing tests have been addressed. Record this rule in the AI workflow guidance and link it from the CI overview.

## Pull request type

- [x] Documentation content changes

## What is the current behavior?

The project AI guidance does not reserve SLO activation for the developer. An agent may treat a failing `check-slo-label` check as a reason to add the label automatically.

## What is the new behavior?

Agents must leave the `SLO` label to the developer. A failing `check-slo-label` check does not authorize adding the label or bypassing the gate; agents should complete the other fixes and checks first.

## Other information

Only `.agents/rules/workflow.md` and `.agents/context/techContext.md` are changed. Verified the documentation link and `git diff --check`. Runtime tests were not run for this documentation-only change.
